### PR TITLE
chore: update layers view oc: 5201

### DIFF
--- a/projects/wm-core/src/box/poi-box/poi-box.component.html
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.html
@@ -4,6 +4,10 @@
       <wm-img [src]="img.thumbnail" size="225x100"></wm-img>
     </div>
     <div class="wm-box-name">{{properties.name|wmtrans}}</div>
+    <ion-label *ngIf="properties.distanceFromCurrentLocation">
+      {{"Distanza da te" | wmtrans}}
+      <span>{{properties.distanceFromCurrentLocation|distance:'auto':0}}</span>
+    </ion-label>
     <ng-container *ngIf="properties.updatedAt as updatedAt">
       <wm-updated-at [updatedAt]="updatedAt"></wm-updated-at>
     </ng-container>

--- a/projects/wm-core/src/box/poi-box/poi-box.component.scss
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.scss
@@ -8,7 +8,7 @@ wm-poi-box {
   ion-card {
     overflow: hidden;
     width: 90%;
-    max-height: 210px;
+    max-height: 250px;
     border-radius: 15px;
     padding: 10px;
     margin: auto;
@@ -22,6 +22,14 @@ wm-poi-box {
       background-position: center;
       background-repeat: no-repeat;
       background-size: cover;
+    }
+    ion-label {
+      color: var(--wm-color-darkgrey);
+      height: var(--wm-font-sm);
+      font-size: var(--wm-font-sm);
+      span {
+        font-weight: var(--wm-font-weight-bold);
+      }
     }
     .wm-box-taxonomies {
       position: absolute;

--- a/projects/wm-core/src/box/poi-box/poi-box.component.ts
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.ts
@@ -1,11 +1,8 @@
-import {ChangeDetectionStrategy, Component, ViewEncapsulation, EventEmitter, Input, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+
 import {BaseBoxComponent} from '../box';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
-
-interface PoiBoxFeature extends WmFeature<Point> {
-  distanceFromCurrentLocation?: number;
-}
 
 @Component({
   selector: 'wm-poi-box',
@@ -14,7 +11,4 @@ interface PoiBoxFeature extends WmFeature<Point> {
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class PoiBoxComponent extends BaseBoxComponent<PoiBoxFeature> {
-  @Input() data: PoiBoxFeature;
-  @Output() clickEVT: EventEmitter<void> = new EventEmitter<void>();
-}
+export class PoiBoxComponent extends BaseBoxComponent<WmFeature<Point>> {}

--- a/projects/wm-core/src/box/poi-box/poi-box.component.ts
+++ b/projects/wm-core/src/box/poi-box/poi-box.component.ts
@@ -1,8 +1,11 @@
-import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-
+import {ChangeDetectionStrategy, Component, ViewEncapsulation, EventEmitter, Input, Output} from '@angular/core';
 import {BaseBoxComponent} from '../box';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
+
+interface PoiBoxFeature extends WmFeature<Point> {
+  distanceFromCurrentLocation?: number;
+}
 
 @Component({
   selector: 'wm-poi-box',
@@ -11,4 +14,7 @@ import {Point} from 'geojson';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class PoiBoxComponent extends BaseBoxComponent<WmFeature<Point>> {}
+export class PoiBoxComponent extends BaseBoxComponent<PoiBoxFeature> {
+  @Input() data: PoiBoxFeature;
+  @Output() clickEVT: EventEmitter<void> = new EventEmitter<void>();
+}

--- a/projects/wm-core/src/filters/status-filter/status-filter.component.ts
+++ b/projects/wm-core/src/filters/status-filter/status-filter.component.ts
@@ -65,6 +65,8 @@ export class StatusFilterComponent {
 
   resetFilters(): void {
     this._store.dispatch(goToHome());
+    //TODO: inserire la chiusura del dettaglio in goToHome; lo faccio dopo aver modificato
+    // la logica degli stati del map details
     this._store.dispatch(setMapDetailsStatus({status: 'none'}));
     this.resetFiltersEVT.emit();
   }

--- a/projects/wm-core/src/filters/status-filter/status-filter.component.ts
+++ b/projects/wm-core/src/filters/status-filter/status-filter.component.ts
@@ -11,8 +11,10 @@ import {poiFilters} from '@wm-core/store/features/ec/ec.selector';
 import {Filter} from '@wm-core/types/config';
 import {Observable} from 'rxjs';
 import {
+  goToHome,
   resetTrackFilters,
   setLayer,
+  setMapDetailsStatus,
   togglePoiFilter,
   toggleTrackFilter,
 } from '@wm-core/store/user-activity/user-activity.action';
@@ -62,6 +64,8 @@ export class StatusFilterComponent {
   }
 
   resetFilters(): void {
+    this._store.dispatch(goToHome());
+    this._store.dispatch(setMapDetailsStatus({status: 'none'}));
     this.resetFiltersEVT.emit();
   }
 }

--- a/projects/wm-core/src/home/home-result/home-result.component.ts
+++ b/projects/wm-core/src/home/home-result/home-result.component.ts
@@ -62,7 +62,23 @@ export class WmHomeResultComponent implements OnDestroy {
   );
   ectracks$ = this._store.select(tracks);
   lastFilterType$ = this._store.select(lastFilterType);
-  pois$: Observable<WmFeature<Point>[]> = this._store.select(pois);
+  pois$: Observable<WmFeature<Point>[]> = this._store.select(pois).pipe(
+    switchMap(pois =>
+      pois.length ? combineLatest([
+        ...pois.map(poi =>
+          this._geolocationSvc.getDistanceFromCurrentLocation(poi.geometry?.coordinates).pipe(
+            map(distance => ({
+              ...poi,
+              properties: {
+                ...poi.properties,
+                distanceFromCurrentLocation: distance
+              }
+            }))
+          )
+        )
+      ]) : of([])
+    )
+  );
   showResultType$: BehaviorSubject<string> = new BehaviorSubject<string>('tracks');
   showTracks$ = this._store.select(showTracks);
   tracks$: Observable<IHIT[]>;

--- a/projects/wm-core/src/home/home.component.html
+++ b/projects/wm-core/src/home/home.component.html
@@ -26,7 +26,7 @@
       (ugcBoxEvt)="setUgc()"
     ></wm-home-landing>
     <ng-container *ngIf="showResult$|async">
-      <wm-status-filter (resetFiltersEVT)="goToHome()"></wm-status-filter>
+      <wm-status-filter></wm-status-filter>
       <wm-home-ugc *ngIf="(ugcOpened$|async);else layerView"></wm-home-ugc>
       <ng-template #layerView>
         <wm-home-layer></wm-home-layer>

--- a/projects/wm-core/src/home/home.component.ts
+++ b/projects/wm-core/src/home/home.component.ts
@@ -112,10 +112,6 @@ export class WmHomeComponent implements AfterContentInit {
     this._store.dispatch(loadEcPois());
   }
 
-  goToHome(): void {
-    this._store.dispatch(goToHome());
-  }
-
   openExternalUrl(url: string): void {
     window.open(url);
   }

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -31,7 +31,7 @@ import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {set} from 'ol/transform';
 
 export const key = 'userActivity';
-export type mapDetailsStatus = 'open' | 'onlyTitle' | 'none' | 'background' | 'toggle';
+export type mapDetailsStatus = 'open' | 'onlyTitle' | 'none' | 'background' | 'toggle' | 'full';
 export interface UserActivityState {
   ugcOpened: boolean;
   mapDetailsStatus: mapDetailsStatus;

--- a/projects/wm-core/src/tab-description/tab-description.component.ts
+++ b/projects/wm-core/src/tab-description/tab-description.component.ts
@@ -60,8 +60,8 @@ export class WmTabDescriptionComponent {
 
   private _checkIfContentIsTruncated() {
     const interval = setInterval(() => {
-      const element = this.descriptionElement.nativeElement;
-      const scrollHeight = element.scrollHeight;
+      const element = this.descriptionElement?.nativeElement;
+      const scrollHeight = element?.scrollHeight;
       if (scrollHeight && scrollHeight > 0) {
         clearInterval(interval);
         const lineHeight = parseInt(window.getComputedStyle(element).lineHeight);


### PR DESCRIPTION
chore: Update status-filter.component.ts and home.component.html

- Added dispatch to goToHome() in resetFilters() method of StatusFilterComponent
- Added dispatch to setMapDetailsStatus({status: 'none'}) in resetFilters() method of StatusFilterComponent
- Removed (resetFiltersEVT)="goToHome()" event binding from wm-status-filter component in home.component.html

chore: Update tab-description.component.ts

- Refactor code to handle null values for descriptionElement and scrollHeight variables.

chore(user-activity): add 'full' option to mapDetailsStatus

This commit adds the 'full' option to the mapDetailsStatus type in the UserActivityState interface of the user-activity.reducer.ts file. This allows for more flexibility in handling the map details status.

chore: Update poi-box component and home-result component

- Increased the max-height of ion-card in poi-box.component.scss to 250px
- Added an ion-label in poi-box.component.html to display the distance from the current location
- Modified pois$ observable in home-result.component.ts to include the distanceFromCurrentLocation property for each point of interest (poi)
