### PR TITLE
chore(home): add close popup functionality with button oc: 4786

### DIFF
--- a/projects/wm-core/src/home/home.component.html
+++ b/projects/wm-core/src/home/home.component.html
@@ -13,6 +13,16 @@
   >
   </wm-searchbar>
   <ng-container *ngIf="(popup$|async) as popup; else mainContent">
+    <ion-row class="ion-justify-content-end">
+      <ion-col size="auto">
+        <ion-chip
+          [outline]="true"
+          (click)="closePopup()"
+        >
+          {{ 'Torna alla home' | wmtrans }}
+        </ion-chip>
+      </ion-col>
+    </ion-row>
     <wm-inner-component-html [html]="popup.html" [enableDismiss]="false"></wm-inner-component-html>
   </ng-container>
   <ng-template #mainContent>

--- a/projects/wm-core/src/home/home.component.ts
+++ b/projects/wm-core/src/home/home.component.ts
@@ -116,6 +116,11 @@ export class WmHomeComponent implements AfterContentInit {
     this._store.dispatch(goToHome());
   }
 
+  closePopup(): void {
+    this.popup$.next(null);
+    this.goToHome();
+  }
+
   openExternalUrl(url: string): void {
     window.open(url);
   }


### PR DESCRIPTION
Added a button to the popup that allows users to return to the home screen. The button is styled as an ion-chip and triggers the `closePopup` method, which dismisses the popup and navigates back to the home content.