### PR TITLE
chore: Remove unused code in AuthEffects oc:5027

### DIFF
--- a/projects/wm-core/src/localization/i18n/de.ts
+++ b/projects/wm-core/src/localization/i18n/de.ts
@@ -148,4 +148,8 @@ export const wmDE = {
     '<span class="orange">Stufe 2: Abschnitte teilweise in großer Höhe (Höhe zwischen {{orange}} und {{red}} Metern)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Stufe 3: in großer Höhe (Höhe über {{red}} Metern)</span>',
+  'Un utente è già stato registrato con questa email.': 'Ein Benutzer ist bereits mit dieser E-Mail registriert.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'Die eingegebene E-Mail ist nicht korrekt. Bitte versuchen Sie es erneut.',
+  'La password inserita non è corretta. Per favore, riprova.': 'Das eingegebene Passwort ist nicht korrekt. Bitte versuchen Sie es erneut.',
+  'Errore': 'Fehler',
 };

--- a/projects/wm-core/src/localization/i18n/en.ts
+++ b/projects/wm-core/src/localization/i18n/en.ts
@@ -153,4 +153,8 @@ export const wmEN = {
     '<span class="orange">Level 2: sections partially in high altitude (altitude between {{orange}} meters and {{red}} meters)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Level 3: in high altitude (altitude above {{red}} meters)</span>',
+  'Un utente è già stato registrato con questa email.': 'A user has already been registered with this email.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'The email entered is incorrect. Please try again.',
+  'La password inserita non è corretta. Per favore, riprova.': 'The password entered is incorrect. Please try again.',
+  'Errore': 'Error',
 };

--- a/projects/wm-core/src/localization/i18n/es.ts
+++ b/projects/wm-core/src/localization/i18n/es.ts
@@ -144,4 +144,8 @@ export const wmES = {
     '<span class="orange">Nivel 2: tramos parcialmente en alta altitud (altitud entre {{orange}} metros y {{red}} metros)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Nivel 3: en alta altitud (altitud superior a {{red}} metros)</span>',
+  'Un utente è già stato registrato con questa email.': 'Un usuario ya está registrado con esta dirección de correo electrónico.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'El correo electrónico introducido no es correcto. Por favor, inténtalo de nuevo.',
+  'La password inserita non è corretta. Per favore, riprova.': 'La contraseña introducida no es correcta. Por favor, inténtalo de nuevo.',
+  'Errore': 'Error',
 };

--- a/projects/wm-core/src/localization/i18n/fr.ts
+++ b/projects/wm-core/src/localization/i18n/fr.ts
@@ -147,4 +147,8 @@ export const wmFR = {
     '<span class="orange">Niveau 2: sections partiellement en altitude (altitude comprise entre {{orange}} mètres et {{red}} mètres)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Niveau 3: sections en altitude (altitude supérieure à {{red}} mètres)</span>',
+  'Un utente è già stato registrato con questa email.': 'Un utilisateur a déjà été enregistré avec cet email.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'L\'email saisie est incorrecte. Veuillez réessayer.',
+  'La password inserita non è corretta. Per favore, riprova.': 'Le mot de passe saisi est incorrect. Veuillez réessayer.',
+  'Errore': 'Erreur',
 };

--- a/projects/wm-core/src/localization/i18n/it.ts
+++ b/projects/wm-core/src/localization/i18n/it.ts
@@ -153,4 +153,8 @@ export const wmIT = {
     '<span class="orange">Livello 2: tratti parzialmente in alta quota (quota compresa tra {{orange}} metri e {{red}} metri)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>',
+  'Un utente è già stato registrato con questa email.': 'Un utente è già stato registrato con questa email.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'L\'email inserita non è corretta. Per favore, riprova.',
+  'La password inserita non è corretta. Per favore, riprova.': 'La password inserita non è corretta. Per favore, riprova.',
+  'Errore': 'Errore',
 };

--- a/projects/wm-core/src/localization/i18n/pr.ts
+++ b/projects/wm-core/src/localization/i18n/pr.ts
@@ -145,4 +145,8 @@ export const wmPR = {
     '<span class="orange">Nível 2: seções parcialmente em alta altitude (altitude entre {{orange}} metros e {{red}} metros)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Nível 3: seções em alta altitude (altitude superior a {{red}} metros)</span>',
+  'Un utente è già stato registrato con questa email.': 'Um usuário já foi registrado com este e-mail.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'O e-mail inserido está incorreto. Por favor, tente novamente.',
+  'La password inserita non è corretta. Per favore, riprova.': 'A senha inserida está incorreta. Por favor, tente novamente.',
+  'Errore': 'Erro',
 };

--- a/projects/wm-core/src/localization/i18n/sq.ts
+++ b/projects/wm-core/src/localization/i18n/sq.ts
@@ -152,4 +152,8 @@ export const wmSQ = {
     '<span class="orange">Niveli 2: seksione që nuk preken nga lartësia e madhe (lartësia midis {{orange}} metra dhe {{red}} metra)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Niveli 3: seksione që preken nga lartësia e madhe (lartësia më e madhe se {{red}} metra)</span>',
+  'Un utente è già stato registrato con questa email.': 'Një përdorues është tashmë regjistruar me këtë email.',
+  'L\'email inserita non è corretta. Per favore, riprova.': 'Email-i që keni futur nuk është e saktë. Ju lutem provoni përsëri.',
+  'La password inserita non è corretta. Per favore, riprova.': 'Fjalëkalimi që keni futur nuk është i saktë. Ju lutem provoni përsëri.',
+  'Errore': 'Gabim',
 };

--- a/projects/wm-core/src/store/auth/auth.effects.ts
+++ b/projects/wm-core/src/store/auth/auth.effects.ts
@@ -111,9 +111,10 @@ export class AuthEffects {
           AuthActions.loadSignUpsFailure,
           AuthActions.loadAuthsFailure,
         ),
-        filter(r => r != null && r.error.error.error != 'Unauthorized'),
+        filter(r => r != null && r.error?.error?.error != 'Unauthorized'),
         switchMap(e => {
-          return this._createErrorAlert(this._langSvc.instant(e.error.error));
+          const errorMessage = e.error?.error?.error ?? 'Errore';
+          return this._createErrorAlert(this._langSvc.instant(errorMessage));
         }),
         switchMap(alert => {
           alert.present();
@@ -160,7 +161,6 @@ export class AuthEffects {
   ) {}
 
   private _createErrorAlert(error: string): Promise<HTMLIonAlertElement> {
-    return null;
     return this._alertCtrl.create({
       mode: 'ios',
       header: this._langSvc.instant('Ops!'),


### PR DESCRIPTION
The `_createErrorAlert` method was returning `null`, which is unnecessary. This commit removes the unused code and returns a promise to create an alert using `_alertCtrl.create()`.
