### PR TITLE
chore(user-activity): add function to extract filter taxonomies oc: 5210

### DIFF
--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -129,10 +129,15 @@ export const userActivityReducer = createReducer(
   }),
   on(setLayer, (state, {layer}) => {
     let poisSelectedFilterIdentifiers = state.poisSelectedFilterIdentifiers ?? [];
-    const filterTaxonomiesPreviousLayer = extractFilterTaxonomies(state.layer);
-    const filterTaxonomies = extractFilterTaxonomies(layer);
+    let filterTaxonomies = [];
 
-    if (filterTaxonomies) {
+    if (layer == null) {
+      const filterTaxonomiesPreviousLayer = extractFilterTaxonomies(state.layer) ?? [];
+      poisSelectedFilterIdentifiers = poisSelectedFilterIdentifiers.filter(
+        i => !filterTaxonomiesPreviousLayer.includes(i)
+      );
+    } else {
+      filterTaxonomies = extractFilterTaxonomies(layer);
       poisSelectedFilterIdentifiers = (state.poisSelectedFilterIdentifiers ?? []).filter(
         i => i.indexOf('poi_') < 0 && i.indexOf('where_') < 0,
       );
@@ -142,11 +147,6 @@ export const userActivityReducer = createReducer(
           ...poisSelectedFilterIdentifiers,
           ...(filterTaxonomies ?? []),
         ]),
-      );
-    }
-    if (layer == null && filterTaxonomiesPreviousLayer) {
-      poisSelectedFilterIdentifiers = poisSelectedFilterIdentifiers.filter(
-        i => !filterTaxonomiesPreviousLayer.includes(i)
       );
     }
 


### PR DESCRIPTION
This commit adds a new function called `extractFilterTaxonomies` to the user-activity.reducer.ts file. This function is used to extract filter taxonomies from a given layer object. It filters out any taxonomies with null identifiers and maps them into an array of strings. The extracted filter taxonomies are then used in the setLayer reducer to update the poisSelectedFilterIdentifiers state based on the selected layer's taxonomies. Additionally, when a layer is set to null, the previous layer's filter taxonomies are removed from the poisSelectedFilterIdentifiers state.

Co-authored-by: Z
