### PR TITLE
fix: Add startWith operator in home-result and track-related-poi components oc:5333

### DIFF
--- a/projects/wm-core/src/home/home-result/home-result.component.ts
+++ b/projects/wm-core/src/home/home-result/home-result.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import {Store} from '@ngrx/store';
 import {BehaviorSubject, Observable, Subscription, combineLatest, from, of} from 'rxjs';
-import {map, startWith, switchMap, take} from 'rxjs/operators';
+import {map, startWith, switchMap} from 'rxjs/operators';
 import {ecTracksLoading, poisInitCount} from '@wm-core/store/features/ec/ec.selector';
 
 import {
@@ -67,6 +67,7 @@ export class WmHomeResultComponent implements OnDestroy {
       pois?.length ? combineLatest([
         ...pois.map(poi =>
           this._geolocationSvc.getDistanceFromCurrentLocation(poi.geometry?.coordinates).pipe(
+            startWith(null),
             map(distance => ({
               ...poi,
               properties: {
@@ -110,6 +111,7 @@ export class WmHomeResultComponent implements OnDestroy {
                 this._geolocationSvc
                   .getDistanceFromCurrentLocation(track.start)
                   .pipe(
+                    startWith(null),
                     map(distance => ({
                       ...track,
                       distanceFromCurrentLocation: distance,

--- a/projects/wm-core/src/track-related-poi/track-related-poi.component.ts
+++ b/projects/wm-core/src/track-related-poi/track-related-poi.component.ts
@@ -16,7 +16,7 @@ import {
 import {Observable, BehaviorSubject, combineLatest, of} from 'rxjs';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
-import {map, switchMap} from 'rxjs/operators';
+import {map, startWith, switchMap} from 'rxjs/operators';
 
 export const MAX_VISIBLE_POIS = 4;
 @Component({
@@ -40,6 +40,7 @@ export class TrackRelatedPoiComponent {
       pois?.length ? combineLatest([
         ...pois.map(poi =>
           this._geolocationSvc.getDistanceFromCurrentLocation(poi.geometry?.coordinates).pipe(
+            startWith(null),
             map(distance => ({
               ...poi,
               properties: {


### PR DESCRIPTION
The startWith operator was added to the getDistanceFromCurrentLocation method in both the home-result and track-related-poi components. This ensures that the distance calculation is triggered even when there is no initial value, improving the accuracy of the results.
