### PR TITLE
chore: Add modal-ugc-track-uploader component oc: 4669

### DIFF
--- a/projects/wm-core/src/box/box.ts
+++ b/projects/wm-core/src/box/box.ts
@@ -1,4 +1,5 @@
 import {ChangeDetectorRef, Directive, EventEmitter, Input, Output} from '@angular/core';
+import {Store} from '@ngrx/store';
 import {LangService} from '@wm-core/localization/lang.service';
 
 @Directive({selector: 'basebox'})
@@ -10,7 +11,11 @@ export class BaseBoxComponent<T> {
 
   public defaultPhotoPath = '/assets/icon/no-photo.svg';
 
-  constructor(private _langSvc: LangService, private _cdr: ChangeDetectorRef) {
+  constructor(
+    protected _langSvc: LangService,
+    protected _cdr: ChangeDetectorRef,
+    protected _store: Store,
+  ) {
     this._langSvc.onLangChange.subscribe(() => {
       this._cdr.markForCheck();
     });

--- a/projects/wm-core/src/box/ugc-box/ugc-box.component.html
+++ b/projects/wm-core/src/box/ugc-box/ugc-box.component.html
@@ -1,12 +1,13 @@
 <div class="wm-box" (click)="clickEVT.emit()">
-  <div
-    class="color"
-  ></div>
+  <div class="color"></div>
   <wm-img
     class="webmapp-card-big-image-container wm-result-img"
     [src]="defaultPhotoPath"
     size="225x100"
   ></wm-img>
+  <ion-button color="light" (click)="openUgcUploader()">
+    <ion-icon slot="icon-only" name="cloud-upload-outline"></ion-icon>
+  </ion-button>
   <div class="wm-box-title">{{"I miei percorsi" | wmtrans}}</div>
   <ng-content></ng-content>
 </div>

--- a/projects/wm-core/src/box/ugc-box/ugc-box.component.scss
+++ b/projects/wm-core/src/box/ugc-box/ugc-box.component.scss
@@ -70,4 +70,15 @@ wm-ugc-box {
       white-space: break-spaces;
     }
   }
+
+  ion-button {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    top: 0;
+    left: 0;
+    margin: 10px;
+    --padding-start: 0.5em;
+    --padding-end: 0.5em;
+  }
 }

--- a/projects/wm-core/src/box/ugc-box/ugc-box.component.ts
+++ b/projects/wm-core/src/box/ugc-box/ugc-box.component.ts
@@ -1,6 +1,14 @@
-import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+  ChangeDetectorRef,
+} from '@angular/core';
 import {BaseBoxComponent} from '../box';
 import {IUGCBOX} from '../../types/config';
+import {Store} from '@ngrx/store';
+import {openUgcUploader} from '@wm-core/store/user-activity/user-activity.action';
+import {LangService} from '@wm-core/localization/lang.service';
 
 @Component({
   selector: 'wm-ugc-box',
@@ -11,4 +19,8 @@ import {IUGCBOX} from '../../types/config';
 })
 export class UgcBoxComponent extends BaseBoxComponent<IUGCBOX> {
   public defaultPhotoPath = 'assets/images/profile/my-path.webp';
+
+  openUgcUploader() {
+    this._store.dispatch(openUgcUploader());
+  }
 }

--- a/projects/wm-core/src/localization/i18n/de.ts
+++ b/projects/wm-core/src/localization/i18n/de.ts
@@ -107,4 +107,15 @@ export const wmDE = {
   'Annulla': 'Stornieren',
   'Dalla libreria': 'Aus der Bibliothek',
   'Scatta una foto': 'Ein Foto machen',
+  'Carica File': 'Datei hochladen',
+  'Trascina qui il tuo file o clicca per selezionare':
+    'Ziehen Sie hier Ihre Datei oder klicken Sie, um zu wählen',
+  'Accetta i seguenti formati': 'Akzeptiert die folgenden Formate',
+  'Tipo di file non supportato': 'Typ des Dateis nicht unterstützt',
+  'Il file non contiene una geometria valida': 'Der Datei enthält keine gültige Geometrie',
+  'Errore durante la lettura del file, riprova':
+    'Fehler beim Lesen des Dateis, versuchen Sie es erneut',
+  'Si è verificato un errore durante il salvataggio della traccia. Riprova':
+    'Es ist ein Fehler beim Speichern der Strecke aufgetreten. Versuchen Sie es erneut',
+  'La traccia è stata salvata correttamente': 'Die Strecke wurde erfolgreich gespeichert',
 };

--- a/projects/wm-core/src/localization/i18n/en.ts
+++ b/projects/wm-core/src/localization/i18n/en.ts
@@ -114,4 +114,13 @@ export const wmEN = {
   'Dalla libreria': 'From the library',
   'Scatta una foto': 'Take a picture',
   'placeholder': 'Search',
+  'Carica File': 'Upload File',
+  'Trascina qui il tuo file o clicca per selezionare': 'Drag and drop your file or click to select',
+  'Accetta i seguenti formati': 'Accepts the following formats',
+  'Tipo di file non supportato': 'File type not supported',
+  'Il file non contiene una geometria valida': 'The file does not contain a valid geometry',
+  'Errore durante la lettura del file, riprova': 'Error reading file, try again',
+  'Si è verificato un errore durante il salvataggio della traccia. Riprova':
+    'An error occurred while saving the track. Try again',
+  'La traccia è stata salvata correttamente': 'The track has been saved correctly',
 };

--- a/projects/wm-core/src/localization/i18n/es.ts
+++ b/projects/wm-core/src/localization/i18n/es.ts
@@ -104,4 +104,14 @@ export const wmES = {
   'Annulla': 'Cancelar',
   'Dalla libreria': 'De la biblioteca',
   'Scatta una foto': 'Toma una fotografía',
+  'Carica File': 'Carga archivo',
+  'Trascina qui il tuo file o clicca per selezionare':
+    'Arrastra tu archivo o haz clic para seleccionar',
+  'Accetta i seguenti formati': 'Acepta los siguientes formatos',
+  'Tipo di file non supportato': 'Tipo de archivo no soportado',
+  'Il file non contiene una geometria valida': 'El archivo no contiene una geometría válida',
+  'Errore durante la lettura del file, riprova': 'Error al leer el archivo, inténtalo de nuevo',
+  'Si è verificato un errore durante il salvataggio della traccia. Riprova':
+    'Se ha producido un error al guardar la ruta. Inténtalo de nuevo',
+  'La traccia è stata salvata correttamente': 'La ruta se ha guardado correctamente',
 };

--- a/projects/wm-core/src/localization/i18n/fr.ts
+++ b/projects/wm-core/src/localization/i18n/fr.ts
@@ -107,4 +107,14 @@ export const wmFR = {
   'Dalla libreria': 'De la bibliothèque',
   'Scatta una foto': 'Prendre une photo',
   'placeholder': 'Chercher',
+  'Carica File': 'Charger le fichier',
+  'Trascina qui il tuo file o clicca per selezionare':
+    'Déplacez votre fichier ou cliquez pour sélectionner',
+  'Accetta i seguenti formati': 'Accepte les formats suivants',
+  'Tipo di file non supportato': 'Type de fichier non pris en charge',
+  'Il file non contiene una geometria valida': 'Le fichier ne contient pas de géométrie valide',
+  'Errore durante la lettura del file, riprova': 'Erreur lors de la lecture du fichier, réessayez',
+  'Si è verificato un errore durante il salvataggio della traccia. Riprova':
+    'Une erreur est survenue lors de la sauvegarde de la piste. Réessayez',
+  'La traccia è stata salvata correttamente': 'La piste a été sauvegardée correctement',
 };

--- a/projects/wm-core/src/localization/i18n/it.ts
+++ b/projects/wm-core/src/localization/i18n/it.ts
@@ -113,4 +113,14 @@ export const wmIT = {
   'Dalla libreria': 'Dalla libreria',
   'Scatta una foto': 'Scatta una foto',
   'placeholder': 'Cerca',
+  'Carica File': 'Carica File',
+  'Trascina qui il tuo file o clicca per selezionare':
+    'Trascina qui il tuo file o clicca per selezionare',
+  'Accetta i seguenti formati': 'Accetta i seguenti formati',
+  'Tipo di file non supportato': 'Tipo di file non supportato',
+  'Il file non contiene una geometria valida': 'Il file non contiene una geometria valida',
+  'Errore durante la lettura del file, riprova': 'Errore durante la lettura del file, riprova',
+  'Si è verificato un errore durante il salvataggio della traccia. Riprova':
+    'Si è verificato un errore durante il salvataggio della traccia. Riprova',
+  'La traccia è stata salvata correttamente': 'La traccia è stata salvata correttamente',
 };

--- a/projects/wm-core/src/localization/i18n/pr.ts
+++ b/projects/wm-core/src/localization/i18n/pr.ts
@@ -104,4 +104,15 @@ export const wmPR = {
   'Annulla': 'Cancelar',
   'Dalla libreria': 'Da biblioteca',
   'Scatta una foto': 'Tire uma fotografia',
+  'Carica File': 'Carrega ficheiro',
+  'Trascina qui il tuo file o clicca per selezionare':
+    'Arrastra o seu ficheiro ou clica para selecionar',
+  'Accetta i seguenti formati': 'Aceita os seguintes formatos',
+  'Tipo di file non supportato': 'Tipo de ficheiro não suportado',
+  'Il file non contiene una geometria valida': 'O ficheiro não contém uma geometria válida',
+  'Errore durante la lettura del file, riprova':
+    'Errore durante a leitura do ficheiro, tente novamente',
+  'Si è verificato un errore durante il salvataggio della traccia. Riprova':
+    'Ocorreu um erro ao salvar a trilha. Tente novamente',
+  'La traccia è stata salvata correttamente': 'A trilha foi salva corretamente',
 };

--- a/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.html
+++ b/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.html
@@ -1,0 +1,75 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>{{'Carica File'|wmtrans}}</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="cancel()">
+        <ion-icon name="close"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ng-container *ngIf="selectedFile$ | async as selectedFile; else noFileSelected">
+    <ion-item lines="none">
+      <ion-icon name="document" slot="start"></ion-icon>
+      <ion-label>
+        <h3>{{'File selezionato'|wmtrans}}:</h3>
+        <p>{{selectedFile.name}}</p>
+      </ion-label>
+      <ion-button (click)="removeFile()" size="small" fill="clear" color="danger" slot="end">
+        <ion-icon name="trash"></ion-icon>
+      </ion-button>
+    </ion-item>
+    <wm-form [confPOIFORMS]="confTRACKFORMS$|async" (formGroupEvt)="fg = $event"></wm-form>
+  </ng-container>
+  <ng-template #noFileSelected>
+    <ion-grid>
+      <ion-row>
+        <ion-col>
+          <ion-card
+            (dragover)="onDragOver($event)"
+            (dragleave)="onDragLeave($event)"
+            (drop)="onDrop($event)"
+            [class.ion-activated]="isDragging$|async"
+            (click)="fileInput.click()"
+            class="ion-text-center ion-padding"
+          >
+            <ion-card-content>
+              <ion-icon name="cloud-upload" size="large"></ion-icon>
+              <ion-text>
+                <h2>{{'Trascina qui il tuo file o clicca per selezionare'|wmtrans}}</h2>
+                <p>{{'Accetta i seguenti formati'|wmtrans}}: {{acceptedFileTypes}}</p>
+              </ion-text>
+            </ion-card-content>
+          </ion-card>
+          <input
+            #fileInput
+            type="file"
+            (change)="onFileSelected($event)"
+            [accept]="acceptedFileTypes"
+            [multiple]="false"
+            hidden
+          />
+        </ion-col>
+      </ion-row>
+    </ion-grid>
+  </ng-template>
+</ion-content>
+
+<ion-footer>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button (click)="cancel()" color="medium">{{'Annulla'|wmtrans}}</ion-button>
+    </ion-buttons>
+    <ion-buttons slot="end">
+      <ion-button
+        (click)="upload()"
+        [disabled]="!(selectedFile$|async) || !fg?.valid || !fg?.dirty"
+        color="primary"
+      >
+        {{'Carica'|wmtrans}}
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-footer>

--- a/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.scss
+++ b/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.scss
@@ -1,0 +1,46 @@
+wm-modal-ugc-track-uploader {
+  ion-content {
+    --padding-top: 0;
+    --padding-bottom: 0;
+  }
+
+  ion-grid {
+    height: 100%;
+    padding: 0;
+  }
+
+  ion-row {
+    height: 100%;
+  }
+
+  ion-col {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  ion-card {
+    flex: 1;
+    margin: 0;
+    height: 100%;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &.ion-activated {
+      background-color: var(--ion-color-light);
+    }
+  }
+
+  ion-icon[name='cloud-upload'] {
+    font-size: 48px;
+    margin-bottom: 16px;
+  }
+
+  ion-item {
+    --padding-start: 16px;
+    --padding-end: 16px;
+  }
+}

--- a/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.ts
+++ b/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.ts
@@ -1,0 +1,300 @@
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+  Input,
+} from '@angular/core';
+import {UntypedFormGroup} from '@angular/forms';
+import {AlertController, ModalController} from '@ionic/angular';
+import {Store} from '@ngrx/store';
+import {confGeohubId, confTRACKFORMS} from '@wm-core/store/conf/conf.selector';
+import {WmFeature, WmProperties} from '@wm-types/feature';
+import {LineString} from 'geojson';
+import {BehaviorSubject, EMPTY, from, Observable} from 'rxjs';
+import * as toGeoJSON from '@tmcw/togeojson';
+import {DOMParser} from 'xmldom';
+import {catchError, map, switchMap, take} from 'rxjs/operators';
+import {DeviceService} from '@wm-core/services/device.service';
+import {LangService} from '@wm-core/localization/lang.service';
+import {saveUgcTrack} from '@wm-core/utils/localForage';
+import {generateUUID} from '@wm-core/utils/localForage';
+import {syncUgcTracks} from '@wm-core/store/features/ugc/ugc.actions';
+
+@Component({
+  selector: 'wm-modal-ugc-track-uploader',
+  templateUrl: './modal-ugc-track-uploader.component.html',
+  styleUrls: ['./modal-ugc-track-uploader.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ModalUgcTrackUploaderComponent {
+  private _ugcTrack: WmFeature<LineString> | null = null;
+
+  @ViewChild('fileInput') fileInput!: ElementRef;
+
+  acceptedFileTypes: string = '.gpx,.kml,.geojson';
+  confTRACKFORMS$: Observable<any[]> = this._store.select(confTRACKFORMS);
+  fg: UntypedFormGroup;
+  geohubId$: Observable<number> = this._store.select(confGeohubId);
+  isDragging$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  selectedFile$: BehaviorSubject<File | null> = new BehaviorSubject<File | null>(null);
+
+  constructor(
+    private _store: Store,
+    private _modalCtrl: ModalController,
+    private _deviceSvc: DeviceService,
+    private _langSvc: LangService,
+    private _alertCtrl: AlertController,
+  ) {}
+
+  cancel(): void {
+    this._modalCtrl.dismiss();
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging$.next(false);
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging$.next(true);
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging$.next(false);
+
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this._handleFile(files[0]);
+    }
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this._handleFile(input.files[0]);
+    }
+  }
+
+  removeFile(): void {
+    this.selectedFile$.next(null);
+    this._ugcTrack = null;
+  }
+
+  upload(): void {
+    if (this.selectedFile$.value) {
+      this.geohubId$
+        .pipe(
+          take(1),
+          switchMap(geohubId =>
+            from(this._deviceSvc.getInfo()).pipe(
+              map(device => {
+                const dateNow = new Date();
+                const properties: WmProperties = {
+                  name: this.fg.value.title,
+                  form: this.fg.value,
+                  uuid: generateUUID(),
+                  app_id: `${geohubId}`,
+                  createdAt: dateNow,
+                  updatedAt: dateNow,
+                  device,
+                };
+                this._ugcTrack.properties = {
+                  ...this._ugcTrack.properties,
+                  ...properties,
+                };
+                return this._ugcTrack;
+              }),
+            ),
+          ),
+          switchMap(feature => saveUgcTrack(feature)),
+          switchMap(_ => {
+            this.cancel();
+            return this._alertCtrl.create({
+              message: `${this._langSvc.instant('La traccia è stata salvata correttamente')}!`,
+              buttons: ['OK'],
+            });
+          }),
+          switchMap(alert => alert.present()),
+          catchError(_ => {
+            this._showErrorAlert(
+              this._langSvc.instant(
+                'Si è verificato un errore durante il salvataggio della traccia. Riprova',
+              ),
+            );
+            return EMPTY;
+          }),
+        )
+        .subscribe(() => this._store.dispatch(syncUgcTracks()));
+    }
+  }
+
+  private _deleteUnnecessaryProperties(feature: WmFeature<LineString>): WmFeature<LineString> {
+    if (feature.properties) {
+      delete feature.properties.id;
+      delete feature.properties.uuid;
+      delete feature.properties.image_gallery;
+    }
+    return feature;
+  }
+
+  private _handleFile(file: File): void {
+    if (!this._isFileTypeAccepted(file)) {
+      this.selectedFile$.next(null);
+      this._showErrorAlert(this._langSvc.instant('Tipo di file non supportato'));
+      return;
+    }
+
+    this._readFileContent(file)
+      .pipe(
+        take(1),
+        map(fileContent => {
+          const result = this._validateAndConvertToWmFeature(fileContent, file.name);
+          if (result) {
+            this._ugcTrack = result;
+            this.selectedFile$.next(file);
+          } else {
+            this.selectedFile$.next(null);
+            this._showErrorAlert(
+              this._langSvc.instant('Il file non contiene una geometria valida'),
+            );
+          }
+        }),
+        catchError(error => {
+          this.selectedFile$.next(null);
+          this._showErrorAlert(
+            this._langSvc.instant('Errore durante la lettura del file, riprova'),
+          );
+          return EMPTY;
+        }),
+      )
+      .subscribe();
+  }
+
+  private _isFileTypeAccepted(file: File): boolean {
+    if (this.acceptedFileTypes === '*') return true;
+
+    const acceptedTypes = this.acceptedFileTypes.split(',').map(type => {
+      return type.trim().toLowerCase();
+    });
+
+    const fileExtension = '.' + file.name.split('.').pop()?.toLowerCase();
+    const fileType = file.type.toLowerCase();
+
+    return acceptedTypes.some(type => {
+      if (type.startsWith('.')) {
+        return type === fileExtension;
+      } else if (type.endsWith('/*')) {
+        return fileType.startsWith(type.replace('/*', '/'));
+      } else {
+        return type === fileType;
+      }
+    });
+  }
+
+  private _isValidGeoJsonFeature(data: any): boolean {
+    return (
+      data &&
+      data.type === 'Feature' &&
+      data.geometry &&
+      data.geometry.type === 'LineString' &&
+      Array.isArray(data.geometry.coordinates) &&
+      data.geometry.coordinates.length > 0
+    );
+  }
+
+  private _readFileContent(file: File): Observable<string> {
+    return new Observable(observer => {
+      const reader = new FileReader();
+
+      reader.onload = e => {
+        observer.next(e.target?.result as string);
+        observer.complete();
+      };
+
+      reader.onerror = e => {
+        observer.error(new Error('Errore nella lettura del file'));
+      };
+
+      reader.readAsText(file);
+
+      // Cleanup quando l'observable viene unsubscribed
+      return () => {
+        reader.abort();
+      };
+    });
+  }
+
+  private _showErrorAlert(message: string): void {
+    from(
+      this._alertCtrl.create({
+        header: this._langSvc.instant('Ops!'),
+        message,
+        buttons: ['OK'],
+      }),
+    )
+      .pipe(switchMap(alert => alert.present()))
+      .subscribe();
+  }
+
+  private _validateAndConvertToWmFeature(
+    content: string,
+    fileName: string,
+  ): WmFeature<LineString> | null {
+    const extension = fileName.split('.').pop()?.toLowerCase();
+    let geojsonFeature: WmFeature<LineString>;
+
+    try {
+      switch (extension) {
+        case 'gpx':
+          const gpxDoc = new DOMParser().parseFromString(content, 'text/xml');
+          const gpxConverted = toGeoJSON.gpx(gpxDoc);
+          // Cerca la prima feature con geometria LineString
+          const lineStringGpx = gpxConverted?.features?.find(
+            feature => feature.geometry?.type === 'LineString',
+          );
+          if (lineStringGpx) {
+            geojsonFeature = lineStringGpx as WmFeature<LineString>;
+          } else {
+            return null;
+          }
+          break;
+
+        case 'kml':
+          const kmlDoc = new DOMParser().parseFromString(content, 'text/xml');
+          const kmlConverted = toGeoJSON.kml(kmlDoc);
+          const lineStringKml = kmlConverted?.features?.find(
+            feature => feature.geometry?.type === 'LineString',
+          );
+          if (lineStringKml) {
+            geojsonFeature = lineStringKml as WmFeature<LineString>;
+          } else {
+            return null;
+          }
+          break;
+        case 'geojson':
+          const geojsonParsed = JSON.parse(content);
+          geojsonFeature = geojsonParsed;
+          break;
+
+        default:
+          return null;
+      }
+
+      if (!this._isValidGeoJsonFeature(geojsonFeature)) {
+        return null;
+      }
+
+      return this._deleteUnnecessaryProperties(geojsonFeature);
+    } catch (error) {
+      return null;
+    }
+  }
+}

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -87,3 +87,5 @@ export const trackElevationChartHoverElemenents = createAction(
   '[User Activity] track elevation chart hover elements',
   props<{elements: WmSlopeChartHoverElements}>(),
 );
+
+export const openUgcUploader = createAction('[User Activity] open ugc uploader');

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -3,6 +3,7 @@ import {
   closeUgc,
   goToHome,
   inputTyped,
+  openUgcUploader,
   resetPoiFilters,
   setLayer,
   toggleTrackFilter,
@@ -32,6 +33,8 @@ import {debounceTime, map, mergeMap, skip, switchMap, tap, withLatestFrom} from 
 import {combineLatest, of} from 'rxjs';
 import {Filter} from '@wm-core/types/config';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+import {ModalController} from '@ionic/angular';
+import {ModalUgcTrackUploaderComponent} from '@wm-core/modal-ugc-track-uploader/modal-ugc-track-uploader.component';
 
 @Injectable()
 export class UserActivityEffects {
@@ -59,6 +62,19 @@ export class UserActivityEffects {
       ),
       tap(() => this._urlHandlerSvc.resetURL()),
     ),
+  );
+  openUgcUploader$ = createEffect(
+    () =>
+      this._actions$.pipe(
+        ofType(openUgcUploader),
+        switchMap(() =>
+          this._modalCtrl.create({
+            component: ModalUgcTrackUploaderComponent,
+          }),
+        ),
+        switchMap(modal => modal.present()),
+      ),
+    {dispatch: false},
   );
   removeTrackFilters$ = createEffect(() =>
     this._actions$.pipe(
@@ -141,5 +157,6 @@ export class UserActivityEffects {
     private _actions$: Actions,
     private _store: Store,
     private _urlHandlerSvc: UrlHandlerService,
+    private _modalCtrl: ModalController,
   ) {}
 }

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -65,6 +65,7 @@ import {ImageGalleryComponent} from './image-gallery/image-gallery.component';
 import {TrackRelatedPoiComponent} from './track-related-poi/track-related-poi.component';
 import {UgcPoiPropertiesComponent} from './ugc-poi-properties/ugc-poi-properties.component';
 import {WmTrackAlertComponent} from './track-alert/track-alert.component';
+import {ModalUgcTrackUploaderComponent} from './modal-ugc-track-uploader/modal-ugc-track-uploader.component';
 export const declarations = [
   WmAddressComponent,
   WmTabDetailComponent,
@@ -102,6 +103,7 @@ export const declarations = [
   TrackRelatedPoiComponent,
   UgcPoiPropertiesComponent,
   WmTrackAlertComponent,
+  ModalUgcTrackUploaderComponent,
 ];
 const modules = [
   WmSharedModule,


### PR DESCRIPTION
This commit adds the modal-ugc-track-uploader component, which allows users to upload track files in various formats such as GPX, KML, and GeoJSON. The component includes HTML, SCSS, and TypeScript files that handle file selection, drag and drop functionality, validation of file types, reading file content, and converting it into a WmFeature object. Users can cancel the upload process or proceed with uploading the selected track file.

chore(ugc-box): Add UGC uploader button

- Added an import statement for the `Store` from `@ngrx/store`
- Added a new parameter `_store` of type `Store` to the constructor
- Added a new method `openUgcUploader()` that dispatches the `openUgcUploader()` action
- Updated the HTML template to include an `<ion-button>` element with an icon for uploading UGC
- Updated the SCSS file to style the UGC uploader button

chore(user-activity): add functionality to open UGC uploader

This commit adds the ability to open the UGC uploader in the user activity module. It includes changes to the action file, effects file, and imports necessary components and services.

chore(i18n): add file upload translations

- Added translations for file upload feature in multiple languages.
- Updated the translation files for German, English, Spanish, French, Italian, and Portuguese.
- Translated phrases related to uploading files and error messages.
