### PR TITLE
chore: Update geolocation.service.ts oc: 4166

### DIFF
--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -22,7 +22,7 @@ export class GeolocationService {
     isRecording: false,
     isPaused: false,
   };
-  private _watcher: BehaviorSubject<string | null> = new BehaviorSubject<null>(null);
+  private _watcher: BehaviorSubject<{type: 'web' | 'background' | null, id: string | null}> = new BehaviorSubject<{type: 'web' | 'background' | null, id: string | null}>({type: null, id: null});
 
   get active(): boolean {
     return !!this?._state?.isActive;
@@ -92,17 +92,8 @@ export class GeolocationService {
    */
   start(): void {
     this.onStart$.next(true);
-    //const isLocalServer: boolean = window.location.href.indexOf('localhost') !== -1;
-    if (this._watcher.value == null) {
-      if (
-        this._platform.is('ios') ||
-        this._platform.is('android') ||
-        this._platform.is('capacitor')
-      ) {
-        this._nativeWatcher();
-      } else {
-        this._webWatcher();
-      }
+    if (this._watcher.value.type === null) {
+      this._webWatcher();
     }
   }
 
@@ -116,7 +107,10 @@ export class GeolocationService {
     this.onStart$.next(true);
     this.onRecord$.next(true);
     this.onPause$.next(false);
-    //  this._recordStopwatch.start();
+    if (this._platform.is('ios') || this._platform.is('android') || this._platform.is('capacitor')) {
+      this._clearCurrentWatcher();
+      this._backgroundGeolocationWatcher();
+    }
   }
 
   /**
@@ -126,12 +120,7 @@ export class GeolocationService {
     this.onStart$.next(false);
     this.onRecord$.next(false);
     this.onPause$.next(false);
-    if (this._watcher.value != null) {
-      backgroundGeolocation.removeWatcher({
-        id: this._watcher.value,
-      });
-    }
-    this._watcher.next(null);
+    this._clearCurrentWatcher();
   }
 
   /**
@@ -139,6 +128,10 @@ export class GeolocationService {
    */
   stopRecording(): CGeojsonLineStringFeature {
     this._recordStopwatch.stop();
+    if (this._watcher.value.type === 'background') {
+      this._clearCurrentWatcher();
+      this._webWatcher();
+    }
     return this._stopRecording();
   }
 
@@ -147,6 +140,58 @@ export class GeolocationService {
     const locations: Array<Location> = this._recordedFeature?.properties?.locations ?? [];
     locations.push(location);
     this._recordedFeature.setProperty('locations', locations);
+  }
+
+  private _backgroundGeolocationWatcher(): void {
+    const distanceFilter = +localStorage.getItem('wm-distance-filter') || 10;
+    backgroundGeolocation
+      .addWatcher(
+        {
+          // If the "backgroundMessage" option is defined, the watcher will
+          // provide location updates whether the app is in the background or the
+          // foreground. If it is not defined, location updates are only
+          // guaranteed in the foreground. This is true on both platforms.
+
+          // On Android, a notification must be shown to continue receiving
+          // location updates in the background. This option specifies the text of
+          // that notification.
+          backgroundMessage: 'Cancel to prevent battery drain.',
+
+          // The title of the notification mentioned above. Defaults to "Using
+          // your location".
+          backgroundTitle: 'Tracking You.',
+
+          // Whether permissions should be requested from the user automatically,
+          // if they are not already granted. Defaults to "true".
+          requestPermissions: true,
+
+          // If "true", stale locations may be delivered while the device
+          // obtains a GPS fix. You are responsible for checking the "time"
+          // property. If "false", locations are guaranteed to be up to date.
+          // Defaults to "false".
+          stale: false,
+
+          // The minimum number of metres between subsequent locations. Defaults
+          // to 0.
+          distanceFilter,
+        },
+        (location, error) => {
+          if (error) {
+            return console.error(error);
+          }
+          console.log(
+            'backgroundGeolocation->GeolocationService location:',
+            JSON.stringify(location),
+          );
+          if (this.onStart$.value) {
+            this._locationUpdate(location);
+          }
+          return console.log(location);
+        },
+      )
+      .then(watcher_id => {
+        this._watcher.next({type: 'background', id: watcher_id});
+      });
   }
 
   private _calculateSpeed(prevLocation: Location, currentLocation: Location): number {
@@ -159,6 +204,15 @@ export class GeolocationService {
       return dist / 1000 / (time / 3600);
     }
     return 0;
+  }
+
+  private _clearCurrentWatcher(): void {
+    if (this._watcher.value.type === 'web' && this._watcher.value.id !== null) {
+      navigator.geolocation.clearWatch(parseInt(this._watcher.value.id));
+    } else if (this._watcher.value.type === 'background' && this._watcher.value.id !== null) {
+      backgroundGeolocation.removeWatcher({ id: this._watcher.value.id });
+    }
+    this._watcher.next({type: null, id: null});
   }
 
   //TODO: da tipizzare la funzione
@@ -211,61 +265,6 @@ export class GeolocationService {
     this.onLocationChange.next(this._currentLocation);
   }
 
-  private _nativeWatcher(): void {
-    const distanceFilter = +localStorage.getItem('wm-distance-filter') || 10;
-
-    backgroundGeolocation
-      .addWatcher(
-        {
-          // If the "backgroundMessage" option is defined, the watcher will
-          // provide location updates whether the app is in the background or the
-          // foreground. If it is not defined, location updates are only
-          // guaranteed in the foreground. This is true on both platforms.
-
-          // On Android, a notification must be shown to continue receiving
-          // location updates in the background. This option specifies the text of
-          // that notification.
-          backgroundMessage: 'Cancel to prevent battery drain.',
-
-          // The title of the notification mentioned above. Defaults to "Using
-          // your location".
-          backgroundTitle: 'Tracking You.',
-
-          // Whether permissions should be requested from the user automatically,
-          // if they are not already granted. Defaults to "true".
-          requestPermissions: true,
-
-          // If "true", stale locations may be delivered while the device
-          // obtains a GPS fix. You are responsible for checking the "time"
-          // property. If "false", locations are guaranteed to be up to date.
-          // Defaults to "false".
-          stale: false,
-
-          // The minimum number of metres between subsequent locations. Defaults
-          // to 0.
-          distanceFilter,
-        },
-        (location, error) => {
-          if (error) {
-            return console.error(error);
-          }
-          console.log(
-            'backgroundGeolocation->GeolocationService location:',
-            JSON.stringify(location),
-          );
-          if (this.onStart$.value) {
-            this._locationUpdate(location);
-          }
-          return console.log(location);
-        },
-      )
-      .then(watcher_id => {
-        // When a watcher is no longer needed, it should be removed by calling
-        // 'removeWatcher' with an object containing its ID.
-        this._watcher.next(watcher_id);
-      });
-  }
-
   /**
    * Stop the location record
    */
@@ -278,8 +277,7 @@ export class GeolocationService {
   }
 
   private _webWatcher(): void {
-    this._watcher.next('navigator');
-    navigator.geolocation.watchPosition(
+    const watcherId = navigator.geolocation.watchPosition(
       res => {
         if (this.onStart$.value) {
           this._locationUpdate((res as any).coords as Location);
@@ -290,5 +288,6 @@ export class GeolocationService {
       },
       {maximumAge: 60000, timeout: 100, enableHighAccuracy: true},
     );
+    this._watcher.next({type: 'web', id: watcherId.toString()});
   }
 }


### PR DESCRIPTION
- Refactored the _watcher property in GeolocationService to include type and id
- Updated start() and stopRecording() methods to use the new _watcher structure
- Added a new private method, _backgroundGeolocationWatcher(), to handle background geolocation tracking
- Created a new private method, _clearCurrentWatcher(), to clear the current watcher based on its type
- Removed the _nativeWatcher() method as it is no longer needed
- Modified the _webWatcher() method to update the _watcher property with the correct type and id
