### PR TITLE
chore: Add saving UGC media for UGC tracks oc: 4247

### DIFF
--- a/projects/wm-core/src/utils/localForage.ts
+++ b/projects/wm-core/src/utils/localForage.ts
@@ -391,6 +391,12 @@ export async function saveUgcPoi(feature: WmFeature<Point>): Promise<void> {
 
 export async function saveUgcTrack(feature: WmFeature<LineString>): Promise<void> {
   const properties = feature.properties;
+  const photos = properties.photos ?? [];
+
+  photos.forEach(photo => {
+    saveUgcMedia(photo);
+  });
+
   const featureId = properties.id ?? properties.uuid;
   const storage = properties.id ? synchronizedUgcTrack : deviceUgcTrack;
   await handleAsync(storage.setItem(`${featureId}`, feature), 'saveUgcTrack: Failed');


### PR DESCRIPTION
This commit adds the functionality to save UGC media for UGC tracks. It retrieves the photos from the feature properties and saves each photo using the saveUgcMedia function. This ensures that all associated media is properly saved along with the track data.
