### PR TITLE
fix(ugc): update UGC POI properties and delete functionality oc: 4656

### DIFF
--- a/projects/wm-core/src/store/features/ugc/ugc.effects.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.effects.ts
@@ -274,10 +274,10 @@ export class UgcEffects {
                   syncUgcPois(),
                   enableSyncInterval(),
                 ]),
-                catchError(error => of(updateUgcTrackFailure({error}), enableSyncInterval())),
+                catchError(error => of(updateUgcPoiFailure({error}), enableSyncInterval())),
               );
             }
-            return of(updateUgcTrackFailure({error: 'Track ID not found'}));
+            return of(updateUgcPoiFailure({error: 'Poi ID not found'}));
           }),
         ),
       ),

--- a/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
@@ -16,6 +16,8 @@ import {
   loadcurrentUgcPoiIdSuccess,
   loadcurrentUgcPoiIdFailure,
   currentCustomTrack,
+  updateUgcPoiSuccess,
+  deleteUgcPoiSuccess,
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {WmFeature} from '@wm-types/feature';
 import {IHIT} from '@wm-core/types/elastic';
@@ -101,9 +103,17 @@ export const UgcReducer = createReducer(
     ...state,
     currentUgcTrack: undefined,
   })),
+  on(deleteUgcPoiSuccess, state => ({
+    ...state,
+    currentUgcPoi: undefined,
+  })),
   on(updateUgcTrackSuccess, (state, {track}) => ({
     ...state,
     currentUgcTrack: track,
+  })),
+  on(updateUgcPoiSuccess, (state, {poi}) => ({
+    ...state,
+    currentUgcPoi: poi,
   })),
   on(currentCustomTrack, (state, {currentCustomTrack}) => ({
     ...state,

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.html
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.html
@@ -38,12 +38,12 @@
       <ion-button
         class="wm-ugc-poi-button"
         color="danger"
-        (click)="deleteTrack()"
+        (click)="deletePoi()"
         >{{'delete'|wmtrans}}</ion-button
       >
     </ng-container>
     <ng-template #editingButtons>
-      <ion-button class="wm-ugc-poi-button" (click)="updateTrack()">{{'save'|wmtrans}}</ion-button>
+      <ion-button class="wm-ugc-poi-button" (click)="updatePoi()">{{'save'|wmtrans}}</ion-button>
       <ion-button
         class="wm-ugc-poi-button"
         (click)="this.isEditing$.next(false)"


### PR DESCRIPTION
- Updated the code in `ugc.effects.ts` to handle errors when updating UGC POI.
- Updated the code in `ugc.reducer.ts` to handle successful deletion and update of UGC POI.
- Modified the HTML template in `ugc-poi-properties.component.html` to reflect changes in button labels and function calls for deleting and updating UGC POI.
- Modified the TypeScript file in `ugc-poi-properties.component.ts` to handle deletion and updating of UGC POI, including confirmation alerts.

These changes allow users to update properties of a UGC Point of Interest (POI) and delete a specific UGC POI.
