### PR TITLE
fix(geolocation): add altitude to recorded feature coordinates oc: 4838

### DIFF
--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -171,7 +171,7 @@ export class GeolocationService {
 
   private _addLocationToRecordedFeature(location: Location): void {
     if (this._recordedFeature) {
-      this._recordedFeature.geometry.coordinates.push([location.longitude, location.latitude]);
+      this._recordedFeature.geometry.coordinates.push([location.longitude, location.latitude, location.altitude]);
       const locations: Array<Location> = this._recordedFeature?.properties?.locations ?? [];
       locations.push(location);
       this._recordedFeature.properties.locations = locations;


### PR DESCRIPTION
This commit adds the altitude parameter to the coordinates array of the recorded feature in the GeolocationService. It also updates the locations array in the properties of the recorded feature.
