### PR TITLE
fix(home-result): add support for uuid in setPoi function oc: 4819

### DIFF
--- a/projects/wm-core/src/home/home-result/home-result.component.ts
+++ b/projects/wm-core/src/home/home-result/home-result.component.ts
@@ -92,7 +92,7 @@ export class WmHomeResultComponent implements OnDestroy {
   }
 
   setPoi(f: WmFeature<Point>): void {
-    const id = f?.properties?.id ?? null;
+    const id = f?.properties?.id ?? f?.properties?.uuid ?? null;
     this.poiEVT.emit(id);
   }
 }

--- a/projects/wm-core/src/store/features/ec/ec.effects.ts
+++ b/projects/wm-core/src/store/features/ec/ec.effects.ts
@@ -32,7 +32,7 @@ export class EcEffects {
       ofType(currentEcPoiId),
       withLatestFrom(this._store.select(pois).pipe(filter(p => p != null && p.length > 0))),
       map(([actions, pois]) => {
-        const ecPoi = pois.find(p => p?.properties?.id == actions.currentEcPoiId);
+        const ecPoi = actions.currentEcPoiId ? pois.find(p => p?.properties?.id == actions.currentEcPoiId) : null;
         return loadCurrentEcPoiSuccess({ecPoi});
       }),
       catchError(error => of(loadCurrentEcPoiFailure({error}))),


### PR DESCRIPTION
The setPoi function in the WmHomeResultComponent now checks for the presence of a uuid property in addition to the id property when setting the poi. This allows for more flexibility in identifying and emitting the poi id.

chore(ec): Update EcEffects to handle null currentEcPoiId
