### PR TITLE
feat(ugc): add deleteUgcTrack and deleteUgcPoi actions oc: 4454

### DIFF
--- a/projects/wm-core/src/store/features/ugc/ugc.actions.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.actions.ts
@@ -32,3 +32,16 @@ export const loadCurrentUgcTrackFailure = createAction(
   '[Ugc] Load Current UgcTrack Failure',
   props<{error: any}>(),
 );
+export const enableSyncInterval = createAction('[Ugc] Enable Sync Interval');
+export const disableSyncInterval = createAction('[Ugc] Disable Sync Interval');
+
+export const deleteUgcTrack = createAction(
+  '[Ugc] Delete Ugc Track',
+  props<{track: WmFeature<LineString>}>(),
+);
+export const deleteUgcTrackSuccess = createAction('[Ugc] Delete Ugc Track Success');
+export const deleteUgcTrackFailure = createAction('[Ugc] Delete Ugc Track Failure', props<{error: string}>());
+
+export const deleteUgcPoi = createAction('[Ugc] Delete Ugc Poi', props<{poi: WmFeature<Point>}>());
+export const deleteUgcPoiSuccess = createAction('[Ugc] Delete Ugc Poi Success');
+export const deleteUgcPoiFailure = createAction('[Ugc] Delete Ugc Poi Failure', props<{error: string}>());

--- a/projects/wm-core/src/store/features/ugc/ugc.actions.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.actions.ts
@@ -39,9 +39,12 @@ export const deleteUgcTrack = createAction(
   '[Ugc] Delete Ugc Track',
   props<{track: WmFeature<LineString>}>(),
 );
-export const deleteUgcTrackSuccess = createAction('[Ugc] Delete Ugc Track Success');
+export const deleteUgcTrackSuccess = createAction('[Ugc] Delete Ugc Track Success', props<{track: WmFeature<LineString>}>());
 export const deleteUgcTrackFailure = createAction('[Ugc] Delete Ugc Track Failure', props<{error: string}>());
 
-export const deleteUgcPoi = createAction('[Ugc] Delete Ugc Poi', props<{poi: WmFeature<Point>}>());
-export const deleteUgcPoiSuccess = createAction('[Ugc] Delete Ugc Poi Success');
+export const deleteUgcPoi = createAction(
+  '[Ugc] Delete Ugc Poi',
+  props<{poi: WmFeature<Point>}>(),
+);
+export const deleteUgcPoiSuccess = createAction('[Ugc] Delete Ugc Poi Success', props<{poi: WmFeature<Point>}>());
 export const deleteUgcPoiFailure = createAction('[Ugc] Delete Ugc Poi Failure', props<{error: string}>());

--- a/projects/wm-core/src/store/features/ugc/ugc.effects.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.effects.ts
@@ -1,9 +1,17 @@
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
-import {mergeMap, map, catchError, switchMap, filter, takeUntil, startWith} from 'rxjs/operators';
+import {mergeMap, map, catchError, switchMap, filter, takeUntil, startWith, finalize, tap, withLatestFrom} from 'rxjs/operators';
 import {of, from, interval} from 'rxjs';
 import {
   currentUgcTrackId,
+  deleteUgcPoi,
+  deleteUgcPoiFailure,
+  deleteUgcPoiSuccess,
+  deleteUgcTrack,
+  deleteUgcTrackFailure,
+  deleteUgcTrackSuccess,
+  disableSyncInterval,
+  enableSyncInterval,
   loadCurrentUgcTrackFailure,
   loadCurrentUgcTrackSuccess,
   syncUgc,
@@ -16,8 +24,10 @@ import {
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {UgcService} from '@wm-core/store/features/ugc/ugc.service';
 import {select, Store} from '@ngrx/store';
-import {activableUgc} from './ugc.selector';
-import {getUgcPois, getUgcTrack, getUgcTracks} from '@wm-core/utils/localForage';
+import {activableUgc, syncUgcIntervalEnabled} from './ugc.selector';
+import {getUgcPois, getUgcTrack, getUgcTracks, removeDeviceUgcPoi, removeDeviceUgcTrack, removeSynchronizedUgcPoi, removeSynchronizedUgcTrack} from '@wm-core/utils/localForage';
+import {AlertController} from '@ionic/angular';
+import {LangService} from '@wm-core/localization/lang.service';
 const SYNC_INTERVAL = 60000;
 @Injectable({
   providedIn: 'root',
@@ -33,6 +43,108 @@ export class UgcEffects {
         ),
       ),
     ),
+  );
+  deleteUgcFailure$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(deleteUgcTrackFailure, deleteUgcPoiFailure),
+      switchMap(() => this._alertCtrl.create({
+        header: this._langSvc.instant('Ops!'),
+        message: this._langSvc.instant('Non è stato possibile eliminare il tracciato, riprova più tardi'),
+        buttons: ['OK']
+      })),
+      switchMap(alert => alert.present()),
+    ),
+    { dispatch: false }
+  );
+  deleteUgcPoi$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(deleteUgcPoi),
+      mergeMap(action =>
+        of(disableSyncInterval()).pipe(
+          mergeMap(() => {
+            if (action.poi?.properties?.id) {
+              const poiId = action.poi?.properties?.id;
+              return from(this._ugcSvc.deleteApiPoi(poiId)).pipe(
+                tap(() => removeSynchronizedUgcPoi(poiId)),
+                mergeMap(() => [
+                  deleteUgcPoiSuccess(),
+                  syncUgcPois(),
+                  enableSyncInterval()
+                ]),
+                catchError(error => of(deleteUgcPoiFailure({error}), enableSyncInterval())),
+              );
+            }
+
+            return from(removeDeviceUgcPoi(action.poi?.properties?.uuid)).pipe(
+              mergeMap(() => [
+                deleteUgcPoiSuccess(),
+                syncUgcPois(),
+                enableSyncInterval()
+              ]),
+              catchError(error => of(deleteUgcPoiFailure({error}), enableSyncInterval())),
+            );
+          })
+        )
+      ),
+    ),
+  );
+  deleteUgcSuccess$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(deleteUgcTrackSuccess, deleteUgcPoiSuccess),
+      switchMap(() => this._alertCtrl.create({
+        message: this._langSvc.instant('Tracciato eliminato con successo'),
+        buttons: ['OK']
+      })),
+      switchMap(alert => alert.present()),
+    ),
+    { dispatch: false }
+  );
+  deleteUgcTrack$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(deleteUgcTrack),
+      mergeMap(action =>
+        of(disableSyncInterval()).pipe(
+          mergeMap(() => {
+            if (action.track?.properties?.id) {
+              const trackId = action.track?.properties?.id;
+              return from(this._ugcSvc.deleteApiTrack(trackId)).pipe(
+                tap(() => removeSynchronizedUgcTrack(trackId)),
+                mergeMap(() => [
+                  deleteUgcTrackSuccess(),
+                  syncUgcTracks(),
+                  enableSyncInterval()
+                ]),
+                catchError(error => of(deleteUgcTrackFailure({error}), enableSyncInterval())),
+              );
+            }
+
+            return from(removeDeviceUgcTrack(action.track?.properties?.uuid)).pipe(
+              mergeMap(() => [
+                deleteUgcTrackSuccess(),
+                syncUgcTracks(),
+                enableSyncInterval()
+              ]),
+              catchError(error => of(deleteUgcTrackFailure({error}), enableSyncInterval())),
+            );
+          })
+        )
+      ),
+    ),
+  );
+  deleyeUgcError$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(deleteUgcTrackFailure, deleteUgcPoiFailure),
+      switchMap((action) => {
+        const entity = action.type === deleteUgcTrackFailure.type ? 'tracciato' : 'POI';
+        return this._alertCtrl.create({
+        header: this._langSvc.instant('Ops!'),
+        message: this._langSvc.instant(`Non è stato possibile eliminare il ${entity}, riprova più tardi`),
+        buttons: ['OK']
+      })
+    }),
+      switchMap(alert => alert.present()),
+    ),
+    { dispatch: false }
   );
   loadUgcPois$ = createEffect(() =>
     this._actions$.pipe(
@@ -65,15 +177,17 @@ export class UgcEffects {
   syncOnInterval$ = createEffect(() =>
     this._store.pipe(
       select(activableUgc),
-      filter(activable => activable),
+      withLatestFrom(this._store.pipe(select(syncUgcIntervalEnabled))),
+      filter(([activable, syncEnabled]) => activable && syncEnabled),
       switchMap(() =>
         interval(SYNC_INTERVAL).pipe(
           startWith(0),
           takeUntil(
             this._store.pipe(
               select(activableUgc),
-              filter(activable => !activable),
-            ),
+              withLatestFrom(this._store.pipe(select(syncUgcIntervalEnabled))),
+              filter(([activable, syncEnabled]) => !activable || !syncEnabled)
+            )
           ),
           map(() => syncUgc()),
         ),
@@ -114,5 +228,11 @@ export class UgcEffects {
     ),
   );
 
-  constructor(private _ugcSvc: UgcService, private _actions$: Actions, private _store: Store) {}
+  constructor(
+    private _ugcSvc: UgcService,
+    private _actions$: Actions,
+    private _store: Store,
+    private _alertCtrl: AlertController,
+    private _langSvc: LangService,
+  ) {}
 }

--- a/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
@@ -9,6 +9,9 @@ import {
   updateUgcPois,
   loadCurrentUgcTrackSuccess,
   loadCurrentUgcTrackFailure,
+  enableSyncInterval,
+  disableSyncInterval,
+  deleteUgcTrackSuccess,
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {WmFeature} from '@wm-types/feature';
 import {IHIT} from '@wm-core/types/elastic';
@@ -21,6 +24,7 @@ export interface UgcState {
   ugcTracks: IHIT[];
   ugcPois: IHIT[];
   currentUgcTrack?: WmFeature<LineString>;
+  syncUgcIntervalEnabled: boolean;
 }
 export interface ApiRootState {
   [searchKey]: UgcState;
@@ -33,6 +37,7 @@ const initialState: UgcState = {
   syncable: false,
   ugcTracks: [],
   ugcPois: [],
+  syncUgcIntervalEnabled: true,
 };
 
 export const UgcReducer = createReducer(
@@ -68,6 +73,18 @@ export const UgcReducer = createReducer(
   on(loadCurrentUgcTrackFailure, (state, {error}) => ({
     ...state,
     error,
+  })),
+  on(enableSyncInterval, state => ({
+    ...state,
+    syncIntervalEnabled: true,
+  })),
+  on(disableSyncInterval, state => ({
+    ...state,
+    syncIntervalEnabled: false,
+  })),
+  on(deleteUgcTrackSuccess, state => ({
+    ...state,
+    currentUgcTrack: undefined,
   })),
 );
 export function wmFeatureToHits(features: WmFeature<LineString | Point>[]): IHIT[] {

--- a/projects/wm-core/src/store/features/ugc/ugc.selector.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.selector.ts
@@ -1,4 +1,3 @@
-import {currentUgcTrackId} from './ugc.actions';
 import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {confAUTHEnable} from '@wm-core/store/conf/conf.selector';
@@ -32,3 +31,8 @@ export const countUgcAll = createSelector(
 );
 
 export const currentUgcTrack = createSelector(ugc, state => state.currentUgcTrack);
+
+export const syncUgcIntervalEnabled = createSelector(
+  ugc,
+  (state: UgcState) => state.syncUgcIntervalEnabled,
+);

--- a/projects/wm-core/src/utils/localForage.ts
+++ b/projects/wm-core/src/utils/localForage.ts
@@ -312,12 +312,37 @@ export async function removeSynchronizedUgcTrack(id: number): Promise<void> {
   await handleAsync(synchronizedUgcTrack.removeItem(`${id}`), 'removeSynchronizedUgcTrack: Failed');
 }
 
-export async function removeUgcTrack(trackId: string): Promise<void> {
-  try {
-    await synchronizedUgcTrack.removeItem(`${trackId}`);
-  } catch (error) {
-    console.error('removeUgcTrack: ', error);
-  }
+export async function removeUgcMedia(media: WmFeature<Media, MediaProperties>): Promise<void> {
+  const properties = media.properties;
+  const featureId = properties.id ?? properties.rawData?.uuid;
+  const storage = properties.id ? synchronizedUgcMedia : deviceUgcMedia;
+  await handleAsync(storage.removeItem(`${featureId}`), 'removeUgcMedia: Failed');
+}
+
+export async function removeUgcPoi(poi: WmFeature<Point>): Promise<void> {
+  const properties = poi.properties;
+  const photos = properties.photos ?? [];
+
+  photos.forEach(photo => {
+    removeUgcMedia(photo);
+  });
+
+  const featureId = properties.id ?? properties.rawData?.uuid;
+  const storage = properties.id ? synchronizedUgcPoi : deviceUgcPoi;
+  await handleAsync(storage.removeItem(`${featureId}`), 'removeUgcPoi: Failed');
+}
+
+export async function removeUgcTrack(track: WmFeature<LineString>): Promise<void> {
+  const properties = track.properties;
+  const photos = properties.photos ?? [];
+
+  photos.forEach(photo => {
+    removeUgcMedia(photo);
+  });
+
+  const featureId = properties.id ?? properties.rawData?.uuid;
+  const storage = properties.id ? synchronizedUgcTrack : deviceUgcTrack;
+  await handleAsync(storage.removeItem(`${featureId}`), 'removeUgcTrack: Failed');
 }
 
 export function saveDeviceUgcTrack(feature: WmFeature<LineString>): void {


### PR DESCRIPTION
This commit adds the following actions to the UGC feature:
- enableSyncInterval
- disableSyncInterval
- deleteUgcTrack
- deleteUgcTrackSuccess
- deleteUgcTrackFailure
- deleteUgcPoi
- deleteUgcPoiSuccess
- deleteUgcPoiFailure

These actions allow for enabling/disabling the sync interval, deleting UGC tracks and POIs, and handling success/failure scenarios.
