### PR TITLE
chore(poi-types-badges): add component for displaying badges of POI types oc:5275

### DIFF
--- a/projects/wm-core/src/poi-types-badges/poi-types-badges.component.ts
+++ b/projects/wm-core/src/poi-types-badges/poi-types-badges.component.ts
@@ -1,0 +1,69 @@
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+
+@Component({
+  selector: 'wm-poi-types-badges',
+  template: `
+    <ng-container *ngIf="poiTypes as poiTypes">
+      <div *ngFor="let poiType of poiTypes">
+        <ng-container *ngIf="poiType.icon">
+          <div [innerHTML]="sanitize(poiType.icon)"></div>
+        </ng-container>
+        <span>{{poiType.name | wmtrans}}</span>
+      </div>
+    </ng-container>
+  `,
+  styles: [
+    `
+      wm-poi-types-badges {
+        position: relative;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: var(--wm-feature-details-margin);
+
+        > div {
+          display: flex;
+          flex-direction: row;
+          border: 1px solid var(--wm-color-medium);
+          border-radius: 24px;
+          padding: 4px 8px;
+          color: var(--wm-color-medium);
+          align-items: center;
+
+          div {
+            display: flex;
+          }
+
+          svg {
+            width: 20px;
+            height: 20px;
+            margin-right: 8px;
+
+            circle {
+              fill: var(--wm-color-medium);
+            }
+          }
+
+          span {
+            color: var(--wm-color-medium);
+            font-size: 14px;
+            font-weight: 600;
+          }
+        }
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class PoiTypesBadgesComponent {
+  @Input() poiTypes: any;
+
+  constructor(private _sanitizer: DomSanitizer) {}
+
+  sanitize(html: string) {
+    return this._sanitizer.bypassSecurityTrustHtml(html);
+  }
+}

--- a/projects/wm-core/src/store/features/ec/ec.selector.ts
+++ b/projects/wm-core/src/store/features/ec/ec.selector.ts
@@ -210,8 +210,27 @@ export const currentPoiProperties = createSelector(
     if (JSON.stringify(currentEcPoiProperties) === JSON.stringify({related: false})) {
       currentEcPoiProperties = null;
     }
-    const res = currentEcPoiProperties ?? currentEcRelatedPoiProperties ?? null;
-    return res;
+    let res = currentEcPoiProperties ?? currentEcRelatedPoiProperties ?? null;
+    //TODO: remove this arcoded info
+    if (res) {
+      return {
+        ...res,
+        info: `
+          <h2>Orari ed info</h2>
+          <p>Punti d'Informazione Turistica del Comune di Pietrasanta</p>
+          <p><strong>Orari di apertura:</strong></p>
+          <p>martedì – mercoledì – giovedì ore 10/12.30<br>
+          venerdì – sabato – domenica ore 10/12.30 e 15.30/18;<br>
+          lunedì chiuso</p>
+          <p><strong>Telefono:</strong><br>
+          0584283375</p>
+          <p><strong>Email:</strong><br>
+          infocentro@comune.pietrasanta.lu.it</p>
+        `,
+      };
+    }
+
+    return null;
   },
 );
 

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -70,6 +70,7 @@ import {WmHomeHitMapComponent} from './home/home-hitmap/home-hitmap.component';
 import {MetaComponent} from './meta/meta.component';
 import {GetDirectionsComponent} from './get-directions/get-directions.component';
 import {TravelModeComponent} from './travel-mode/travel-mode.component';
+import {PoiTypesBadgesComponent} from './poi-types-badges/poi-types-badges.component';
 export const declarations = [
   WmTabDetailComponent,
   WmTabDescriptionComponent,
@@ -110,6 +111,7 @@ export const declarations = [
   MetaComponent,
   GetDirectionsComponent,
   TravelModeComponent,
+  PoiTypesBadgesComponent,
 ];
 const modules = [
   WmSharedModule,


### PR DESCRIPTION
This commit adds a new component called PoiTypesBadgesComponent, which is responsible for displaying badges of different POI types. The component takes an input of poiTypes and dynamically generates the badges based on the provided data. Each badge consists of an icon (if available) and the name of the POI type.

The component also includes styling to ensure proper layout and visual representation of the badges. It uses flexbox to arrange the badges in a row with a small gap between them. Each badge has a border, padding, and color defined to make it visually distinct.

Additionally, this commit includes some minor updates to other files:
- ec.selector.ts: Adds temporary arcoded info to currentPoiProperties selector.
- wm-core.module.ts: Imports and declares PoiTypesBadgesComponent in the module.

These changes aim to enhance the user interface by providing a clear visual representation of different POI types through badges.
