### PR TITLE
chore: Update geolocation and ugc services oc: 4247

### DIFF
--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -113,7 +113,7 @@ export class GeolocationService {
    */
   startRecording(): void {
     this._recordStopwatch = new CStopwatch();
-    this._recordedFeature = null;
+    this._recordedFeature = this._getEmptyWmFeature();
     this.onStart$.next(true);
     this.onRecord$.next(true);
     this.onPause$.next(false);
@@ -177,6 +177,14 @@ export class GeolocationService {
       }
     }
     return temp as T;
+  }
+
+  private _getEmptyWmFeature(): WmFeature<LineString> {
+    return {
+      type: 'Feature',
+      geometry: {type: 'LineString', coordinates: []},
+      properties: {},
+    };
   }
 
   /**

--- a/projects/wm-core/src/services/ugc.service.ts
+++ b/projects/wm-core/src/services/ugc.service.ts
@@ -20,6 +20,7 @@ import {
   saveUgcPoi,
   saveUgcTrack,
   getImg,
+  removeDeviceUgcPoi,
 } from 'wm-core/utils/localForage';
 import {
   Media,
@@ -224,7 +225,7 @@ export class UgcService {
         try {
           const res = await this.saveApiPoi(deviceUgcPoi);
           if (res) {
-            await removeDeviceUgcTrack(deviceUgcPoi.properties.uuid);
+            await removeDeviceUgcPoi(deviceUgcPoi.properties.uuid);
             // console.log(`Poi con uuid ${deviceUgcPoi.properties.uuid} sincronizzata e rimossa.`);
           }
         } catch (trackError) {
@@ -300,7 +301,7 @@ export class UgcService {
   async saveApiPoi(poi: WmFeature<Point>): Promise<WmFeature<Point> | null> {
     if (poi != null) {
       return this._http
-        .post<WmFeature<Point>>(`${this.environment.api}/api/ugc/poi/store`, poi)
+        .post<WmFeature<Point>>(`${this.environment.api}/api/ugc/poi/store/v2`, poi)
         .pipe(catchError(_ => of(null)))
         .toPromise();
     }
@@ -318,7 +319,7 @@ export class UgcService {
   async saveApiTrack(track: WmFeature<LineString>): Promise<WmFeature<LineString> | null> {
     if (track != null) {
       return this._http
-        .post<WmFeature<LineString>>(`${this.environment.api}/api/ugc/track/store`, track)
+        .post<WmFeature<LineString>>(`${this.environment.api}/api/ugc/track/store/v2`, track)
         .pipe(catchError(_ => of(null)))
         .toPromise();
     }

--- a/projects/wm-core/src/utils/localForage.ts
+++ b/projects/wm-core/src/utils/localForage.ts
@@ -188,7 +188,7 @@ export async function getUgcMediasByIds(
   ids: string[] = [],
 ): Promise<WmFeature<Media, MediaProperties>[]> {
   const ugcMedias = await getUgcMedias();
-  return ugcMedias.filter(media => ids.includes(media.properties.id || media.properties.uuid));
+  return ugcMedias.filter(media => ids.includes(media.properties.id?.toString() || media.properties.uuid));
 }
 
 export async function getUgcPoi(poiId: string): Promise<WmFeature<Point> | null> {


### PR DESCRIPTION
- In the GeolocationService, initialize _recordedFeature with an empty WmFeature object.
- In the UgcService, update the API endpoints for saving poi and track to use "/v2" suffix.
- In the localForage utility, update the filter condition to include media with matching ids.

These changes ensure proper functionality and compatibility with the latest requirements.
