### PR TITLE
fix: Fix null check in user-activity.selector.ts oc: 4815

### DIFF
--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -78,7 +78,7 @@ export const onlyPoisFilter = createSelector(
   filterTracks,
   poisSelectedFilterIdentifiers,
   (ftracks, fpois) => {
-    return (ftracks.length ?? 0) === 0 && (fpois.length ?? 0) > 0;
+    return (ftracks?.length ?? 0) === 0 && (fpois?.length ?? 0) > 0;
   },
 );
 export const showTracks = createSelector(


### PR DESCRIPTION
The code change fixes a null check in the user-activity.selector.ts file. The previous code did not handle null values correctly, causing potential issues. This fix ensures that the length of arrays is properly checked before performing comparisons.
