### PR TITLE
chore: Add features-in-viewport component oc: 5363

### DIFF
--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.html
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.html
@@ -1,0 +1,14 @@
+<ng-container *ngIf="featuresInViewport$ | async as featuresInViewport">
+  <ion-slides
+    [options]="sliderOptions"
+    [ngClass]="{'slide-in': featuresInViewport.length > 0}"
+    #slider
+  >
+    <ion-slide *ngFor="let feature of featuresInViewport">
+      <wm-search-box
+        [data]="feature"
+        (clickEVT)="setTrack(feature?.id)"
+      ></wm-search-box>
+    </ion-slide>
+  </ion-slides>
+</ng-container>

--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.scss
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.scss
@@ -1,6 +1,6 @@
 wm-features-in-viewport {
   position: absolute;
-  bottom: 16px;
+  bottom: 38px;
   left: 0;
   width: 100%;
 
@@ -9,6 +9,21 @@ wm-features-in-viewport {
       wm-search-box {
         width: 100%;
         margin: 0;
+        ion-card {
+          display: flex;
+          width: 100%;
+          max-height: 150px;
+          margin: 0;
+          .wm-box-taxonomies{
+            display: none;
+          }
+          ion-card-header{
+            padding-right: 0px;
+            ion-card-title{
+              margin: 5px 0px;
+            }
+          }
+        }
       }
     }
 

--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.scss
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.scss
@@ -1,0 +1,45 @@
+wm-features-in-viewport {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  width: 100%;
+
+  ion-slides {
+    ion-slide {
+      wm-search-box {
+        width: 100%;
+        margin: 0;
+      }
+    }
+
+    &.slide-in {
+      animation: slideIn 0.4s forwards;
+    }
+
+    &.slide-out {
+      animation: slideOut 0.4s forwards;
+    }
+
+    @keyframes slideIn {
+      from {
+        transform: translateY(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateY(0);
+        opacity: 1;
+      }
+    }
+
+    @keyframes slideOut {
+      from {
+        transform: translateY(0);
+        opacity: 1;
+      }
+      to {
+        transform: translateY(100%);
+        opacity: 0;
+      }
+    }
+  }
+}

--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.ts
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.ts
@@ -1,0 +1,29 @@
+import {Component, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+import {featuresInViewport} from '@wm-core/store/user-activity/user-activity.selector';
+import {Observable} from 'rxjs';
+
+@Component({
+  selector: 'wm-features-in-viewport',
+  templateUrl: './features-in-viewport.component.html',
+  styleUrls: ['./features-in-viewport.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class WmFeaturesInViewportComponent {
+  featuresInViewport$: Observable<any[]> = this._store.select(featuresInViewport);
+  sliderOptions: any = {
+    slidesPerView: 1.2,
+    spaceBetween: 16,
+    slidesOffsetBefore: 16,
+    slidesOffsetAfter: 16,
+    freeMode: true,
+  };
+
+  constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {}
+
+  setTrack(id: number): void {
+    this._urlHandlerSvc.setTrack(id);
+  }
+}

--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -1,7 +1,4 @@
-<div
-  class="webmapp-pageroute-map-container"
-  [class.show-bottom-features]="hasFeatureInViewport$|async"
->
+<div class="webmapp-pageroute-map-container">
   <wm-map
     #wmap
     [wmMapConf]="confMap$|async"

--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -1,4 +1,7 @@
-<div class="webmapp-pageroute-map-container">
+<div
+  class="webmapp-pageroute-map-container"
+  [class.show-bottom-features]="hasFeatureInViewport$|async"
+>
   <wm-map
     #wmap
     [wmMapConf]="confMap$|async"
@@ -27,8 +30,10 @@
     [wmMapLayerDataLayerUrls]="dataLayerUrls$|async"
     [wmMapLayerLayer]="currentLayer$|async"
     [wmMapLayerRefresh]="refreshLayer$|async"
+    [wmMapEnableFeaturesInViewport]="enableFeaturesInViewport$|async"
     [wmMapLayerDisableLayers]="wmMapEcTracksDisableLayer$|async"
     (colorSelectedFromLayerEVT)="trackColor$.next($event)"
+    (featuresInViewportEVT)="featuresInViewport($event)"
     wmMapPois
     [wmMapInputTyped]="apiSearchInputTyped$|async"
     [wmMapPoisPoi]="currentEcPoiId$|async"
@@ -93,4 +98,5 @@
     ></ion-progress-bar>
   </wm-map>
   <ng-content></ng-content>
+  <wm-features-in-viewport></wm-features-in-viewport>
 </div>

--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -27,7 +27,8 @@
     [wmMapLayerDataLayerUrls]="dataLayerUrls$|async"
     [wmMapLayerLayer]="currentLayer$|async"
     [wmMapLayerRefresh]="refreshLayer$|async"
-    [wmMapEnableFeaturesInViewport]="enableFeaturesInViewport$|async"
+    [wmMapLayerEnableFeaturesInViewport]="confOPTIONFEATURESINVIEWPORT$|async"
+    [wmMapLayerShowFeaturesInViewport]="showFeaturesInViewport$|async"
     [wmMapLayerDisableLayers]="wmMapEcTracksDisableLayer$|async"
     (colorSelectedFromLayerEVT)="trackColor$.next($event)"
     (featuresInViewportEVT)="featuresInViewport($event)"
@@ -95,5 +96,5 @@
     ></ion-progress-bar>
   </wm-map>
   <ng-content></ng-content>
-  <wm-features-in-viewport></wm-features-in-viewport>
+  <wm-features-in-viewport *ngIf="showFeaturesInViewport$|async"></wm-features-in-viewport>
 </div>

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -3,7 +3,6 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
-  Inject,
   OnDestroy,
   Output,
   ViewChild,
@@ -60,12 +59,10 @@ import {
   distinctUntilChanged,
   filter,
   map,
-  mergeAll,
   startWith,
   switchMap,
   take,
   tap,
-  withLatestFrom,
 } from 'rxjs/operators';
 import {
   confJIDOUPDATETIME,
@@ -78,13 +75,11 @@ import {
   chartHoverElements,
   drawTrackOpened,
   ecLayer,
-  enableFeaturesInViewport,
   inputTyped,
   loading,
   mapFilters,
   poiFilterIdentifiers,
   ugcOpened,
-  hasFeatureInViewport,
   wmMapHitMapChangeFeatureById,
 } from '@wm-core/store/user-activity/user-activity.selector';
 import {WmFeature} from '@wm-types/feature';
@@ -102,7 +97,7 @@ import {WmMapTrackRelatedPoisDirective} from '@map-core/directives';
 import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {WmMapComponent} from '@map-core/components';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
-import {poi, track} from '@wm-core/store/features/features.selector';
+import {enableFeaturesInViewport, poi, track} from '@wm-core/store/features/features.selector';
 import {FiltersComponent} from '@wm-core/filters/filters.component';
 import {ActivatedRoute} from '@angular/router';
 import {Actions, ofType} from '@ngrx/effects';
@@ -111,7 +106,7 @@ import {DeviceService} from '@wm-core/services/device.service';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
 import {EnvironmentService} from '@wm-core/services/environment.service';
-import { FeatureLike } from 'ol/Feature';
+import {FeatureLike} from 'ol/Feature';
 
 const initPadding = [10, 10, 10, 10];
 const initMenuOpened = true;
@@ -175,7 +170,6 @@ export class WmGeoboxMapComponent implements OnDestroy {
   enableFeaturesInViewport$: Observable<boolean> = this._store.select(enableFeaturesInViewport);
   geohubId$ = this._store.select(confGeohubId);
   graphhopperHost$: Observable<string> = of(this._environmentSvc.graphhopperHost);
-  hasFeatureInViewport$: Observable<boolean> = this._store.select(hasFeatureInViewport);
   isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));
   isMobile$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(this._deviceSvc.isMobile);
   langs$ = this._store.select(confLANGUAGES).pipe(

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -42,6 +42,7 @@ import {
   togglePoiFilter,
   toggleTrackFilter,
   updateTrackFilter,
+  wmMapFeaturesInViewport,
 } from '@wm-core/store/user-activity/user-activity.action';
 import {
   Filter,
@@ -77,11 +78,13 @@ import {
   chartHoverElements,
   drawTrackOpened,
   ecLayer,
+  enableFeaturesInViewport,
   inputTyped,
   loading,
   mapFilters,
   poiFilterIdentifiers,
   ugcOpened,
+  hasFeatureInViewport,
   wmMapHitMapChangeFeatureById,
 } from '@wm-core/store/user-activity/user-activity.selector';
 import {WmFeature} from '@wm-types/feature';
@@ -108,6 +111,7 @@ import {DeviceService} from '@wm-core/services/device.service';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
 import {EnvironmentService} from '@wm-core/services/environment.service';
+import { FeatureLike } from 'ol/Feature';
 
 const initPadding = [10, 10, 10, 10];
 const initMenuOpened = true;
@@ -168,8 +172,10 @@ export class WmGeoboxMapComponent implements OnDestroy {
   currentUgcPoiIDToMap$: Observable<number | string | null>;
   dataLayerUrls$: Observable<IDATALAYER>;
   drawTrackOpened$: Observable<boolean> = this._store.select(drawTrackOpened);
+  enableFeaturesInViewport$: Observable<boolean> = this._store.select(enableFeaturesInViewport);
   geohubId$ = this._store.select(confGeohubId);
   graphhopperHost$: Observable<string> = of(this._environmentSvc.graphhopperHost);
+  hasFeatureInViewport$: Observable<boolean> = this._store.select(hasFeatureInViewport);
   isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));
   isMobile$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(this._deviceSvc.isMobile);
   langs$ = this._store.select(confLANGUAGES).pipe(
@@ -346,6 +352,15 @@ export class WmGeoboxMapComponent implements OnDestroy {
       this.isLogged$.pipe(startWith(false)),
       this.toggleUgcDirective$.pipe(startWith(true)),
     ]).pipe(map(([isLogged, toggleUgcDirective]) => !(isLogged && toggleUgcDirective)));
+  }
+
+  featuresInViewport(features: FeatureLike[]): void {
+    const featureIds = features
+      .map(feature => feature.getProperties()?.id)
+      .filter(id => id != null);
+
+    this._store.dispatch(wmMapFeaturesInViewport({featureIds}));
+
   }
 
   ngOnDestroy(): void {

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -68,6 +68,7 @@ import {
   confJIDOUPDATETIME,
   confShowDrawTrack,
   confAUTHEnable,
+  confOPTIONFEATURESINVIEWPORT,
 } from '@wm-core/store/conf/conf.selector';
 import {currentCustomTrack as currentCustomTrackAction} from '@wm-core/store/features/ugc/ugc.actions';
 import {IDATALAYER} from '@map-core/types/layer';
@@ -97,7 +98,7 @@ import {WmMapTrackRelatedPoisDirective} from '@map-core/directives';
 import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {WmMapComponent} from '@map-core/components';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
-import {enableFeaturesInViewport, poi, track} from '@wm-core/store/features/features.selector';
+import {poi, showFeaturesInViewport, track} from '@wm-core/store/features/features.selector';
 import {FiltersComponent} from '@wm-core/filters/filters.component';
 import {ActivatedRoute} from '@angular/router';
 import {Actions, ofType} from '@ngrx/effects';
@@ -154,6 +155,9 @@ export class WmGeoboxMapComponent implements OnDestroy {
   confJIDOUPDATETIME$: Observable<any> = this._store.select(confJIDOUPDATETIME);
   confMap$: Observable<any> = this._store.select(confMAP);
   confOPTIONS$: Observable<IOPTIONS> = this._store.select(confOPTIONS);
+  confOPTIONFEATURESINVIEWPORT$: Observable<boolean> = this._store.select(
+    confOPTIONFEATURESINVIEWPORT,
+  );
   currentCustomTrack$: Observable<WmFeature<LineString>> = this._store.select(currentCustomTrack);
   currentEcPoiId$ = this._store.select(currentEcPoiId);
   currentLayer$ = this._store.select(ecLayer);
@@ -167,7 +171,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
   currentUgcPoiIDToMap$: Observable<number | string | null>;
   dataLayerUrls$: Observable<IDATALAYER>;
   drawTrackOpened$: Observable<boolean> = this._store.select(drawTrackOpened);
-  enableFeaturesInViewport$: Observable<boolean> = this._store.select(enableFeaturesInViewport);
+  showFeaturesInViewport$: Observable<boolean> = this._store.select(showFeaturesInViewport);
   geohubId$ = this._store.select(confGeohubId);
   graphhopperHost$: Observable<string> = of(this._environmentSvc.graphhopperHost);
   isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));

--- a/projects/wm-core/src/store/conf/conf.reducer.ts
+++ b/projects/wm-core/src/store/conf/conf.reducer.ts
@@ -121,7 +121,7 @@ const initialConfState: ICONF = {
     showShapefileDownload: false,
     showTravelMode: true, // TODO: set to false
     showGetDirections: true, // TODO: set to false
-    showFeatureInViewport: true, // TODO: set to false
+    enableFeatureInViewport: true, // TODO: set to false
   },
   THEME: {
     primary: '#3880ff',

--- a/projects/wm-core/src/store/conf/conf.reducer.ts
+++ b/projects/wm-core/src/store/conf/conf.reducer.ts
@@ -121,6 +121,7 @@ const initialConfState: ICONF = {
     showShapefileDownload: false,
     showTravelMode: true, // TODO: set to false
     showGetDirections: true, // TODO: set to false
+    showFeatureInViewport: true, // TODO: set to false
   },
   THEME: {
     primary: '#3880ff',

--- a/projects/wm-core/src/store/conf/conf.selector.ts
+++ b/projects/wm-core/src/store/conf/conf.selector.ts
@@ -140,6 +140,10 @@ export const confHOME = createSelector(confFeature, confFILTERS, (state, filters
 
   return state.HOME;
 });
+export const confOPTIONFEATURESINVIEWPORT = createSelector(
+  confOPTIONS,
+  state => state.enableFeatureInViewport,
+);
 
 const getLayers = (layersID: number[], layers: ILAYER[], tracks: IHIT[]): ILAYER[] => {
   return layers

--- a/projects/wm-core/src/store/features/ec/ec.actions.ts
+++ b/projects/wm-core/src/store/features/ec/ec.actions.ts
@@ -55,3 +55,7 @@ export const currentEcImageGalleryIndex = createAction(
   '[ec] Set current ec image gallery index',
   props<{currentEcImageGalleryIndex: number | null}>(),
 );
+export const currentEcImageGalleryIndex = createAction(
+  '[ec] Set current ec image gallery index',
+  props<{currentEcImageGalleryIndex: number | null}>(),
+);

--- a/projects/wm-core/src/store/features/ec/ec.actions.ts
+++ b/projects/wm-core/src/store/features/ec/ec.actions.ts
@@ -55,7 +55,3 @@ export const currentEcImageGalleryIndex = createAction(
   '[ec] Set current ec image gallery index',
   props<{currentEcImageGalleryIndex: number | null}>(),
 );
-export const currentEcImageGalleryIndex = createAction(
-  '[ec] Set current ec image gallery index',
-  props<{currentEcImageGalleryIndex: number | null}>(),
-);

--- a/projects/wm-core/src/store/features/ec/ec.reducer.ts
+++ b/projects/wm-core/src/store/features/ec/ec.reducer.ts
@@ -104,4 +104,11 @@ export const ecReducer = createReducer(
     };
     return newState;
   }),
+  on(currentEcImageGalleryIndex, (state, {currentEcImageGalleryIndex}) => {
+    const newState: Ec = {
+      ...state,
+      currentEcImageGalleryIndex: currentEcImageGalleryIndex,
+    };
+    return newState;
+  }),
 );

--- a/projects/wm-core/src/store/features/ec/ec.service.ts
+++ b/projects/wm-core/src/store/features/ec/ec.service.ts
@@ -118,6 +118,7 @@ export class EcService {
     inputTyped?: string;
     layer?: any;
     filterTracks?: Filter[];
+    trackIds?: number[];
   }): Promise<IRESPONSE> {
     let query = this._baseUrl;
 
@@ -127,6 +128,10 @@ export class EcService {
 
     if (options.layer && options.layer.id != null) {
       query += `&layer=${options.layer.id}`;
+    }
+
+    if (options.trackIds) {
+      query += `&ids=[${options.trackIds.join(',')}]`;
     }
 
     if (options.filterTracks != null && options.filterTracks.length > 0) {

--- a/projects/wm-core/src/store/features/features.selector.ts
+++ b/projects/wm-core/src/store/features/features.selector.ts
@@ -82,7 +82,7 @@ export const featureFirstCoordinates = createSelector(
   poiFirstCoordinates,
   (trackFirstCoordinates, poiFirstCoordinates) => trackFirstCoordinates ?? poiFirstCoordinates,
 );
-export const enableFeaturesInViewport = createSelector(
+export const showFeaturesInViewport = createSelector(
   featureOpened,
   ecLayer,
   (featureOpened, ecLayer) => {

--- a/projects/wm-core/src/store/features/features.selector.ts
+++ b/projects/wm-core/src/store/features/features.selector.ts
@@ -1,7 +1,7 @@
 import {createSelector} from '@ngrx/store';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
-import {ugcOpened} from '../user-activity/user-activity.selector';
+import {ecLayer, ugcOpened} from '../user-activity/user-activity.selector';
 import {
   countEcAll,
   countEcPois,
@@ -9,7 +9,6 @@ import {
   currentEcPoi,
   currentEcRelatedPoi,
   currentEcTrack,
-  ec,
   ecPois,
   ecTracks,
 } from './ec/ec.selector';
@@ -82,4 +81,11 @@ export const featureFirstCoordinates = createSelector(
   trackFirstCoordinates,
   poiFirstCoordinates,
   (trackFirstCoordinates, poiFirstCoordinates) => trackFirstCoordinates ?? poiFirstCoordinates,
+);
+export const enableFeaturesInViewport = createSelector(
+  featureOpened,
+  ecLayer,
+  (featureOpened, ecLayer) => {
+    return featureOpened == false && ecLayer == null;
+  },
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -4,6 +4,7 @@ import {WmFeature} from '@wm-types/feature';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {Point} from 'geojson';
 import {mapDetailsStatus} from './user-activity.reducer';
+import { IHIT } from '@wm-core/types/elastic';
 
 export const openUgc = createAction('[User Activity] Open User Generated Content');
 export const closeUgc = createAction('[User Activity] Close User Generated Content');
@@ -103,3 +104,7 @@ export const wmMapHitMapChangeFeatureById = createAction(
 );
 
 export const backOfMapDetails = createAction('[User Activity] back of map details');
+
+export const wmMapFeaturesInViewport = createAction('[User Activity] wm map features in viewport', props<{featureIds: number[]}>());
+export const wmMapFeaturesInViewportSuccess = createAction('[User Activity] wm map features in viewport success', props<{featuresInViewport: IHIT[]}>());
+export const wmMapFeaturesInViewportFailure = createAction('[User Activity] wm map features in viewport failure');

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -11,9 +11,6 @@ import {
   toggleTrackFilter,
   toggleTrackFilterByIdentifier,
   updateTrackFilter,
-  wmMapFeaturesInViewport,
-  wmMapFeaturesInViewportSuccess,
-  wmMapFeaturesInViewportFailure,
 } from './user-activity.action';
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
@@ -51,7 +48,7 @@ import {Filter} from '@wm-core/types/config';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {ModalController} from '@ionic/angular';
 import {ModalUgcTrackUploaderComponent} from '@wm-core/modal-ugc-track-uploader/modal-ugc-track-uploader.component';
-import { EcService } from '../features/ec/ec.service';
+import {EcService} from '@wm-core/store/features/ec/ec.service';
 
 @Injectable()
 export class UserActivityEffects {
@@ -199,25 +196,11 @@ export class UserActivityEffects {
       }),
     ),
   );
-  featuresInViewport$ = createEffect(() =>
-    this._actions$.pipe(
-      ofType(wmMapFeaturesInViewport),
-      switchMap(({featureIds}) => {
-        if (featureIds.length === 0) {
-          return of(null);
-        }
-        return this._ecService.getQuery({trackIds: featureIds});
-      }),
-      map((response) => wmMapFeaturesInViewportSuccess({featuresInViewport: response?.hits ?? []})),
-      catchError(() => of(wmMapFeaturesInViewportFailure())),
-    ),
-  );
 
   constructor(
     private _actions$: Actions,
     private _store: Store,
     private _urlHandlerSvc: UrlHandlerService,
     private _modalCtrl: ModalController,
-    private _ecService: EcService,
   ) {}
 }

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -25,10 +25,12 @@ import {
   closeDownloads,
   wmMapHitMapChangeFeatureById,
   setMapDetailsStatus,
+  wmMapFeaturesInViewportSuccess,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {set} from 'ol/transform';
+import { IHIT } from '@wm-core/types/elastic';
 
 export const key = 'userActivity';
 export type mapDetailsStatus = 'open' | 'onlyTitle' | 'background' | 'full';
@@ -50,6 +52,7 @@ export interface UserActivityState {
   chartHoverElements: WmSlopeChartHoverElements;
   currentEcPoiId?: any;
   wmMapHitMapChangeFeatureById?: number;
+  featuresInViewport: IHIT[];
 }
 
 export interface UserAcitivityRootState {
@@ -68,6 +71,7 @@ const initialState: UserActivityState = {
   loading: {pois: false, layer: false},
   chartHoverElements: null,
   wmMapHitMapChangeFeatureById: null,
+  featuresInViewport: [],
 };
 
 function extractFilterTaxonomies(layer) {
@@ -266,6 +270,14 @@ export const userActivityReducer = createReducer(
     const newState: UserActivityState = {
       ...state,
       wmMapHitMapChangeFeatureById: id,
+    };
+    return newState;
+  }),
+
+  on(wmMapFeaturesInViewportSuccess, (state, {featuresInViewport}) => {
+    const newState: UserActivityState = {
+      ...state,
+      featuresInViewport,
     };
     return newState;
   }),

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -3,6 +3,7 @@ import {currentCustomTrack} from '../features/ugc/ugc.selector';
 import {UserActivityState} from './user-activity.reducer';
 import {confFlowLineQuote} from '../conf/conf.selector';
 import {WmSlopeChartFlowLineQuote} from '@wm-types/slope-chart';
+import { featureOpened } from '../features/features.selector';
 
 export const userActivity = createFeatureSelector<UserActivityState>('user-activity');
 
@@ -157,3 +158,10 @@ export const flowLineQuoteText = createSelector(
     return flowLineQuote;
   },
 );
+
+export const featuresInViewport = createSelector(userActivity, state => state.featuresInViewport);
+export const hasFeatureInViewport = createSelector(featuresInViewport, featuresInViewport => featuresInViewport && featuresInViewport.length > 0);
+//TODO: modify enableFeaturesInViewport, use featureSelected and layerSelected
+export const enableFeaturesInViewport = createSelector(mapDetailsStatus, (mapDetailsStatus) => {
+  return !mapDetailsStatus || mapDetailsStatus === 'background';
+});

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -3,7 +3,6 @@ import {currentCustomTrack} from '../features/ugc/ugc.selector';
 import {UserActivityState} from './user-activity.reducer';
 import {confFlowLineQuote} from '../conf/conf.selector';
 import {WmSlopeChartFlowLineQuote} from '@wm-types/slope-chart';
-import { featureOpened } from '../features/features.selector';
 
 export const userActivity = createFeatureSelector<UserActivityState>('user-activity');
 
@@ -161,7 +160,3 @@ export const flowLineQuoteText = createSelector(
 
 export const featuresInViewport = createSelector(userActivity, state => state.featuresInViewport);
 export const hasFeatureInViewport = createSelector(featuresInViewport, featuresInViewport => featuresInViewport && featuresInViewport.length > 0);
-//TODO: modify enableFeaturesInViewport, use featureSelected and layerSelected
-export const enableFeaturesInViewport = createSelector(mapDetailsStatus, (mapDetailsStatus) => {
-  return !mapDetailsStatus || mapDetailsStatus === 'background';
-});

--- a/projects/wm-core/src/tab-description/tab-description.component.scss
+++ b/projects/wm-core/src/tab-description/tab-description.component.scss
@@ -4,6 +4,7 @@ wm-tab-description{
 
   .webmapp-pageroute-tabdescription-description {
     padding: 10px;
+    padding-bottom: 0;
     margin-bottom: 10px;
     color: var(--wm-feature-details-description-color);
     overflow: hidden;

--- a/projects/wm-core/src/types/config.ts
+++ b/projects/wm-core/src/types/config.ts
@@ -308,6 +308,7 @@ export interface IOPTIONS {
   downloadFullGemoetryRouteIndex: boolean;
   downloadRoutesInWebapp: boolean;
   download_track_enable?: boolean;
+  enableFeatureInViewport: boolean;
   enableTrackAdoption: boolean;
   forceDefaultFeatureColor: boolean;
   forceWelcomePagePopup: boolean;
@@ -345,7 +346,6 @@ export interface IOPTIONS {
   showEleMax: boolean;
   showEleMin: boolean;
   showEleTo: boolean;
-  showFeatureInViewport: boolean;
   showGeojsonDownload: boolean;
   showGetDirections?: boolean;
   showGpxDownload: boolean;

--- a/projects/wm-core/src/types/config.ts
+++ b/projects/wm-core/src/types/config.ts
@@ -345,6 +345,7 @@ export interface IOPTIONS {
   showEleMax: boolean;
   showEleMin: boolean;
   showEleTo: boolean;
+  showFeatureInViewport: boolean;
   showGeojsonDownload: boolean;
   showGetDirections?: boolean;
   showGpxDownload: boolean;

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -73,6 +73,7 @@ import {TravelModeComponent} from './travel-mode/travel-mode.component';
 import {PoiTypesBadgesComponent} from './poi-types-badges/poi-types-badges.component';
 import {WmRelatedPoisNavigatorComponent} from './releted-pois-navigator/related-pois-navigator.component';
 import {ImageDetailComponent} from './image-detail/image-detail.component';
+import {WmFeaturesInViewportComponent} from './features-in-viewport/features-in-viewport.component';
 import {WmDifficultyComponent} from './difficulty/difficulty.component';
 export const declarations = [
   WmTabDetailComponent,
@@ -117,6 +118,7 @@ export const declarations = [
   PoiTypesBadgesComponent,
   WmRelatedPoisNavigatorComponent,
   ImageDetailComponent,
+  WmFeaturesInViewportComponent,
   WmDifficultyComponent,
 ];
 const modules = [


### PR DESCRIPTION
This commit adds the features-in-viewport component, which displays a list of features in a slide show format. The component template and styles are also included.

chore: Update geobox-map.component.html and geobox-map.component.ts

- Added class "show-bottom-features" to the div element in geobox-map.component.html
- Added input property "enableFeaturesInViewport$" and event listener "featuresInViewport()" in geobox-map.component.ts

chore: Update user-activity actions and reducer

This commit updates the user-activity.actions.ts file by adding a new action called "wmMapFeaturesInViewport". It also updates the user-activity.reducer.ts file by adding a new case for this action, which sets the "featuresInViewport" property in the state. Additionally, it adds new selectors in the user-activity.selector.ts file to retrieve the features in viewport and check if there are any features in viewport. Finally, it adds a selector to enable features in viewport based on the map details status.

chore: Update user-activity.action.ts, user-activity.effects.ts, and user-activity.reducer.ts

- Add import for IHIT from '@wm-core/types/elastic'
- Modify wmMapFeaturesInViewport action to accept featureIds instead of features
- Add wmMapFeaturesInViewportSuccess and wmMapFeaturesInViewportFailure actions
- Implement featuresInViewport$ effect in user-activity.effects.ts to fetch features based on featureIds and handle success and failure cases
- Update UserActivityState interface in user-activity.reducer.ts to use IHIT type for featuresInViewport property
- Update the reducer logic for wmMapFeaturesInViewport action to set the featuresInViewport state with the response from the API call

chore: Update features-in-viewport component

- Replace TODO comment with wm-search-box component
- Add data binding and click event to wm-search-box
- Remove unnecessary CSS styles for .wm-features-in-viewport-feature
- Update constructor to include UrlHandlerService dependency
- Add setTrack method to handle click event in wm-search-box

chore: Update geobox-map.component.ts

- Import FeatureLike from 'ol/Feature'
- Modify featuresInViewport method to extract feature ids and dispatch wmMapFeaturesInViewport action with the extracted ids

chore(ec): add support for filtering by trackIds

This commit adds the ability to filter tracks in the EcService by their trackIds. The trackIds parameter is now accepted and used to construct the query string for filtering.