### PR TITLE
chore(environment): update share link logic oc:5401

### DIFF
--- a/projects/wm-core/src/services/environment.service.ts
+++ b/projects/wm-core/src/services/environment.service.ts
@@ -75,9 +75,14 @@ export class EnvironmentService {
 
   private _assignShareLink() {
     const host = Object.entries(this._environment.redirects).find(
-      ([key, val]) => val.appId === this._appId,
+      ([_, val]) => val.appId === this._appId && val.shardName === this._shardName,
     );
-    this._shareLink = host ? host[0] : `${this.appId}.app.webmapp.it`;
+    if(host){
+      this._shareLink = host[0];
+    } else {
+      const subdomain = this._shardName == 'geohub' ? 'app' : this._shardName;
+      this._shareLink = `${this._appId}.${subdomain}.webmapp.it`;
+    }
   }
 
   private _isOldShardName(shardName: string): boolean {


### PR DESCRIPTION
- Added condition to check for shardName in addition to appId when assigning the share link
- If host is found, set the share link to the corresponding key
- If host is not found, generate a new share link based on the appId and shardName
