### PR TITLE
chore(conf): add flow line quote text to track properties oc:4740,4745,4739,4741,4727

### DIFF
--- a/projects/wm-core/src/store/conf/conf.selector.ts
+++ b/projects/wm-core/src/store/conf/conf.selector.ts
@@ -29,6 +29,14 @@ export const confAUTHEnable = createSelector(
   },
 );
 export const confMAP = createSelector(confFeature, state => state.MAP);
+export const confFlowLineQuote = createSelector(confMAP, state =>
+  state.flow_line_quote_show
+    ? {
+        flow_line_quote_orange: state.flow_line_quote_orange,
+        flow_line_quote_red: state.flow_line_quote_red,
+      }
+    : null,
+);
 export const confJIDOUPDATETIME = createSelector(confFeature, state => state.JIDO_UPDATE_TIME);
 export const confTRANSLATIONS = createSelector(confFeature, state => state.TRANSLATIONS);
 export const confRecordTrackShow = createSelector(confMAP, state => state.record_track_show);

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -1,6 +1,7 @@
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {currentCustomTrack} from '../features/ugc/ugc.selector';
 import {UserActivityState} from './user-activity.reducer';
+import {confFlowLineQuote} from '../conf/conf.selector';
 
 export const userActivity = createFeatureSelector<UserActivityState>('user-activity');
 
@@ -109,4 +110,25 @@ export const showResult = createSelector(
       ugcOpened
     );
   },
+);
+
+export const flowLineQuoteText = createSelector(
+  chartHoverElements,
+  confFlowLineQuote,
+  (elements, flowLine) => {
+    if (!elements?.location?.altitude || !flowLine) return null;
+
+    const {altitude} = elements.location;
+    const {flow_line_quote_orange, flow_line_quote_red} = flowLine;
+
+    const green = `<span class="green">Livello 1: tratti non interessati dall'alta quota (quota minore di ${flow_line_quote_orange} metri)</span>`;
+    const orange = `<span class="orange">Livello 2: tratti parzialmente in alta quota (quota compresa tra ${flow_line_quote_orange} metri e ${flow_line_quote_red} metri)</span>`;
+    const red = `<span class="red">Livello 3: in alta quota (quota superiore ${flow_line_quote_red} metri)</span>`;
+
+    return altitude < flow_line_quote_orange
+      ? green
+      : altitude > flow_line_quote_orange && altitude < flow_line_quote_red
+      ? orange
+      : red;
+  }
 );

--- a/projects/wm-core/src/track-properties/track-properties.component.html
+++ b/projects/wm-core/src/track-properties/track-properties.component.html
@@ -18,13 +18,16 @@
     *ngIf="ecTrackProperties?.not_accessible != null && ecTrackProperties?.not_accessible === true"
     [alert]="ecTrackProperties?.not_accessible_message"
   ></wm-track-alert>
+  <wm-track-edges [properties]="ecTrackProperties" [conf]="currentLayer$|async"></wm-track-edges>
+  <ion-label *ngIf="flowLineQuoteText$|async as flowLineQuoteText">
+    <div [innerHTML]="flowLineQuoteText"></div>
+  </ion-label>
   <wm-slope-chart
     (hover)="onLocationHover($event)"
     [currentTrack]="ecTrack$|async"
     id="webmapp-track-details-elevation-chart"
   >
   </wm-slope-chart>
-  <wm-track-edges [properties]="ecTrackProperties" [conf]="currentLayer$|async"></wm-track-edges>
   <wm-tab-detail class="webmapp-route-tab" [properties]="ecTrackProperties"></wm-tab-detail>
   <wm-tab-howto
     *ngIf="ecTrackProperties?.taxonomy?.activity"

--- a/projects/wm-core/src/track-properties/track-properties.component.ts
+++ b/projects/wm-core/src/track-properties/track-properties.component.ts
@@ -1,15 +1,16 @@
 import {Component, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
-import {confOPTIONS} from '@wm-core/store/conf/conf.selector';
+import {confFlowLineQuote, confOPTIONS} from '@wm-core/store/conf/conf.selector';
 import {currentEcTrack, currentEcTrackProperties} from '@wm-core/store/features/ec/ec.selector';
 import {trackElevationChartHoverElemenents} from '@wm-core/store/user-activity/user-activity.action';
-import {ecLayer} from '@wm-core/store/user-activity/user-activity.selector';
+import {chartHoverElements, ecLayer, flowLineQuoteText} from '@wm-core/store/user-activity/user-activity.selector';
 import {IOPTIONS} from '@wm-core/types/config';
 import {LineStringProperties, WmFeature} from '@wm-types/feature';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {LineString} from 'geojson';
-import {Observable} from 'rxjs';
+import {BehaviorSubject, Observable, combineLatest} from 'rxjs';
+import {distinctUntilChanged, filter, take} from 'rxjs/operators';
 @Component({
   selector: 'wm-track-properties',
   templateUrl: './track-properties.component.html',
@@ -18,16 +19,30 @@ import {Observable} from 'rxjs';
   encapsulation: ViewEncapsulation.None,
 })
 export class TrackPropertiesComponent {
+  chartHoverElements$: Observable<WmSlopeChartHoverElements> =
+    this._store.select(chartHoverElements);
   confOPTIONS$: Observable<IOPTIONS> = this._store.select(confOPTIONS);
   currentLayer$ = this._store.select(ecLayer);
   ecTrack$: Observable<WmFeature<LineString>> = this._store.select(currentEcTrack);
   ecTrackProperties$: Observable<LineStringProperties> =
     this._store.select(currentEcTrackProperties);
+  flowLineQuoteText$: Observable<string | null> = this._store.select(flowLineQuoteText);
 
   constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {}
 
   close(): void {
     this._urlHandlerSvc.updateURL({track: undefined});
+  }
+
+  getFlowPopoverText(altitude = 0, orangeTreshold = 800, redTreshold = 1500): string {
+    const green = `<span class="green">Livello 1: tratti non interessati dall'alta quota (quota minore di ${orangeTreshold} metri)</span>`;
+    const orange = `<span class="orange">Livello 2: tratti parzialmente in alta quota (quota compresa tra ${orangeTreshold} metri e ${redTreshold} metri)</span>`;
+    const red = `<span class="red">Livello 3: in alta quota (quota superiore ${redTreshold} metri)</span>`;
+    return altitude < orangeTreshold
+      ? green
+      : altitude > orangeTreshold && altitude < redTreshold
+      ? orange
+      : red;
   }
 
   onLocationHover(event: WmSlopeChartHoverElements): void {

--- a/projects/wm-core/src/track-properties/track-properties.component.ts
+++ b/projects/wm-core/src/track-properties/track-properties.component.ts
@@ -34,17 +34,6 @@ export class TrackPropertiesComponent {
     this._urlHandlerSvc.updateURL({track: undefined});
   }
 
-  getFlowPopoverText(altitude = 0, orangeTreshold = 800, redTreshold = 1500): string {
-    const green = `<span class="green">Livello 1: tratti non interessati dall'alta quota (quota minore di ${orangeTreshold} metri)</span>`;
-    const orange = `<span class="orange">Livello 2: tratti parzialmente in alta quota (quota compresa tra ${orangeTreshold} metri e ${redTreshold} metri)</span>`;
-    const red = `<span class="red">Livello 3: in alta quota (quota superiore ${redTreshold} metri)</span>`;
-    return altitude < orangeTreshold
-      ? green
-      : altitude > orangeTreshold && altitude < redTreshold
-      ? orange
-      : red;
-  }
-
   onLocationHover(event: WmSlopeChartHoverElements): void {
     this._store.dispatch(trackElevationChartHoverElemenents({elements: event}));
   }


### PR DESCRIPTION
This commit adds the functionality to display the flow line quote text in the track properties component. The flow line quote text is calculated based on the altitude of the location and certain threshold values. The text will be displayed dynamically based on the altitude value.

The following files were modified:
- projects/wm-core/src/store/conf/conf.selector.ts
- projects/wm-core/src/store/user-activity/user-activity.selector.ts
- projects/wm-core/src/track-properties/track-properties.component.html
- projects/wm-core/src/track-properties/track-properties.component.ts
