### PR TITLE
chore(track-useful-urls): improve serialization of download options oc: 4782

### DIFF
--- a/projects/wm-core/src/track-useful-urls/track-useful-urls.component.ts
+++ b/projects/wm-core/src/track-useful-urls/track-useful-urls.component.ts
@@ -37,7 +37,14 @@ export class WmTrackDownloadUrlsComponent implements OnInit {
         output = new XMLSerializer().serializeToString(output);
         break;
       case 'kml':
-        output = tokml(g);
+        const serializedFeature = {
+          ...g,
+          properties: Object.entries(g.properties).reduce((acc, [key, value]) => {
+            acc[key] = typeof value === 'object' ? JSON.stringify(value) : value;
+            return acc;
+          }, {} as { [key: string]: any }),
+        };
+        output = tokml(serializedFeature);
         break;
       case 'geojson':
         output = JSON.stringify(g);


### PR DESCRIPTION
- Refactored the code to improve serialization of download options in GPX and KML formats.
- Added support for nested properties in GPX format.
- Serialized feature properties as strings in KML format to prevent serialization errors.

chore: Update modal-ugc-track-uploader.component.ts

- Import Feature from geojson
- Add private method _deserializeProperties to deserialize feature properties
- Modify _handleFile method to use _deserializeProperties for LineString features

Refactor track-useful-urls.component.ts to simplify code and improve readability

The code changes in track-useful-urls.component.ts involve refactoring to simplify the code and improve readability. The changes include removing unnecessary lines of code related to metadata and extensions, and restructuring the options object for better organization. These modifications aim to enhance the overall quality of the component's implementation.
