### PR TITLE
chore: Update camera and ugc services oc:4764

### DIFF
--- a/projects/wm-core/src/services/camera.service.ts
+++ b/projects/wm-core/src/services/camera.service.ts
@@ -194,6 +194,7 @@ export class CameraService {
           saved: false,
           format: 'image/jpeg',
         };
+        saveImg(fakePhoto.webPath);
         const fakeFeature: Feature<Media, MediaProperties> = {
           type: 'Feature',
           geometry: {

--- a/projects/wm-core/src/utils/localForage.ts
+++ b/projects/wm-core/src/utils/localForage.ts
@@ -483,11 +483,6 @@ export async function saveUgcMedia(feature: WmFeature<Media, MediaProperties>): 
 export async function saveUgcPoi(feature: WmFeature<Point>): Promise<void> {
   if (!feature) return;
   const properties = feature.properties;
-  const photos = properties.photos ?? [];
-
-  photos.forEach(photo => {
-    saveUgcMedia(photo);
-  });
 
   const featureId = properties.id ?? properties?.uuid;
   const storage = properties.id ? synchronizedUgcPoi : deviceUgcPoi;
@@ -496,12 +491,6 @@ export async function saveUgcPoi(feature: WmFeature<Point>): Promise<void> {
 
 export async function saveUgcTrack(feature: WmFeature<LineString>): Promise<void> {
   const properties = feature.properties;
-  const photos = properties.photos ?? [];
-
-  photos.forEach(photo => {
-    saveUgcMedia(photo);
-  });
-
   const featureId = properties.id ?? properties.uuid;
   const storage = properties.id ? synchronizedUgcTrack : deviceUgcTrack;
   await handleAsync(storage.setItem(`${featureId}`, feature), 'saveUgcTrack: Failed');


### PR DESCRIPTION
- Added a call to the `saveImg` function in the `CameraService` to save an image.
- Added a call to the `saveImg` function in the `UgcService` to save images.
- Updated the `saveApiPoi` and `saveApiTrack` functions in the `UgcService` to use form data for sending data.
- Updated the `syncUgc`, `syncUgcMedias`, `syncUgcPois`, and `syncUgcTracks` functions in the `UgcService` to handle errors during synchronization.
- Removed unnecessary calls to the `saveUgcMedia` function in the `localForage.ts`.

This commit updates the camera and ugc services by adding functionality for saving images, using form data for API requests, handling errors during synchronization, and removing unnecessary code.
