### PR TITLE
chore(image-gallery): add arrow buttons for navigation oc: 4652

### DIFF
--- a/projects/wm-core/src/image-gallery/image-gallery.component.html
+++ b/projects/wm-core/src/image-gallery/image-gallery.component.html
@@ -13,4 +13,12 @@
       ></wm-img>
     </ion-slide>
   </ion-slides>
+  <ng-container *ngIf="showArrows && imageGallery.length > 1">
+    <ion-button class="left" (click)="prev()">
+      <ion-icon name="arrow-back-outline"></ion-icon>
+    </ion-button>
+    <ion-button class="right" (click)="next()">
+      <ion-icon name="arrow-forward-outline"></ion-icon>
+    </ion-button>
+  </ng-container>
 </ng-container>

--- a/projects/wm-core/src/image-gallery/image-gallery.component.scss
+++ b/projects/wm-core/src/image-gallery/image-gallery.component.scss
@@ -1,7 +1,7 @@
 wm-image-gallery {
+  position: relative;
   .webmapp-pagepoi-info-body-photoslider {
     padding: 10px 0;
-    overflow: visible;
     .webmapp-pagepoi-info-body-photo {
       height: 150px !important;
       width: 250px !important;
@@ -12,6 +12,25 @@ wm-image-gallery {
       &::part(image) {
         border-radius: 15px;
       }
+    }
+  }
+  ion-button {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 99;
+    width: 45px;
+    height: 45px;
+    --border-radius: 100%;
+    --background: #f0f0f0;
+    --color: black;
+
+    &.left {
+      margin-left: 15px;
+    }
+    &.right {
+      right: 0;
+      margin-right: 15px;
     }
   }
 }

--- a/projects/wm-core/src/image-gallery/image-gallery.component.ts
+++ b/projects/wm-core/src/image-gallery/image-gallery.component.ts
@@ -5,7 +5,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {IonModal, ModalController} from '@ionic/angular';
+import {IonModal, IonSlides, ModalController} from '@ionic/angular';
 import {ModalImageComponent} from '@wm-core/modal-image/modal-image.component';
 import {BehaviorSubject} from 'rxjs';
 
@@ -25,12 +25,16 @@ export class ImageGalleryComponent {
     } else {
       this.sliderOptions$.next({
         slidesPerView: 1.3,
+        centeredSlides: true,
+        spaceBetween: 10,
       });
     }
     this.imageGallery$.next(imgGallery);
   }
 
+  @Input() showArrows = false;
   @ViewChild(IonModal) modal: IonModal;
+  @ViewChild('slider') slider: IonSlides;
 
   imageGallery$: BehaviorSubject<null | any[]> = new BehaviorSubject<null | any[]>(null);
   sliderOptions$: BehaviorSubject<any> = new BehaviorSubject<any>({
@@ -38,6 +42,14 @@ export class ImageGalleryComponent {
   });
 
   constructor(private _modalCtrl: ModalController) {}
+
+  next(): void {
+    this.slider.slideNext();
+  }
+
+  prev(): void {
+    this.slider.slidePrev();
+  }
 
   async showPhoto(idx) {
     const modal = await this._modalCtrl.create({

--- a/projects/wm-core/src/tab-image-gallery/tab-image-gallery.component.html
+++ b/projects/wm-core/src/tab-image-gallery/tab-image-gallery.component.html
@@ -1,4 +1,4 @@
 <div *ngIf="imageGallery?.length > 0">
   <ion-label class="webmapp-pageroute-tabdescription-title">{{'Galleria' | wmtrans}} </ion-label>
-  <wm-image-gallery [imageGallery]="imageGallery"></wm-image-gallery>
+  <wm-image-gallery [imageGallery]="imageGallery" [showArrows]="showArrows"></wm-image-gallery>
 </div>

--- a/projects/wm-core/src/tab-image-gallery/tab-image-gallery.component.ts
+++ b/projects/wm-core/src/tab-image-gallery/tab-image-gallery.component.ts
@@ -7,9 +7,11 @@ import {Component, Input} from '@angular/core';
 })
 export class TabImageGalleryComponent {
   @Input() imageGallery;
+  @Input() showArrows = false;
 
   public sliderOptions: any = {
     slidesPerView: 1.3,
   };
+
   constructor() {}
 }


### PR DESCRIPTION
- Added arrow buttons to the image gallery component for easy navigation between images.
- The left button allows users to go to the previous image, while the right button allows them to go to the next image.
- The arrow buttons are positioned on top of the image gallery and have a circular shape with a light gray background color.
- The arrow buttons are only displayed if there are more than one image in the gallery.

chore(image-gallery): add type annotations to next() and prev()

- Added type annotations to the `next()` and `prev()` methods in the `ImageGalleryComponent` class for better code clarity and maintainability.
