### PR TITLE
chore: Update user-activity actions, reducer, and selector oc: 4491

### DIFF
--- a/projects/wm-core/src/map/map.component.ts
+++ b/projects/wm-core/src/map/map.component.ts
@@ -12,6 +12,8 @@ import {
   resetTrackFilters,
   setLastFilterType,
   setLayer,
+  startLoader,
+  stopLoader,
   togglePoiFilter,
   toggleTrackFilter,
   updateTrackFilter,
@@ -127,7 +129,6 @@ export class WmCoreMapComponent {
   constructor(
     private _store: Store,
     private _langService: LangService,
-    private _loadingSvc: WmLoadingService,
     private _modalCtrl: ModalController,
     private _router: Router,
     private _route: ActivatedRoute,
@@ -180,20 +181,16 @@ export class WmCoreMapComponent {
   setLoader(event: string): void {
     console.log(event);
     switch (event) {
+      case 'rendering:pois_start':
       case 'rendering:layer_start':
-        this._loadingSvc.show('Rendering Layer');
+        this._store.dispatch(startLoader());
         break;
       case 'rendering:layer_done':
-        this._loadingSvc.close('Rendering Layer');
-        break;
-      case 'rendering:pois_start':
-        this._loadingSvc.show('Rendering Pois');
-        break;
       case 'rendering:pois_done':
-        this._loadingSvc.close('Rendering Pois');
+        this._store.dispatch(stopLoader());
         break;
       default:
-        this._loadingSvc.close();
+        this._store.dispatch(stopLoader());
     }
   }
 

--- a/projects/wm-core/src/store/auth/auth.reducer.ts
+++ b/projects/wm-core/src/store/auth/auth.reducer.ts
@@ -8,23 +8,15 @@ export const authFeatureKey = 'auth';
 export interface AuthState {
   error?: HttpErrorResponse;
   isLogged: boolean;
-  loading: boolean;
   user?: IUser;
 }
 
 export const initialState: AuthState = {
   isLogged: false,
-  loading: false,
 };
 
 export const authReducer = createReducer(
   initialState,
-  on(AuthActions.loadAuths, AuthActions.loadSignIns, state => {
-    return {
-      ...state,
-      loading: true,
-    };
-  }),
   on(AuthActions.loadSignUpsSuccess, (state, {user}) => {
     localStorage.setItem('access_token', user.access_token);
     return {
@@ -50,7 +42,6 @@ export const authReducer = createReducer(
       isLogged: true,
       user,
       error: undefined,
-      loading: false,
       syncing: true,
     };
   }),
@@ -61,7 +52,6 @@ export const authReducer = createReducer(
       user: undefined,
       isLogged: false,
       error,
-      loading: false,
     };
   }),
   on(AuthActions.loadAuthsSuccess, (state, {user}) => {
@@ -70,7 +60,6 @@ export const authReducer = createReducer(
       isLogged: true,
       user,
       error: undefined,
-      loading: false,
       syncing: true,
     };
   }),
@@ -81,7 +70,6 @@ export const authReducer = createReducer(
       user: undefined,
       isLogged: false,
       error,
-      loading: false,
     };
   }),
   on(AuthActions.loadSignOutsSuccess, state => {

--- a/projects/wm-core/src/store/auth/auth.selectors.ts
+++ b/projects/wm-core/src/store/auth/auth.selectors.ts
@@ -5,7 +5,6 @@ import {confWEBAPP} from '../conf/conf.selector';
 export const selectAuthState = createFeatureSelector<fromAuth.AuthState>(fromAuth.authFeatureKey);
 export const isLogged = createSelector(selectAuthState, state => state != null && state.isLogged);
 export const error = createSelector(selectAuthState, state => state != null && state.error);
-export const loading = createSelector(selectAuthState, state => state.loading);
 export const user = createSelector(selectAuthState, state => {
   return state.user;
 });

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -67,3 +67,6 @@ export const togglePoiFilter = createAction(
   props<{filterIdentifier: string}>(),
 );
 export const resetPoiFilters = createAction('[User Activity] pois: reset all pois filters');
+
+export const startLoader = createAction('[User Activity] loader: start loader');
+export const stopLoader = createAction('[User Activity] loader: stop loader');

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -16,6 +16,8 @@ import {
   setCurrentPoi,
   setLastFilterType,
   setLayer,
+  startLoader,
+  stopLoader,
   togglePoiFilter,
   toggleTrackFilter,
   updateTrackFilter,
@@ -34,6 +36,7 @@ export interface UserActivityState {
   drawTrack: boolean;
   layer?: any;
   lastFilterType?: 'tracks' | 'pois' | null;
+  loading: boolean;
 }
 
 export interface UserAcitivityRootState {
@@ -47,6 +50,7 @@ const initialState: UserActivityState = {
   drawTrack: false,
   filterTaxonomies: [],
   lastFilterType: null,
+  loading: false,
 };
 
 export const userActivityReducer = createReducer(
@@ -189,4 +193,6 @@ export const userActivityReducer = createReducer(
     };
     return newState;
   }),
+  on(startLoader, state => ({...state, loading: true})),
+  on(stopLoader, state => ({...state, loading: false})),
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -77,3 +77,5 @@ export const poisSelectedFilterIdentifiers = createSelector(
   userActivity,
   state => state.poisSelectedFilterIdentifiers,
 );
+
+export const loading = createSelector(userActivity, state => state.loading);


### PR DESCRIPTION
This commit updates the user-activity action file by adding two new actions: startLoader and stopLoader. It also modifies the reducer to handle these actions and update the loading state accordingly. Additionally, the selector file is updated to include a new selector for the loading state.

chore: Remove loading property from auth reducer and selectors

The loading property in the auth reducer and selectors has been removed as it is no longer needed. This change simplifies the code and improves performance.

chore(map): add loader start and stop functionality

This commit adds the functionality to start and stop the loader in the map component. The loader is started when rendering a layer or rendering pois starts, and it is stopped when rendering a layer or rendering pois is done.
