### PR TITLE
chore: update layers view oc: 5203

### DIFF
--- a/projects/wm-core/src/filters/status-filter/status-filter.component.scss
+++ b/projects/wm-core/src/filters/status-filter/status-filter.component.scss
@@ -12,9 +12,9 @@ wm-status-filter {
     max-height: 200px;
     overflow: auto;
     .wm-status-filter-icn {
-      height: 55%;
+      height: 17px;
       * {
-        height: 180%;
+        height: 100%;
       }
     }
     ion-chip {
@@ -24,14 +24,10 @@ wm-status-filter {
 
       display: flex;
       flex-direction: row;
-      flex-wrap: wrap;
       justify-content: space-between;
-      align-content: stretch;
-      align-items: stretch;
       ion-label {
         order: 0;
         flex: 1 1 auto;
-        align-self: stretch;
       }
       ion-icon,
       i {

--- a/projects/wm-core/src/filters/status-filter/status-filter.component.ts
+++ b/projects/wm-core/src/filters/status-filter/status-filter.component.ts
@@ -65,9 +65,6 @@ export class StatusFilterComponent {
 
   resetFilters(): void {
     this._store.dispatch(goToHome());
-    //TODO: inserire la chiusura del dettaglio in goToHome; lo faccio dopo aver modificato
-    // la logica degli stati del map details
-    this._store.dispatch(setMapDetailsStatus({status: 'none'}));
     this.resetFiltersEVT.emit();
   }
 }

--- a/projects/wm-core/src/home/home-result/home-result.component.ts
+++ b/projects/wm-core/src/home/home-result/home-result.component.ts
@@ -64,7 +64,7 @@ export class WmHomeResultComponent implements OnDestroy {
   lastFilterType$ = this._store.select(lastFilterType);
   pois$: Observable<WmFeature<Point>[]> = this._store.select(pois).pipe(
     switchMap(pois =>
-      pois.length ? combineLatest([
+      pois?.length ? combineLatest([
         ...pois.map(poi =>
           this._geolocationSvc.getDistanceFromCurrentLocation(poi.geometry?.coordinates).pipe(
             map(distance => ({
@@ -104,7 +104,7 @@ export class WmHomeResultComponent implements OnDestroy {
         return ectracks;
       }),
       switchMap(tracks =>
-        tracks.length
+        tracks?.length
           ? combineLatest(
               tracks.map(track =>
                 this._geolocationSvc

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -101,3 +101,5 @@ export const wmMapHitMapChangeFeatureById = createAction(
   '[User Activity] hit map change feature by id',
   props<{id: number}>(),
 );
+
+export const backOfMapDetails = createAction('[User Activity] back of map details');

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -60,13 +60,7 @@ export class UserActivityEffects {
           this._urlHandlerSvc.updateURL({ugc_poi: undefined});
           return;
         }
-        this._urlHandlerSvc.updateURL({
-          track: undefined,
-          ugc_track: undefined,
-          ugc_poi: undefined,
-          poi: undefined,
-          layer: undefined
-        });
+        this._urlHandlerSvc.resetURL();
         return setMapDetailsStatus({status: 'background'});
       }),
       filter(action => !!action)

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -31,7 +31,7 @@ import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {set} from 'ol/transform';
 
 export const key = 'userActivity';
-export type mapDetailsStatus = 'open' | 'onlyTitle' | 'none' | 'background' | 'toggle' | 'full';
+export type mapDetailsStatus = 'open' | 'onlyTitle' | 'background' | 'full';
 export interface UserActivityState {
   ugcOpened: boolean;
   mapDetailsStatus: mapDetailsStatus;
@@ -58,7 +58,7 @@ export interface UserAcitivityRootState {
 
 const initialState: UserActivityState = {
   ugcOpened: false,
-  mapDetailsStatus: 'none',
+  mapDetailsStatus: 'background',
   downloadsOpened: false,
   inputTyped: null,
   filterTracks: [],

--- a/projects/wm-core/src/track-related-poi/track-related-poi.component.ts
+++ b/projects/wm-core/src/track-related-poi/track-related-poi.component.ts
@@ -37,7 +37,7 @@ export class TrackRelatedPoiComponent {
   isExpanded$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   pois$: Observable<WmFeature<Point>[]> = this._store.select(currentEcRelatedPois).pipe(
     switchMap(pois =>
-      pois.length ? combineLatest([
+      pois?.length ? combineLatest([
         ...pois.map(poi =>
           this._geolocationSvc.getDistanceFromCurrentLocation(poi.geometry?.coordinates).pipe(
             map(distance => ({


### PR DESCRIPTION
chore: Update status-filter.component.ts and home.component.html

- Added dispatch to goToHome() in resetFilters() method of StatusFilterComponent
- Added dispatch to setMapDetailsStatus({status: 'none'}) in resetFilters() method of StatusFilterComponent
- Removed (resetFiltersEVT)="goToHome()" event binding from wm-status-filter component in home.component.html

chore: Update tab-description.component.ts

- Refactor code to handle null values for descriptionElement and scrollHeight variables.

chore(user-activity): add 'full' option to mapDetailsStatus

This commit adds the 'full' option to the mapDetailsStatus type in the UserActivityState interface of the user-activity.reducer.ts file. This allows for more flexibility in handling the map details status.

chore: Update poi-box component and home-result component

- Increased the max-height of ion-card in poi-box.component.scss to 250px
- Added an ion-label in poi-box.component.html to display the distance from the current location
- Modified pois$ observable in home-result.component.ts to include the distanceFromCurrentLocation property for each point of interest (poi)
