### PR TITLE
chore(geolocation): add openAppSettings method oc:4750

### DIFF
--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -98,6 +98,10 @@ export class GeolocationService {
     };
   }
 
+  openAppSettings(): void {
+    backgroundGeolocation.openSettings();
+  }
+
   /**
    * Pause the geolocation record if active
    */


### PR DESCRIPTION
This commit adds a new method called `openAppSettings` to the `GeolocationService` class in the `geolocation.service.ts` file. This method calls the `backgroundGeolocation.openSettings()` function to open the app settings for geolocation.
