### PR TITLE
fix: currentEcPois on start oc:5334

### DIFF
--- a/projects/wm-core/src/store/features/ec/ec.reducer.ts
+++ b/projects/wm-core/src/store/features/ec/ec.reducer.ts
@@ -11,6 +11,7 @@ import {
   currentEcRelatedPoiId,
   loadCurrentEcPoiSuccess,
   loadCurrentEcPoiFailure,
+  loadEcPoisFailure,
 } from '@wm-core/store/features/ec/ec.actions';
 
 import {IHIT} from '@wm-core/types/elastic';
@@ -26,6 +27,7 @@ export interface Ec {
   currentEcPoiId?: string;
   currentEcPoi?: WmFeature<Point>;
   currentEcRelatedPoiId?: string;
+  ecPoisLoaded: boolean;
 }
 export interface ApiRootState {
   [searchKey]: Ec;
@@ -35,6 +37,7 @@ const initialConfState: Ec = {
   ecPoiFeatures: [],
   hits: [],
   ecTracksLoading: false,
+  ecPoisLoaded: false,
 };
 
 export const ecReducer = createReducer(
@@ -65,8 +68,15 @@ export const ecReducer = createReducer(
     const newState: Ec = {
       ...state,
       ecPoiFeatures,
+      ecPoisLoaded: true,
     };
     return newState;
+  }),
+  on(loadEcPoisFailure, state => {
+    return {
+      ...state,
+      ecPoisLoaded: true,
+    };
   }),
   on(loadCurrentEcTrackSuccess, (state, {ecTrack}) => {
     const newState: Ec = {

--- a/projects/wm-core/src/store/features/ec/ec.selector.ts
+++ b/projects/wm-core/src/store/features/ec/ec.selector.ts
@@ -214,3 +214,4 @@ export const currentPoiProperties = createSelector(
     return res;
   },
 );
+export const ecPoisLoaded = createSelector(ec, state => state.ecPoisLoaded);


### PR DESCRIPTION
chore: Update url-handler.service.ts and ec.reducer.ts

- Added import for Observable in url-handler.service.ts
- Added _ecPoisLoaded$ property in UrlHandlerService class
- Modified subscribe logic in UrlHandlerService to dispatch currentEcPoiId only when ecPoisLoaded is true
- Added ecPoisLoaded property in Ec interface and initialConfState in ec.reducer.ts
- Added loadEcPoisFailure action handler in ec.reducer.ts to set ecPoisLoaded to true on failure
- Added ecPoisLoaded selector in ec.selector.ts
