### PR TITLE
chore: Update UGC track uploader component oc: 4822

### DIFF
--- a/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.html
+++ b/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.html
@@ -50,7 +50,7 @@
               <ion-icon name="cloud-upload" size="large"></ion-icon>
               <ion-text>
                 <h2>{{'Trascina qui il tuo file o clicca per selezionare'|wmtrans}}</h2>
-                <p>{{'Accetta i seguenti formati'|wmtrans}}: {{acceptedFileTypes}}</p>
+                <p>{{'Accetta i seguenti formati'|wmtrans}}: {{'GPX, KML, GeoJSON'}}</p>
               </ion-text>
             </ion-card-content>
           </ion-card>

--- a/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.ts
+++ b/projects/wm-core/src/modal-ugc-track-uploader/modal-ugc-track-uploader.component.ts
@@ -31,7 +31,7 @@ import {syncUgcTracks} from '@wm-core/store/features/ugc/ugc.actions';
 export class ModalUgcTrackUploaderComponent {
   @ViewChild('fileInput') fileInput!: ElementRef;
 
-  acceptedFileTypes: string = '.gpx,.kml,.geojson';
+  acceptedFileTypes: string = '.gpx,.kml,.geojson,application/gpx+xml,application/octet-stream';
   confMap$: Observable<any> = this._store.select(confMAP);
   confTRACKFORMS$: Observable<any[]> = this._store.select(confTRACKFORMS);
   fg: UntypedFormGroup;


### PR DESCRIPTION
- Updated the accepted file types in the HTML template to include GPX, KML, and GeoJSON formats.
- Updated the accepted file types in the TypeScript file to include additional MIME types for GPX, KML, and GeoJSON files.
