### PR TITLE
chore: Add WmRelatedPoisNavigatorComponent oc:5289

### DIFF
--- a/projects/wm-core/src/releted-pois-navigator/related-pois-navigator.component.ts
+++ b/projects/wm-core/src/releted-pois-navigator/related-pois-navigator.component.ts
@@ -1,13 +1,12 @@
 import {Component, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import {Store} from '@ngrx/store';
-import { UrlHandlerService } from '@wm-core/services/url-handler.service';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {
   currentRelatedPoiIndex,
   currentRelatedPoisCount,
   nextRelatedPoiId,
   prevRelatedPoiId,
 } from '@wm-core/store/features/ec/ec.selector';
-import { setCurrentRelatedPoi } from '@wm-core/store/user-activity/user-activity.action';
 import {filter, map, take} from 'rxjs/operators';
 
 @Component({

--- a/projects/wm-core/src/releted-pois-navigator/related-pois-navigator.component.ts
+++ b/projects/wm-core/src/releted-pois-navigator/related-pois-navigator.component.ts
@@ -1,0 +1,96 @@
+import {Component, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
+import {Store} from '@ngrx/store';
+import { UrlHandlerService } from '@wm-core/services/url-handler.service';
+import {
+  currentRelatedPoiIndex,
+  currentRelatedPoisCount,
+  nextRelatedPoiId,
+  prevRelatedPoiId,
+} from '@wm-core/store/features/ec/ec.selector';
+import { setCurrentRelatedPoi } from '@wm-core/store/user-activity/user-activity.action';
+import {filter, map, take} from 'rxjs/operators';
+
+@Component({
+  selector: 'wm-related-pois-navigator',
+  template: `
+    <ng-container *ngIf="currentRelatedPoisCount$|async as currentRelatedPoisCount">
+      <ng-container *ngIf="currentRelatedPoiIndex$|async as currentRelatedPoiIndex">
+        <ng-container *ngIf="currentRelatedPoisCount > 1">
+          <ion-button
+            shape="round"
+            slot="icon-only"
+            color="light"
+            (click)="poiPrev()"
+            [class.disabled]="currentRelatedPoiIndex == 1"
+          >
+            <ion-icon name="arrow-back-outline"></ion-icon>
+          </ion-button>
+          <span>
+            {{currentRelatedPoiIndex}} di {{currentRelatedPoisCount}}
+          </span>
+          <ion-button
+            shape="round"
+            slot="icon-only"
+            color="light"
+            (click)="poiNext()"
+            [class.disabled]="currentRelatedPoiIndex == currentRelatedPoisCount"
+          >
+            <ion-icon name="arrow-forward-outline"></ion-icon>
+          </ion-button>
+        </ng-container>
+      </ng-container>
+    </ng-container>
+  `,
+  styles: [`
+    wm-related-pois-navigator {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+
+      ion-button {
+        height: 28px;
+        width: 28px;
+        --padding-start: 0;
+        --padding-end: 0;
+        --box-shadow: none;
+
+        &.disabled {
+          opacity: 0;
+          pointer-events: none;
+        }
+      }
+
+      span {
+        font-size: var(--wm-font-sm);
+        font-weight: 400;
+      }
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class WmRelatedPoisNavigatorComponent {
+  currentRelatedPoisCount$ = this._store.select(currentRelatedPoisCount);
+  currentRelatedPoiIndex$ = this._store.select(currentRelatedPoiIndex).pipe(filter(index => index != null), map(index => index+1));
+  nextRelatedPoiId$ = this._store.select(nextRelatedPoiId);
+  prevRelatedPoiId$ = this._store.select(prevRelatedPoiId);
+
+  constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {}
+
+  poiNext(): void {
+    this.nextRelatedPoiId$.pipe(take(1)).subscribe(id => {
+      if(id != null) {
+        this._urlHandlerSvc.updateURL({ec_related_poi: id});
+      }
+    });
+  }
+
+  poiPrev(): void {
+    this.prevRelatedPoiId$.pipe(take(1)).subscribe(id => {
+      if(id != null) {
+        this._urlHandlerSvc.updateURL({ec_related_poi: id});
+      }
+    });
+  }
+}

--- a/projects/wm-core/src/store/features/ec/ec.selector.ts
+++ b/projects/wm-core/src/store/features/ec/ec.selector.ts
@@ -237,3 +237,39 @@ export const currentPoiProperties = createSelector(
 export const layerFeaturesCount = createSelector(confMAPLayers, allEcpoiFeatures, ecTracks, (confMAPLayers, allEcpoiFeatures, ecTracks) => {
   return calculateLayerFeaturesCount(confMAPLayers, allEcpoiFeatures, ecTracks);
 });
+
+export const currentRelatedPoiIndex = createSelector(
+  currentEcRelatedPois,
+  currentEcRelatedPoiId,
+  (relatedPois, relatedPoiId) => {
+    if (relatedPois != null) {
+      return relatedPois.findIndex((p: WmFeature<Point>) => +p?.properties?.id === +relatedPoiId);
+    }
+    return null;
+  },
+);
+
+export const currentRelatedPoisCount = createSelector(
+  currentEcRelatedPois,
+  currentEcRelatedPois => {
+    return currentEcRelatedPois?.length ?? 0;
+  },
+);
+
+export const nextRelatedPoiId = createSelector(
+  currentEcRelatedPois,
+  currentEcRelatedPoiId,
+  (relatedPois, relatedPoiId) => {
+    const index = relatedPois.findIndex((p: WmFeature<Point>) => +p?.properties?.id === +relatedPoiId);
+    return relatedPois[index + 1]?.properties?.id ?? null;
+  },
+);
+
+export const prevRelatedPoiId = createSelector(
+  currentEcRelatedPois,
+  currentEcRelatedPoiId,
+  (relatedPois, relatedPoiId) => {
+    const index = relatedPois.findIndex((p: WmFeature<Point>) => +p?.properties?.id === +relatedPoiId);
+    return relatedPois[index - 1]?.properties?.id ?? null;
+  },
+);

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -71,6 +71,7 @@ import {MetaComponent} from './meta/meta.component';
 import {GetDirectionsComponent} from './get-directions/get-directions.component';
 import {TravelModeComponent} from './travel-mode/travel-mode.component';
 import {PoiTypesBadgesComponent} from './poi-types-badges/poi-types-badges.component';
+import {WmRelatedPoisNavigatorComponent} from './releted-pois-navigator/related-pois-navigator.component';
 export const declarations = [
   WmTabDetailComponent,
   WmTabDescriptionComponent,
@@ -112,6 +113,7 @@ export const declarations = [
   GetDirectionsComponent,
   TravelModeComponent,
   PoiTypesBadgesComponent,
+  WmRelatedPoisNavigatorComponent,
 ];
 const modules = [
   WmSharedModule,


### PR DESCRIPTION
This commit adds the WmRelatedPoisNavigatorComponent to the wm-core module. The component provides navigation buttons for related points of interest (POIs) and displays the current index and count of related POIs. It also updates the URL when navigating to the next or previous related POI.

The commit also includes changes to the ec.selector file, adding selectors for retrieving the current related POI index, count, and IDs of the next and previous related POIs.

Additionally, a new file named related-pois-navigator.component.ts is added, which contains the implementation of the WmRelatedPoisNavigatorComponent.
