### PR TITLE
chore: Update search-bar component styles and form width oc:5143

### DIFF
--- a/projects/wm-core/src/search-bar/search-bar.component.scss
+++ b/projects/wm-core/src/search-bar/search-bar.component.scss
@@ -13,7 +13,7 @@ wm-searchbar {
       border-left: 1px solid var(--wm-color-grey);
       padding: 7px 2px 7px 11px;
     }
-    form{
+    form {
       width: 100%;
     }
   }

--- a/projects/wm-core/src/search-bar/search-bar.component.scss
+++ b/projects/wm-core/src/search-bar/search-bar.component.scss
@@ -13,6 +13,9 @@ wm-searchbar {
       border-left: 1px solid var(--wm-color-grey);
       padding: 7px 2px 7px 11px;
     }
+    form{
+      width: 100%;
+    }
   }
   z-index: 400;
 

--- a/projects/wm-core/src/search-bar/search-bar.component.ts
+++ b/projects/wm-core/src/search-bar/search-bar.component.ts
@@ -13,7 +13,6 @@ import {FormBuilder, FormGroup, FormControl} from '@angular/forms';
 import {Store} from '@ngrx/store';
 import {debounceTime, filter} from 'rxjs/operators';
 import {inputTyped} from '@wm-core/store/user-activity/user-activity.action';
-import {merge} from 'rxjs';
 
 interface SearchForm {
   search: FormControl<string>;


### PR DESCRIPTION
- Updated the search-bar component's SCSS file to include a new style for the form element, setting its width to 100%.
- Removed an unused import statement in the search-bar component's TypeScript file.
