### PR TITLE
chore(image-detail): add image detail component oc: 5298

### DIFF
--- a/projects/wm-core/src/image-detail/image-detail.component.html
+++ b/projects/wm-core/src/image-detail/image-detail.component.html
@@ -1,7 +1,7 @@
-<ng-container *ngIf="(currentImageGallery$ | async) as imageGallery">
-  <ng-container *ngIf="(currentImageGalleryIndex$|async) as currentIndex">
+<ng-container *ngIf="(currentImageGallery$ | async) as currentImageGallery">
+  <ng-container *ngIf="(currentImageGalleryIndex$|async) as currentImageGalleryIndex">
     <ion-slides #gallery class="gallery" [options]="slideOptions" (ionSlideTouchEnd)="updateIdx()">
-      <ion-slide *ngFor="let image of imageGallery;" pager="true">
+      <ion-slide *ngFor="let image of currentImageGallery;" pager="true">
         <wm-img [src]="image.url"></wm-img>
         <div
           class="image-caption"
@@ -9,22 +9,22 @@
         >{{image.caption|wmtrans}}</div>
       </ion-slide>
     </ion-slides>
-    <ng-container *ngIf="imageGallery.length > 1">
+    <ng-container *ngIf="currentImageGallery.length > 1">
       <div class="footer">
         <ion-button
           (click)="prev()"
-          [class.disabled]="currentIndex == 1"
+          [class.disabled]="currentImageGalleryIndex == 1"
           size="small"
           color="light"
         >
           <ion-icon name="arrow-back"></ion-icon>
         </ion-button>
         <div class="image-counter">
-          {{currentIndex}} di {{imageGallery.length}}
+          {{currentImageGalleryIndex}} di {{currentImageGallery.length}}
         </div>
         <ion-button
           (click)="next()"
-          [class.disabled]="currentIndex == imageGallery.length"
+          [class.disabled]="currentImageGalleryIndex == currentImageGallery.length"
           size="small"
           color="light"
         >

--- a/projects/wm-core/src/image-detail/image-detail.component.html
+++ b/projects/wm-core/src/image-detail/image-detail.component.html
@@ -1,0 +1,36 @@
+<ng-container *ngIf="(currentImageGallery$ | async) as imageGallery">
+  <ng-container *ngIf="(currentImageGalleryIndex$|async) as currentIndex">
+    <ion-slides #gallery class="gallery" [options]="slideOptions" (ionSlideTouchEnd)="updateIdx()">
+      <ion-slide *ngFor="let image of imageGallery;" pager="true">
+        <wm-img [src]="image.url"></wm-img>
+        <div
+          class="image-caption"
+          *ngIf="image.caption"
+        >{{image.caption|wmtrans}}</div>
+      </ion-slide>
+    </ion-slides>
+    <ng-container *ngIf="imageGallery.length > 1">
+      <div class="footer">
+        <ion-button
+          (click)="prev()"
+          [class.disabled]="currentIndex == 1"
+          size="small"
+          color="light"
+        >
+          <ion-icon name="arrow-back"></ion-icon>
+        </ion-button>
+        <div class="image-counter">
+          {{currentIndex}} di {{imageGallery.length}}
+        </div>
+        <ion-button
+          (click)="next()"
+          [class.disabled]="currentIndex == imageGallery.length"
+          size="small"
+          color="light"
+        >
+          <ion-icon name="arrow-forward"></ion-icon>
+        </ion-button>
+      </div>
+    </ng-container>
+  </ng-container>
+</ng-container>

--- a/projects/wm-core/src/image-detail/image-detail.component.scss
+++ b/projects/wm-core/src/image-detail/image-detail.component.scss
@@ -1,0 +1,48 @@
+wm-image-detail {
+  --footer-height: 55px;
+
+  .gallery {
+    height: calc(100% - var(--footer-height));
+    ion-slide {
+      width: 100%;
+      background-color: white;
+      display: flex;
+      flex-direction: column;
+      padding: 16px;
+      wm-img {
+        width: -webkit-fill-available;
+        transition: all 1s;
+        img {
+          border-radius: 16px;
+        }
+      }
+      .image-caption {
+        margin-top: 16px;
+        font-size: var(--wm-font-size-base);
+      }
+    }
+  }
+
+  .footer {
+    display: flex;
+    height: var(--footer-height);
+    justify-content: space-between;
+    align-items: center;
+    > * {
+      margin: 0 16px;
+    }
+    ion-button {
+      width: 32px;
+      height: 32px;
+      --border-radius: 50%;
+      --padding-start: 0;
+      --padding-end: 0;
+      --box-shadow: none;
+      border-radius: 50%;
+      &.disabled {
+        opacity: 0;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/projects/wm-core/src/image-detail/image-detail.component.ts
+++ b/projects/wm-core/src/image-detail/image-detail.component.ts
@@ -34,13 +34,14 @@ export class ImageDetailComponent implements AfterViewInit{
 
   ngAfterViewInit(): void {
     this.currentImageGalleryIndex$.pipe(take(1)).subscribe(index => {
-      this.slider.slideTo(index);
+      this.slider.slideTo(index - 1);
     });
   }
 
-  async updateIdx(): Promise<void> {
-    const currentIdx = await this.slider.getActiveIndex();
-    this._urlHandlerSvc.updateURL({gallery_index: currentIdx});
+  updateIdx(): void {
+    from(this.slider.getActiveIndex()).pipe(take(1)).subscribe(async (currentIdx) => {
+      this._urlHandlerSvc.updateURL({gallery_index: currentIdx});
+    });
   }
 
   prev(): void {

--- a/projects/wm-core/src/image-detail/image-detail.component.ts
+++ b/projects/wm-core/src/image-detail/image-detail.component.ts
@@ -1,0 +1,59 @@
+import {AfterViewInit, ChangeDetectionStrategy, Component, ViewChild, ViewEncapsulation} from "@angular/core";
+import {beforeInit, setTransition, setTranslate} from "@wm-core/image-gallery/utils";
+import {IonSlides} from "@ionic/angular";
+import {Store} from "@ngrx/store";
+import {UrlHandlerService} from "@wm-core/services/url-handler.service";
+import {currentEcImageGallery, currentEcImageGalleryIndex} from "@wm-core/store/features/ec/ec.selector";
+import {from, Observable} from "rxjs";
+import {map, take} from "rxjs/operators";
+
+@Component({
+  selector: 'wm-image-detail',
+  templateUrl: './image-detail.component.html',
+  styleUrls: ['./image-detail.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ImageDetailComponent implements AfterViewInit{
+  @ViewChild('gallery') slider: IonSlides;
+
+  currentImageGallery$: Observable<any[]> = this._store.select(currentEcImageGallery);
+  currentImageGalleryIndex$: Observable<number> = this._store.select(currentEcImageGalleryIndex).pipe(
+    map(index => index + 1)
+  );
+
+  slideOptions = {
+    on: {
+      beforeInit,
+      setTranslate,
+      setTransition,
+    },
+  };
+
+  constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {}
+
+  ngAfterViewInit(): void {
+    this.currentImageGalleryIndex$.pipe(take(1)).subscribe(index => {
+      this.slider.slideTo(index);
+    });
+  }
+
+  async updateIdx(): Promise<void> {
+    const currentIdx = await this.slider.getActiveIndex();
+    this._urlHandlerSvc.updateURL({gallery_index: currentIdx});
+  }
+
+  prev(): void {
+    from(this.slider.slidePrev()).pipe(take(1)).subscribe(async () => {
+      const currentIdx = await this.slider.getActiveIndex();
+      this._urlHandlerSvc.updateURL({gallery_index: currentIdx});
+    });
+  }
+
+  next(): void {
+    from(this.slider.slideNext()).pipe(take(1)).subscribe(async () => {
+      const activeIndex = await this.slider.getActiveIndex();
+      this._urlHandlerSvc.updateURL({gallery_index: activeIndex});
+    });
+  }
+}

--- a/projects/wm-core/src/image-gallery/image-gallery.component.ts
+++ b/projects/wm-core/src/image-gallery/image-gallery.component.ts
@@ -11,6 +11,7 @@ import {ModalImageComponent} from '@wm-core/modal-image/modal-image.component';
 import {confIsMobile} from '@wm-core/store/conf/conf.selector';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+import {DeviceService} from '@wm-core/services/device.service';
 @Component({
   selector: 'wm-image-gallery',
   templateUrl: './image-gallery.component.html',
@@ -49,6 +50,7 @@ export class ImageGalleryComponent {
     private _modalCtrl: ModalController,
     private _store: Store,
     private _urlHandlerSvc: UrlHandlerService,
+    private _deviceSvc: DeviceService
   ) {}
 
   next(): void {
@@ -61,10 +63,11 @@ export class ImageGalleryComponent {
 
   async showPhoto(idx) {
     this._urlHandlerSvc.updateURL({gallery_index: idx});
-    //TODO: open modal only on desktop
-    const modal = await this._modalCtrl.create({
-      component: ModalImageComponent
-    });
-    modal.present();
+    if (!this._deviceSvc.isMobile) {
+      const modal = await this._modalCtrl.create({
+        component: ModalImageComponent
+      });
+      modal.present();
+    }
   }
 }

--- a/projects/wm-core/src/image-gallery/image-gallery.component.ts
+++ b/projects/wm-core/src/image-gallery/image-gallery.component.ts
@@ -10,7 +10,7 @@ import {Store} from '@ngrx/store';
 import {ModalImageComponent} from '@wm-core/modal-image/modal-image.component';
 import {confIsMobile} from '@wm-core/store/conf/conf.selector';
 import {BehaviorSubject, Observable} from 'rxjs';
-
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 @Component({
   selector: 'wm-image-gallery',
   templateUrl: './image-gallery.component.html',
@@ -45,7 +45,11 @@ export class ImageGalleryComponent {
     spaceBetween: 10,
   });
 
-  constructor(private _modalCtrl: ModalController, private _store: Store) {}
+  constructor(
+    private _modalCtrl: ModalController,
+    private _store: Store,
+    private _urlHandlerSvc: UrlHandlerService,
+  ) {}
 
   next(): void {
     this.slider.slideNext();
@@ -56,9 +60,10 @@ export class ImageGalleryComponent {
   }
 
   async showPhoto(idx) {
+    this._urlHandlerSvc.updateURL({gallery_index: idx});
+    //TODO: open modal only on desktop
     const modal = await this._modalCtrl.create({
-      component: ModalImageComponent,
-      componentProps: {idx, imageGallery: this.imageGallery$.value},
+      component: ModalImageComponent
     });
     modal.present();
   }

--- a/projects/wm-core/src/modal-image/modal-image.component.html
+++ b/projects/wm-core/src/modal-image/modal-image.component.html
@@ -4,31 +4,5 @@
       <i class="icon-outline-close"></i>
     </ion-fab-button>
   </ion-fab>
-  <ion-slides #gallery class="gallery" [options]="slideOptions" (ionSlideTouchEnd)="updateIdx()">
-    <ion-slide *ngFor="let image of imageGallery; let idx = index" pager="true">
-      <wm-img [src]="image.url" class="webmapp-pagepoi-info-body-photo"></wm-img>
-    </ion-slide>
-  </ion-slides>
-  <ng-container *ngIf="imageGallery.length > 1">
-    <ion-fab
-      vertical="bottom"
-      horizontal="start"
-      class="webmapp-pagepoi-top"
-      *ngIf="(idx$|async) > 0"
-    >
-      <ion-fab-button (click)="prev()" size="small" class="webmapp-pagepoi-btntop">
-        <i class="icon-outline-arrow-left"></i>
-      </ion-fab-button>
-    </ion-fab>
-    <ion-fab
-      vertical="bottom"
-      horizontal="end"
-      class="webmapp-pagepoi-top"
-      *ngIf="((idx$|async)+1)< imageGallery.length"
-    >
-      <ion-fab-button (click)="next()" size="small" class="webmapp-pagepoi-btntop">
-        <i class="icon-outline-arrow-right"></i>
-      </ion-fab-button>
-    </ion-fab>
-  </ng-container>
+  <wm-image-detail></wm-image-detail>
 </ion-content>

--- a/projects/wm-core/src/modal-image/modal-image.component.scss
+++ b/projects/wm-core/src/modal-image/modal-image.component.scss
@@ -6,21 +6,6 @@ wm-modal-image {
   margin-bottom: env(safe-area-inset-bottom);
   height: calc(100% - constant(safe-area-inset-top));
   height: calc(100% - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-
-  .gallery {
-    height: 100%;
-    ion-slide {
-      width: 100%;
-      wm-img {
-        height: -webkit-fill-available;
-        width: -webkit-fill-available;
-        transition: all 1s;
-        img {
-          object-fit: contain;
-        }
-      }
-    }
-  }
 }
 ion-modal {
   --border-radius: 16px;
@@ -29,9 +14,6 @@ ion-modal {
 
 ion-modal::part(backdrop) {
   opacity: 1;
-}
-ion-slide {
-  background-color: white;
 }
 ion-fab-button {
   --background: white;

--- a/projects/wm-core/src/modal-image/modal-image.component.ts
+++ b/projects/wm-core/src/modal-image/modal-image.component.ts
@@ -1,15 +1,10 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  Input,
-  ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {BehaviorSubject} from 'rxjs';
-import {IonSlides, ModalController} from '@ionic/angular';
-import {beforeInit, setTransition, setTranslate} from '../image-gallery/utils';
-
+import {ModalController} from '@ionic/angular';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 @Component({
   selector: 'wm-modal-image',
   templateUrl: './modal-image.component.html',
@@ -17,50 +12,11 @@ import {beforeInit, setTransition, setTranslate} from '../image-gallery/utils';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ModalImageComponent implements AfterViewInit {
-  @Input() set idx(val) {
-    this.idx$.next(val);
-  }
-
-  @Input() imageGallery: any;
-  @ViewChild('gallery') slider: IonSlides;
-
-  getActiveIndex$: Promise<number>;
-  idx$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
-  slideOptions = {
-    on: {
-      beforeInit,
-      setTranslate,
-      setTransition,
-    },
-  };
-
-  constructor(private _modalCtrl: ModalController) {}
-
-  ngAfterViewInit(): void {
-    this.slider.slideTo(this.idx$.value);
-    this.getActiveIndex$ = Promise.resolve(this.slider.getActiveIndex());
-    this.slider.ionSlideDidChange;
-  }
+export class ModalImageComponent {
+  constructor(private _modalCtrl: ModalController, private _urlHandlerSvc: UrlHandlerService) {}
 
   closeModal(): void {
+    this._urlHandlerSvc.updateURL({gallery_index: null});
     this._modalCtrl.dismiss();
-  }
-
-  next(): void {
-    let currentIdx = this.idx$.value;
-    this.idx$.next(currentIdx + 1);
-    this.slider.slideTo(currentIdx + 1);
-  }
-
-  prev(): void {
-    let currentIdx = this.idx$.value;
-    this.idx$.next(currentIdx - 1);
-    this.slider.slideTo(currentIdx - 1);
-  }
-
-  async updateIdx(): Promise<void> {
-    const currentIdx = await this.slider.getActiveIndex();
-    this.idx$.next(currentIdx);
   }
 }

--- a/projects/wm-core/src/services/url-handler.service.ts
+++ b/projects/wm-core/src/services/url-handler.service.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {ActivatedRoute, Router} from '@angular/router';
 import {
+  currentEcImageGalleryIndex,
   currentEcLayerId,
   currentEcPoiId,
   currentEcRelatedPoiId,
@@ -27,6 +28,7 @@ export class UrlHandlerService {
     slug: undefined,
     layer: undefined,
     filter: undefined,
+    gallery_index: undefined,
   };
 
   private _ugcOpened$ = this._store.select(ugcOpened);
@@ -65,6 +67,9 @@ export class UrlHandlerService {
       );
       this._store.dispatch(currentUgcTrackId({currentUgcTrackId: params.ugc_track ?? null}));
       this._store.dispatch(currentUgcPoiId({currentUgcPoiId: params.ugc_poi ?? null}));
+      this._store.dispatch(
+        currentEcImageGalleryIndex({currentEcImageGalleryIndex: params.gallery_index ?? null}),
+      );
       this._checkIfUgcIsOpened(params);
       this._currentQueryParams$.next(params);
     });

--- a/projects/wm-core/src/services/url-handler.service.ts
+++ b/projects/wm-core/src/services/url-handler.service.ts
@@ -68,7 +68,9 @@ export class UrlHandlerService {
       this._store.dispatch(currentUgcTrackId({currentUgcTrackId: params.ugc_track ?? null}));
       this._store.dispatch(currentUgcPoiId({currentUgcPoiId: params.ugc_poi ?? null}));
       this._store.dispatch(
-        currentEcImageGalleryIndex({currentEcImageGalleryIndex: params.gallery_index ?? null}),
+        currentEcImageGalleryIndex({
+          currentEcImageGalleryIndex: params.gallery_index ? +params.gallery_index : null,
+        }),
       );
       this._checkIfUgcIsOpened(params);
       this._currentQueryParams$.next(params);

--- a/projects/wm-core/src/store/features/ec/ec.actions.ts
+++ b/projects/wm-core/src/store/features/ec/ec.actions.ts
@@ -59,3 +59,7 @@ export const loadCurrentEcPoiFailure = createAction(
   '[ec] Load Current EcPoi Failure',
   props<{error: any}>(),
 );
+export const currentEcImageGalleryIndex = createAction(
+  '[ec] Set current ec image gallery index',
+  props<{currentEcImageGalleryIndex: number | null}>(),
+);

--- a/projects/wm-core/src/store/features/ec/ec.reducer.ts
+++ b/projects/wm-core/src/store/features/ec/ec.reducer.ts
@@ -108,7 +108,7 @@ export const ecReducer = createReducer(
   on(currentEcImageGalleryIndex, (state, {currentEcImageGalleryIndex}) => {
     const newState: Ec = {
       ...state,
-      currentEcImageGalleryIndex: +currentEcImageGalleryIndex,
+      currentEcImageGalleryIndex: currentEcImageGalleryIndex,
     };
     return newState;
   }),

--- a/projects/wm-core/src/store/features/ec/ec.reducer.ts
+++ b/projects/wm-core/src/store/features/ec/ec.reducer.ts
@@ -11,6 +11,7 @@ import {
   currentEcRelatedPoiId,
   loadCurrentEcPoiSuccess,
   loadCurrentEcPoiFailure,
+  currentEcImageGalleryIndex,
 } from '@wm-core/store/features/ec/ec.actions';
 
 import {IHIT} from '@wm-core/types/elastic';
@@ -26,6 +27,7 @@ export interface Ec {
   currentEcPoiId?: string;
   currentEcPoi?: WmFeature<Point>;
   currentEcRelatedPoiId?: string;
+  currentEcImageGalleryIndex?: number;
 }
 export interface ApiRootState {
   [searchKey]: Ec;
@@ -100,6 +102,13 @@ export const ecReducer = createReducer(
     const newState: Ec = {
       ...state,
       currentEcPoi: null,
+    };
+    return newState;
+  }),
+  on(currentEcImageGalleryIndex, (state, {currentEcImageGalleryIndex}) => {
+    const newState: Ec = {
+      ...state,
+      currentEcImageGalleryIndex: +currentEcImageGalleryIndex,
     };
     return newState;
   }),

--- a/projects/wm-core/src/store/features/ec/ec.selector.ts
+++ b/projects/wm-core/src/store/features/ec/ec.selector.ts
@@ -273,3 +273,17 @@ export const prevRelatedPoiId = createSelector(
     return relatedPois[index - 1]?.properties?.id ?? null;
   },
 );
+
+export const currentEcImageGalleryIndex = createSelector(ec, (state: Ec) => state.currentEcImageGalleryIndex);
+
+export const currentEcImageGallery = createSelector(
+  currentEcRelatedPoiProperties,
+  currentEcTrackProperties,
+  currentEcPoiProperties,
+  (currentEcRelatedPoiProperties, currentEcTrackProperties, currentEcPoiProperties) => {
+    return currentEcRelatedPoiProperties?.image_gallery
+      ?? currentEcTrackProperties?.image_gallery
+      ?? currentEcPoiProperties?.image_gallery
+      ?? null;
+  },
+);

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -55,6 +55,10 @@ export class UserActivityEffects {
       ofType(backOfMapDetails),
       map(() => {
         const queryParams = this._urlHandlerSvc.getCurrentQueryParams();
+        if (queryParams.gallery_index != null) {
+          this._urlHandlerSvc.updateURL({gallery_index: undefined});
+          return;
+        }
         if (queryParams.ec_related_poi != null) {
           this._urlHandlerSvc.updateURL({ec_related_poi: undefined});
           return;

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -72,6 +72,7 @@ import {GetDirectionsComponent} from './get-directions/get-directions.component'
 import {TravelModeComponent} from './travel-mode/travel-mode.component';
 import {PoiTypesBadgesComponent} from './poi-types-badges/poi-types-badges.component';
 import {WmRelatedPoisNavigatorComponent} from './releted-pois-navigator/related-pois-navigator.component';
+import {ImageDetailComponent} from './image-detail/image-detail.component';
 export const declarations = [
   WmTabDetailComponent,
   WmTabDescriptionComponent,
@@ -114,6 +115,7 @@ export const declarations = [
   TravelModeComponent,
   PoiTypesBadgesComponent,
   WmRelatedPoisNavigatorComponent,
+  ImageDetailComponent,
 ];
 const modules = [
   WmSharedModule,


### PR DESCRIPTION
- Added HTML template for the image detail component
- Added SCSS styles for the image detail component
- Added TypeScript logic for the image detail component
- Imported and declared the ImageDetailComponent in wm-core.module.ts

chore(ec): add support for setting current ec image gallery index

This commit adds support for setting the current ec image gallery index in the URL handler service. It also includes actions, reducer logic, and selectors to handle this new feature.

chore: Update modal-image component

- Removed the ion-slides and related code for image gallery functionality
- Added wm-image-detail component to display image details
- Updated styles to remove gallery-related CSS rules

chore: Update image-gallery.component.ts

- Added import statement for UrlHandlerService
- Updated constructor to include UrlHandlerService dependency
- Added call to updateURL method of UrlHandlerService in showPhoto method
