### PR TITLE
chore: Update user-activity.action.ts, user-activity.reducer.ts, and user-activity.selector.ts oc: 4791

### DIFF
--- a/projects/wm-core/src/home/home-result/home-result.component.html
+++ b/projects/wm-core/src/home/home-result/home-result.component.html
@@ -58,63 +58,70 @@
   </ng-container>
 
   <div class="wm-home-content">
-    <ng-container *ngIf="showResultType$|async as showResulType;">
-      <ng-container *ngIf="showResulType === 'tracks'|| showResulType == null">
-        <ng-container *ngIf="tracksLoading$|async">
-          <ion-list *ngFor="let idx of [1,1,1,1,1,1,1]">
-            <ion-list-header>
-              <ion-skeleton-text [animated]="true" style="width: 80px"></ion-skeleton-text>
-            </ion-list-header>
-            <ion-item>
-              <ion-thumbnail slot="start">
-                <ion-skeleton-text [animated]="true"></ion-skeleton-text>
-              </ion-thumbnail>
-              <ion-label>
-                <h3>
-                  <ion-skeleton-text [animated]="true" style="width: 80%;"></ion-skeleton-text>
-                </h3>
-                <p>
-                  <ion-skeleton-text [animated]="true" style="width: 60%;"></ion-skeleton-text>
-                </p>
-                <p>
-                  <ion-skeleton-text [animated]="true" style="width: 30%;"></ion-skeleton-text>
-                </p>
-              </ion-label>
-            </ion-item>
-          </ion-list>
-        </ng-container>
-        <ng-container *ngIf="tracks$|async as tracks">
-          <ng-container *ngIf="tracks.length > 0">
-            <wm-search-box
-              *ngFor="let card of tracks|wmSort:'properties.updatedAt':false|slice:0:200"
-              [data]="card"
-              (clickEVT)="trackEVT.emit(card.id)"
-            >
-              <ng-container top-right *ngIf="ugcOpened$|async">
-                <wm-ugc-synchronized-badge
-                  [properties]="card?.properties"
-                ></wm-ugc-synchronized-badge>
-              </ng-container>
-            </wm-search-box>
-          </ng-container>
-        </ng-container>
-      </ng-container>
-      <div class="pois" *ngIf="showResulType === 'pois'|| showResulType === 'all'">
-        <wm-poi-box
-          *ngFor="let c of pois$|async|wmSort:'properties.updatedAt':false"
-          [data]="c"
-          (clickEVT)="setPoi(c)"
-        >
-          <ng-container top-right *ngIf="ugcOpened$|async">
-            <wm-ugc-synchronized-badge [properties]="c?.properties"></wm-ugc-synchronized-badge>
-          </ng-container>
-        </wm-poi-box>
+    <ng-container *ngIf="(ugcOpened$|async) && !(ugcLoaded$|async); else results">
+      <div class="ugc-loading">
+        <ion-spinner color="primary"></ion-spinner>
       </div>
     </ng-container>
-    <ion-item lines="none" *ngIf="(countAll$|async)==0;">
-      <h5>
-        {{'Spiacenti non ci sono risultati con questi criteri di ricerca.'|wmtrans}}
-      </h5>
-    </ion-item>
+    <ng-template #results>
+      <ng-container *ngIf="showResultType$|async as showResulType;">
+        <ng-container *ngIf="showResulType === 'tracks'|| showResulType == null">
+          <ng-container *ngIf="tracksLoading$|async">
+            <ion-list *ngFor="let idx of [1,1,1,1,1,1,1]">
+              <ion-list-header>
+                <ion-skeleton-text [animated]="true" style="width: 80px"></ion-skeleton-text>
+              </ion-list-header>
+              <ion-item>
+                <ion-thumbnail slot="start">
+                  <ion-skeleton-text [animated]="true"></ion-skeleton-text>
+                </ion-thumbnail>
+                <ion-label>
+                  <h3>
+                    <ion-skeleton-text [animated]="true" style="width: 80%;"></ion-skeleton-text>
+                  </h3>
+                  <p>
+                    <ion-skeleton-text [animated]="true" style="width: 60%;"></ion-skeleton-text>
+                  </p>
+                  <p>
+                    <ion-skeleton-text [animated]="true" style="width: 30%;"></ion-skeleton-text>
+                  </p>
+                </ion-label>
+              </ion-item>
+            </ion-list>
+          </ng-container>
+          <ng-container *ngIf="tracks$|async as tracks">
+            <ng-container *ngIf="tracks.length > 0">
+              <wm-search-box
+                *ngFor="let card of tracks|wmSort:'properties.updatedAt':false|slice:0:200"
+                [data]="card"
+                (clickEVT)="trackEVT.emit(card.id)"
+              >
+                <ng-container top-right *ngIf="ugcOpened$|async">
+                  <wm-ugc-synchronized-badge
+                    [properties]="card?.properties"
+                  ></wm-ugc-synchronized-badge>
+                </ng-container>
+              </wm-search-box>
+            </ng-container>
+          </ng-container>
+        </ng-container>
+        <div class="pois" *ngIf="showResulType === 'pois'|| showResulType === 'all'">
+          <wm-poi-box
+            *ngFor="let c of pois$|async|wmSort:'properties.updatedAt':false"
+            [data]="c"
+            (clickEVT)="setPoi(c)"
+          >
+            <ng-container top-right *ngIf="ugcOpened$|async">
+              <wm-ugc-synchronized-badge [properties]="c?.properties"></wm-ugc-synchronized-badge>
+            </ng-container>
+          </wm-poi-box>
+        </div>
+      </ng-container>
+      <ion-item lines="none" *ngIf="(countAll$|async)==0;">
+        <h5>
+          {{'Spiacenti non ci sono risultati con questi criteri di ricerca.'|wmtrans}}
+        </h5>
+      </ion-item>
+    </ng-template>
   </div>
 </ng-template>

--- a/projects/wm-core/src/home/home-result/home-result.component.scss
+++ b/projects/wm-core/src/home/home-result/home-result.component.scss
@@ -2,5 +2,13 @@ wm-home-result {
   .wm-home-content {
     height: 100%;
     overflow: scroll;
+
+    .ugc-loading{
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 16px;
+    }
   }
 }

--- a/projects/wm-core/src/home/home-result/home-result.component.ts
+++ b/projects/wm-core/src/home/home-result/home-result.component.ts
@@ -16,6 +16,7 @@ import {
   ecLayer,
   lastFilterType,
   showTracks,
+  ugcLoaded,
   ugcOpened,
 } from '@wm-core/store/user-activity/user-activity.selector';
 import {
@@ -65,6 +66,7 @@ export class WmHomeResultComponent implements OnDestroy {
   showTracks$ = this._store.select(showTracks);
   tracks$: Observable<IHIT[]>;
   tracksLoading$: Observable<boolean> = this._store.select(ecTracksLoading);
+  ugcLoaded$: Observable<boolean> = this._store.select(ugcLoaded);
   ugcOpened$: Observable<boolean> = this._store.select(ugcOpened);
 
   constructor(

--- a/projects/wm-core/src/store/auth/auth.effects.ts
+++ b/projects/wm-core/src/store/auth/auth.effects.ts
@@ -6,7 +6,7 @@ import {AuthService} from './auth.service';
 import {from, of} from 'rxjs';
 import {AlertController} from '@ionic/angular';
 import {LangService} from '@wm-core/localization/lang.service';
-import {clearUgcData, getAuth, removeAuth, saveAuth} from '@wm-core/utils/localForage';
+import {clearAuthData, clearUgcData, getAuth, saveAuth} from '@wm-core/utils/localForage';
 import {Store} from '@ngrx/store';
 import {closeUgc} from '../user-activity/user-activity.action';
 
@@ -90,7 +90,7 @@ export class AuthEffects {
           switchMap(async () => {
             this._store.dispatch(closeUgc());
             await clearUgcData();
-            removeAuth();
+            await clearAuthData();
             return AuthActions.loadSignOutsSuccess();
           }),
           catchError(error => {

--- a/projects/wm-core/src/store/features/ugc/ugc.effects.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.effects.ts
@@ -33,11 +33,9 @@ import {
   syncUgcTracks,
   updateUgcPoi,
   updateUgcPoiFailure,
-  updateUgcPois,
   updateUgcPoiSuccess,
   updateUgcTrack,
   updateUgcTrackFailure,
-  updateUgcTracks,
   updateUgcTrackSuccess,
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {UgcService} from '@wm-core/store/features/ugc/ugc.service';
@@ -45,19 +43,16 @@ import {select, Store} from '@ngrx/store';
 import {activableUgc, currentUgcPoi, currentUgcTrack, syncUgcIntervalEnabled} from './ugc.selector';
 import {
   getUgcPoi,
-  getUgcPois,
   getUgcTrack,
-  getUgcTracks,
-  removeDeviceUgcTrack,
   removeUgcPoi,
   removeUgcTrack,
+  saveUgcLoadedOnce,
   saveUgcPoi,
   saveUgcTrack,
 } from '@wm-core/utils/localForage';
 import {AlertController} from '@ionic/angular';
 import {LangService} from '@wm-core/localization/lang.service';
-import {closeUgc, openUgc} from '@wm-core/store/user-activity/user-activity.action';
-import {track} from '../features.selector';
+import {setUgcLoaded} from '@wm-core/store/user-activity/user-activity.action';
 const SYNC_INTERVAL = 60000;
 @Injectable({
   providedIn: 'root',
@@ -177,6 +172,17 @@ export class UgcEffects {
       catchError(error => {
         console.error('Error loading UGC tracks:', error);
         return of(syncUgcFailure({responseType: 'Tracks', error})); // Dispatch a failure action in case of error
+      }),
+    ),
+  );
+  setUgcLoaded$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(syncUgcSuccess, syncUgcFailure),
+      map((action) => {
+        if (action.type === syncUgcSuccess.type) {
+          saveUgcLoadedOnce(true);
+        }
+        return setUgcLoaded({ugcLoaded: true});
       }),
     ),
   );

--- a/projects/wm-core/src/store/features/ugc/ugc.service.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.service.ts
@@ -34,7 +34,7 @@ import {
   WmFeatureCollection,
 } from '@wm-types/feature';
 import {Store} from '@ngrx/store';
-import {syncUgc, syncUgcSuccess, updateUgcPois, updateUgcTracks} from './ugc.actions';
+import {updateUgcPois, updateUgcTracks} from './ugc.actions';
 
 @Injectable({
   providedIn: 'root',
@@ -390,23 +390,22 @@ export class UgcService {
   }
 
   async syncUgc(): Promise<void> {
-    this.isLogged$.pipe(take(1)).subscribe(async isLogged => {
-      if (isLogged) {
-        try {
-          await this.syncUgcPois();
-          await this.syncUgcTracks();
-          await this.syncUgcMedias();
-        } catch (error) {
-          console.error('syncUgc: Errore durante la sincronizzazione:', error);
-        }
-      } else {
-        from(getUgcTracks())
-          .pipe(take(1))
-          .subscribe(ugcTrackFeatures => {
-            this._store.dispatch(updateUgcTracks({ugcTrackFeatures}));
-          });
+    const isLogged = await from(this.isLogged$.pipe(take(1))).toPromise();
+    if (isLogged) {
+      try {
+        await this.syncUgcPois();
+        await this.syncUgcTracks();
+        await this.syncUgcMedias();
+      } catch (error) {
+        console.error('syncUgc: Errore durante la sincronizzazione:', error);
       }
-    });
+    } else {
+      from(getUgcTracks())
+        .pipe(take(1))
+        .subscribe(ugcTrackFeatures => {
+          this._store.dispatch(updateUgcTracks({ugcTrackFeatures}));
+        });
+    }
   }
 
   async syncUgcMedias(): Promise<void> {

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -91,3 +91,5 @@ export const trackElevationChartHoverElemenents = createAction(
 );
 
 export const openUgcUploader = createAction('[User Activity] open ugc uploader');
+
+export const setUgcLoaded = createAction('[User Activity] set ugc loaded', props<{ugcLoaded: boolean}>());

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -23,6 +23,7 @@ import {
   trackElevationChartHoverElemenents,
   openDownloads,
   closeDownloads,
+  setUgcLoaded,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
@@ -44,6 +45,7 @@ export interface UserActivityState {
   drawTrackOpened: boolean;
   chartHoverElements: WmSlopeChartHoverElements;
   currentEcPoiId?: any;
+  ugcLoaded: boolean;
 }
 
 export interface UserAcitivityRootState {
@@ -60,6 +62,7 @@ const initialState: UserActivityState = {
   lastFilterType: null,
   loading: {pois: false, layer: false},
   chartHoverElements: null,
+  ugcLoaded: false,
 };
 
 export const userActivityReducer = createReducer(
@@ -234,6 +237,13 @@ export const userActivityReducer = createReducer(
     const newState: UserActivityState = {
       ...state,
       currentEcPoiId,
+    };
+    return newState;
+  }),
+  on(setUgcLoaded, (state, {ugcLoaded}) => {
+    const newState: UserActivityState = {
+      ...state,
+      ugcLoaded,
     };
     return newState;
   }),

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -146,3 +146,5 @@ export const flowLineQuoteText = createSelector(
       : red;
   },
 );
+
+export const ugcLoaded = createSelector(userActivity, state => state.ugcLoaded);

--- a/projects/wm-core/src/utils/localForage.ts
+++ b/projects/wm-core/src/utils/localForage.ts
@@ -4,6 +4,10 @@ import * as localforage from 'localforage';
 import {downloadTiles, getTilesByGeometry, removeTiles} from '../../../../../map-core/src/utils';
 import {IUser} from '@wm-core/store/auth/auth.model';
 
+export async function clearAuthData(): Promise<void> {
+  await deviceAuth.clear();
+}
+
 export async function clearUgcData(): Promise<void> {
   await Promise.all([
     synchronizedEctrack.clear(),
@@ -225,6 +229,10 @@ export async function getSynchronizedUgcTracks(): Promise<WmFeature<LineString>[
   return keys ? await Promise.all(keys.map(key => getSynchronizedUgcTrack(key))) : [];
 }
 
+export function getUgcLoadedOnce(): Promise<boolean> {
+  return deviceAuth.getItem<boolean>('ugcLoadedOnce');
+}
+
 export async function getUgcMedia(
   mediaId: string,
 ): Promise<WmFeature<Media, MediaProperties> | null> {
@@ -368,6 +376,10 @@ export async function removeSynchronizedUgcTrack(id: number): Promise<void> {
   await handleAsync(synchronizedUgcTrack.removeItem(`${id}`), 'removeSynchronizedUgcTrack: Failed');
 }
 
+export function removeUgcLoadedOnce(): void {
+  deviceAuth.removeItem('ugcLoadedOnce');
+}
+
 export async function removeUgcMedia(media: WmFeature<Media, MediaProperties>): Promise<void> {
   const properties = media.properties;
   const featureId = properties.id ?? properties.rawData?.uuid;
@@ -462,6 +474,10 @@ export async function saveImgInsideTrack(
     });
   }
   return Promise.resolve(totalSize);
+}
+
+export function saveUgcLoadedOnce(ugcLoadedOnce: boolean): void {
+  deviceAuth.setItem('ugcLoadedOnce', ugcLoadedOnce);
 }
 
 export async function saveUgcMedia(feature: WmFeature<Media, MediaProperties>): Promise<void> {


### PR DESCRIPTION
- Added action "setUgcLoaded" to track UGC loading status
- Updated reducer to handle "setUgcLoaded" action and update the state accordingly
- Added selector "ugcLoaded" to retrieve the UGC loading status from the state

chore: Update home-result.component.html, home-result.component.scss, and home-result.component.ts

- Added loading spinner for ugcOpened state
- Updated styles for the loading spinner

chore(utils): add functions to clear and save ugcLoadedOnce data

This commit adds two new functions to the localForage utility module. The `clearAuthData` function clears the authentication data using the `deviceAuth.clear()` method. The `saveUgcLoadedOnce` function saves the `ugcLoadedOnce` boolean value using the `deviceAuth.setItem()` method. These functions provide convenient ways to manage and manipulate the ugcLoadedOnce data in the application.

chore: Remove unused import and refactor syncUgc method

- Removed the unused import for `syncUgcSuccess` action in `ugc.service.ts`
- Refactored the `syncUgc` method to simplify the logic and improve readability

chore: Update auth and ugc effects

- Updated import statements in `auth.effects.ts` to use the new function name `clearAuthData()` instead of `removeAuth()`.
- Updated import statements in `ugc.effects.ts` to remove unused functions `updateUgcPois()` and `updateUgcTracks()`.
- Added a new effect in `ugc.effects.ts` to set the flag for UGC loaded once when syncing is successful.
- Renamed the action from `closeUgc` to `setUgcLoaded` in the new effect.
