### PR TITLE
🐛 fix(geobox-map): update reloadCustomTracks condition oc:5581

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -21,7 +21,7 @@
     wmMapCustomTracks
     [wmMapCustomTrackDrawTrack]="drawTrackOpened$|async"
     [wmMapCustomTrackDrawTrackHost]="graphhopperHost$|async"
-    [reloadCustomTracks]="reloadCustomTracks$|async"
+    [reloadCustomTracks]="(currentCustomTrack$|async) == null"
     (currentCustomTrack)="saveCurrentCustomTrack($event)"
     wmMapLayer
     [jidoUpdateTime]="confJIDOUPDATETIME$|async"

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -220,7 +220,6 @@ export class WmGeoboxMapComponent implements OnDestroy {
   poiIDs$: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
   pois$: Observable<WmFeature<Point>[]> = this._store.select(ecPois);
   refreshLayer$: Observable<any>;
-  reloadCustomTracks$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(null);
   resetSelectedOvelayFeatureEVT$ = new Subject<void>();
   resetSelectedPoi$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   resetSelectedUgcPoi$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
@@ -412,10 +411,6 @@ export class WmGeoboxMapComponent implements OnDestroy {
 
   resetMap(): void {
     this.mapCmp.resetView();
-  }
-
-  reloadCustomTrack(): void {
-    this._store.dispatch(currentCustomTrackAction({currentCustomTrack: null}));
   }
 
   removeActivityFilter(activity: string): void {}

--- a/projects/wm-core/src/slope-chart/slope-chart.component.scss
+++ b/projects/wm-core/src/slope-chart/slope-chart.component.scss
@@ -1,6 +1,5 @@
 wm-slope-chart {
   text-align: center;
-  width: 100%;
   margin: var(--wm-feature-details-margin);
   .webmapp-slopechart-canvas-container {
     margin: 0 auto;


### PR DESCRIPTION
- change reloadCustomTracks binding to check if currentCustomTrack$ is null
- remove unused reloadCustomTrack method and associated BehaviorSubject

💄 style(slope-chart): adjust slope chart styling

- remove unnecessary width property from wm-slope-chart selector
