### PR TITLE
chore: add UgcSynchronizedComponent oc: 4776

### DIFF
--- a/projects/wm-core/src/box/poi-box/poi-box.component.html
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.html
@@ -7,6 +7,10 @@
     <ng-container *ngIf="properties.updatedAt as updatedAt">
       <wm-updated-at [updatedAt]="updatedAt"></wm-updated-at>
     </ng-container>
+    <wm-ugc-synchronized
+      *ngIf="ugcOpened$|async"
+      [properties]="properties"
+    ></wm-ugc-synchronized>
   </ion-card>
 
   <ng-template #taxonomies>

--- a/projects/wm-core/src/box/poi-box/poi-box.component.html
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.html
@@ -7,10 +7,9 @@
     <ng-container *ngIf="properties.updatedAt as updatedAt">
       <wm-updated-at [updatedAt]="updatedAt"></wm-updated-at>
     </ng-container>
-    <wm-ugc-synchronized
-      *ngIf="ugcOpened$|async"
-      [properties]="properties"
-    ></wm-ugc-synchronized>
+    <div class="top-right-content">
+      <ng-content select="[top-right]"></ng-content>
+    </div>
   </ion-card>
 
   <ng-template #taxonomies>

--- a/projects/wm-core/src/box/poi-box/poi-box.component.scss
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.scss
@@ -121,5 +121,13 @@ wm-poi-box {
       height: var(--wm-font-sm);
       margin: 10px;
     }
+    wm-updated-at {
+      margin-top: 10px;
+    }
+    wm-ugc-synchronized {
+      position: absolute;
+      right: 10px;
+      top: 10px;
+    }
   }
 }

--- a/projects/wm-core/src/box/poi-box/poi-box.component.scss
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.scss
@@ -124,7 +124,7 @@ wm-poi-box {
     wm-updated-at {
       margin-top: 10px;
     }
-    wm-ugc-synchronized {
+    .top-right-content {
       position: absolute;
       right: 10px;
       top: 10px;

--- a/projects/wm-core/src/box/poi-box/poi-box.component.ts
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.ts
@@ -3,7 +3,6 @@ import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/co
 import {BaseBoxComponent} from '../box';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
-import {ugcOpened} from '@wm-core/store/user-activity/user-activity.selector';
 
 @Component({
   selector: 'wm-poi-box',
@@ -12,6 +11,4 @@ import {ugcOpened} from '@wm-core/store/user-activity/user-activity.selector';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class PoiBoxComponent extends BaseBoxComponent<WmFeature<Point>> {
-  ugcOpened$ = this._store.select(ugcOpened);
-}
+export class PoiBoxComponent extends BaseBoxComponent<WmFeature<Point>> {}

--- a/projects/wm-core/src/box/poi-box/poi-box.component.ts
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.ts
@@ -1,9 +1,9 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 import {BaseBoxComponent} from '../box';
-import {IHIT} from '../../types/elastic';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
+import {ugcOpened} from '@wm-core/store/user-activity/user-activity.selector';
 
 @Component({
   selector: 'wm-poi-box',
@@ -12,4 +12,6 @@ import {Point} from 'geojson';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class PoiBoxComponent extends BaseBoxComponent<WmFeature<Point>> {}
+export class PoiBoxComponent extends BaseBoxComponent<WmFeature<Point>> {
+  ugcOpened$ = this._store.select(ugcOpened);
+}

--- a/projects/wm-core/src/box/search-box/search-box.component.html
+++ b/projects/wm-core/src/box/search-box/search-box.component.html
@@ -28,12 +28,9 @@
       <ion-skeleton-text class="wm-card-big-title-skeleton" animated></ion-skeleton-text>
     </ng-template>
   </ion-card-header>
-  <ng-container *ngIf="(ugcOpened$|async)">
-    <wm-ugc-synchronized
-      *ngIf="data?.properties as properties"
-      [properties]="properties"
-    ></wm-ugc-synchronized>
-  </ng-container>
+  <div class="top-right-content">
+    <ng-content select="[top-right]"></ng-content>
+  </div>
 </ion-card>
 
 <ng-template #taxonomies>

--- a/projects/wm-core/src/box/search-box/search-box.component.html
+++ b/projects/wm-core/src/box/search-box/search-box.component.html
@@ -28,6 +28,12 @@
       <ion-skeleton-text class="wm-card-big-title-skeleton" animated></ion-skeleton-text>
     </ng-template>
   </ion-card-header>
+  <ng-container *ngIf="(ugcOpened$|async)">
+    <wm-ugc-synchronized
+      *ngIf="data?.properties as properties"
+      [properties]="properties"
+    ></wm-ugc-synchronized>
+  </ng-container>
 </ion-card>
 
 <ng-template #taxonomies>

--- a/projects/wm-core/src/box/search-box/search-box.component.scss
+++ b/projects/wm-core/src/box/search-box/search-box.component.scss
@@ -131,5 +131,10 @@ wm-search-box {
         font-size: var(--wm-font-sm) !important;
       }
     }
+    wm-ugc-synchronized {
+      position: absolute;
+      right: 10px;
+      top: 10px;
+    }
   }
 }

--- a/projects/wm-core/src/box/search-box/search-box.component.scss
+++ b/projects/wm-core/src/box/search-box/search-box.component.scss
@@ -131,7 +131,7 @@ wm-search-box {
         font-size: var(--wm-font-sm) !important;
       }
     }
-    wm-ugc-synchronized {
+    .top-right-content {
       position: absolute;
       right: 10px;
       top: 10px;

--- a/projects/wm-core/src/box/search-box/search-box.component.ts
+++ b/projects/wm-core/src/box/search-box/search-box.component.ts
@@ -1,6 +1,8 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {BaseBoxComponent} from '../box';
-import { IHIT } from '../../types/elastic';
+import {IHIT} from '../../types/elastic';
+import {ugcOpened} from '@wm-core/store/user-activity/user-activity.selector';
+import {Observable} from 'rxjs';
 
 @Component({
   selector: 'wm-search-box',
@@ -9,4 +11,6 @@ import { IHIT } from '../../types/elastic';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class SearchBoxComponent extends BaseBoxComponent<IHIT> {}
+export class SearchBoxComponent extends BaseBoxComponent<IHIT> {
+  ugcOpened$: Observable<boolean> = this._store.select(ugcOpened);
+}

--- a/projects/wm-core/src/box/search-box/search-box.component.ts
+++ b/projects/wm-core/src/box/search-box/search-box.component.ts
@@ -1,8 +1,6 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {BaseBoxComponent} from '../box';
 import {IHIT} from '../../types/elastic';
-import {ugcOpened} from '@wm-core/store/user-activity/user-activity.selector';
-import {Observable} from 'rxjs';
 
 @Component({
   selector: 'wm-search-box',
@@ -11,6 +9,4 @@ import {Observable} from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class SearchBoxComponent extends BaseBoxComponent<IHIT> {
-  ugcOpened$: Observable<boolean> = this._store.select(ugcOpened);
-}
+export class SearchBoxComponent extends BaseBoxComponent<IHIT> {}

--- a/projects/wm-core/src/home/home-result/home-result.component.html
+++ b/projects/wm-core/src/home/home-result/home-result.component.html
@@ -66,6 +66,9 @@
             [data]="card"
             (clickEVT)="trackEVT.emit(card.id)"
           >
+            <ng-container top-right *ngIf="ugcOpened$|async">
+              <wm-ugc-synchronized-badge [properties]="card?.properties"></wm-ugc-synchronized-badge>
+            </ng-container>
           </wm-search-box>
         </ng-container>
       </ng-container>
@@ -76,6 +79,9 @@
         [data]="c"
         (clickEVT)="setPoi(c)"
       >
+        <ng-container top-right *ngIf="ugcOpened$|async">
+          <wm-ugc-synchronized-badge [properties]="c?.properties"></wm-ugc-synchronized-badge>
+        </ng-container>
       </wm-poi-box>
     </div>
   </ng-container>

--- a/projects/wm-core/src/shared/shared.module.ts
+++ b/projects/wm-core/src/shared/shared.module.ts
@@ -3,8 +3,9 @@ import {NgModule} from '@angular/core';
 
 import {IonicModule} from '@ionic/angular';
 import {WmImgComponent} from './img/img.component';
+import {UgcSynchronizedComponent} from './ugc-synchronized/ugc-synchronized.component';
 
-const declarations = [WmImgComponent];
+const declarations = [WmImgComponent, UgcSynchronizedComponent];
 
 @NgModule({
   declarations,

--- a/projects/wm-core/src/shared/shared.module.ts
+++ b/projects/wm-core/src/shared/shared.module.ts
@@ -3,9 +3,9 @@ import {NgModule} from '@angular/core';
 
 import {IonicModule} from '@ionic/angular';
 import {WmImgComponent} from './img/img.component';
-import {UgcSynchronizedComponent} from './ugc-synchronized/ugc-synchronized.component';
+import {UgcSynchronizedBadgeComponent} from './ugc-synchronized-badge/ugc-synchronized-badge.component';
 
-const declarations = [WmImgComponent, UgcSynchronizedComponent];
+const declarations = [WmImgComponent, UgcSynchronizedBadgeComponent];
 
 @NgModule({
   declarations,

--- a/projects/wm-core/src/shared/ugc-synchronized-badge/ugc-synchronized-badge.component.ts
+++ b/projects/wm-core/src/shared/ugc-synchronized-badge/ugc-synchronized-badge.component.ts
@@ -1,9 +1,9 @@
 import {Component, Input, ViewEncapsulation} from '@angular/core';
 import {ChangeDetectionStrategy} from '@angular/core';
-import {LineStringProperties, PointProperties, WmProperties} from '@wm-types/feature';
+import {WmProperties} from '@wm-types/feature';
 
 @Component({
-  selector: 'wm-ugc-synchronized',
+  selector: 'wm-ugc-synchronized-badge',
   template: `
     <ng-container *ngIf="properties?.id; else onlyUuid">
       <ion-icon name="cloud-done-outline" color="primary"></ion-icon>
@@ -14,7 +14,7 @@ import {LineStringProperties, PointProperties, WmProperties} from '@wm-types/fea
   `,
   styles: [
     `
-      wm-ugc-synchronized {
+      wm-ugc-synchronized-badge {
         ion-icon {
           width: 22px;
           height: 22px;
@@ -25,6 +25,6 @@ import {LineStringProperties, PointProperties, WmProperties} from '@wm-types/fea
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class UgcSynchronizedComponent {
+export class UgcSynchronizedBadgeComponent {
   @Input() properties: { [name: string]: any; } | WmProperties;
 }

--- a/projects/wm-core/src/shared/ugc-synchronized/ugc-synchronized.component.ts
+++ b/projects/wm-core/src/shared/ugc-synchronized/ugc-synchronized.component.ts
@@ -1,0 +1,30 @@
+import {Component, Input, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy} from '@angular/core';
+import {LineStringProperties, PointProperties, WmProperties} from '@wm-types/feature';
+
+@Component({
+  selector: 'wm-ugc-synchronized',
+  template: `
+    <ng-container *ngIf="properties?.id; else onlyUuid">
+      <ion-icon name="cloud-done-outline" color="primary"></ion-icon>
+    </ng-container>
+    <ng-template #onlyUuid>
+      <ion-icon name="cloud-offline-outline" color="danger"></ion-icon>
+    </ng-template>
+  `,
+  styles: [
+    `
+      wm-ugc-synchronized {
+        ion-icon {
+          width: 22px;
+          height: 22px;
+        }
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class UgcSynchronizedComponent {
+  @Input() properties: { [name: string]: any; } | WmProperties;
+}


### PR DESCRIPTION
- Added UgcSynchronizedComponent to the shared module
- UgcSynchronizedComponent displays an icon based on the presence of an ID in properties

chore(search-box): add ugc-synchronized component

- Added the `wm-ugc-synchronized` component to the search box template.
- Positioned the `wm-ugc-synchronized` component in the top right corner of the search box.
- Imported and used the `ugcOpened` selector from `@wm-core/store/user-activity/user-activity.selector`.
- Created an observable `ugcOpened$` to track whether UGC (User Generated Content) is opened or not.

chore: Update poi-box component

- Added wm-ugc-synchronized element to the HTML template
- Updated styling in the SCSS file
- Added ugcOpened$ observable to the TypeScript file
