### PR TITLE
chore: Update currentUgcPoiId selector oc: 4855

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -164,7 +164,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
   currentPosition$: Observable<any>;
   currentRelatedPoi$ = this._store.select(currentEcRelatedPoi);
   currentRelatedPoiID$ = this._store.select(currentEcRelatedPoiId);
-  currentUgcPoiIDToMap$: Observable<number | null>;
+  currentUgcPoiIDToMap$: Observable<number | string | null>;
   dataLayerUrls$: Observable<IDATALAYER>;
   drawTrackOpened$: Observable<boolean> = this._store.select(drawTrackOpened);
   geohubId$ = this._store.select(confGeohubId);
@@ -468,8 +468,8 @@ export class WmGeoboxMapComponent implements OnDestroy {
   }
 
   setUgcPoi(poi: WmFeature<Point>): void {
-    const id = poi?.properties?.id ?? null;
-    this._urlHandlerSvc.updateURL({ugc_poi: id ? +id : undefined});
+    const id = poi?.properties?.id ?? poi?.properties?.uuid ?? null;
+    this._urlHandlerSvc.updateURL({ugc_poi: id ? id : undefined});
     this.resetSelectedPoi$.next(!this.resetSelectedPoi$.value);
   }
 

--- a/projects/wm-core/src/home/home.component.ts
+++ b/projects/wm-core/src/home/home.component.ts
@@ -164,8 +164,8 @@ export class WmHomeComponent implements AfterContentInit {
   setPoi(id: string | number): void {
     this.ugcOpened$.pipe(take(1)).subscribe(ugcOpened => {
       const queryParams = ugcOpened
-        ? {ugc_poi: id ? +id : undefined, poi: undefined}
-        : {poi: id ? +id : undefined, ugc_poi: undefined};
+        ? {ugc_poi: id ? id : undefined, poi: undefined}
+        : {poi: id ? id : undefined, ugc_poi: undefined};
       this._urlHandlerSvc.updateURL(queryParams, ['map']);
     });
   }

--- a/projects/wm-core/src/store/features/ugc/ugc.selector.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.selector.ts
@@ -39,7 +39,7 @@ export const currentUgcPoi = createSelector(ugc, state => state.currentUgcPoi);
 export const currentUgcPoiProperties = createSelector(currentUgcPoi, poi => poi?.properties);
 export const currentUgcPoiId = createSelector(
   currentUgcPoiProperties,
-  currentUgcPoiProperties => currentUgcPoiProperties?.id ?? null,
+  currentUgcPoiProperties => currentUgcPoiProperties?.id ?? currentUgcPoiProperties?.uuid ?? null,
 );
 export const syncUgcIntervalEnabled = createSelector(
   ugc,


### PR DESCRIPTION
- Added fallback to uuid property if id is not available.

chore: Update setPoi function in home.component.ts

The setPoi function in home.component.ts has been updated to handle the id parameter correctly. The queryParams object now assigns the id value without converting it to a number when ugcOpened is true. This change ensures that the correct values are passed to the _urlHandlerSvc.updateURL method.

chore: Update currentUgcPoiIDToMap$ type in geobox-map.component.ts

- Updated the type of currentUgcPoiIDToMap$ from Observable<number | null> to Observable<number | string | null>.
- Added support for string values in addition to number values.
- This change allows for more flexibility when mapping UGC POI IDs.
