### PR TITLE
chore(ec): ✨ add aggregation support for layer features count oc:5635

### DIFF
--- a/projects/wm-core/src/store/features/ec/ec.reducer.ts
+++ b/projects/wm-core/src/store/features/ec/ec.reducer.ts
@@ -13,7 +13,7 @@ import {
   currentEcImageGalleryIndex,
 } from '@wm-core/store/features/ec/ec.actions';
 
-import {IHIT} from '@wm-core/types/elastic';
+import {IHIT, IAggregations} from '@wm-core/types/elastic';
 import {LineString} from 'geojson';
 
 export const searchKey = 'search';
@@ -21,7 +21,7 @@ export interface Ec {
   ecPoiFeatures?: WmFeature<Point>[];
   hits?: IHIT[];
   ecTracksLoading: boolean;
-  aggregations?: any;
+  aggregations?: IAggregations;
   currentEcTrack?: WmFeature<LineString>;
   currentEcPoiId?: number;
   currentEcPoi?: WmFeature<Point>;

--- a/projects/wm-core/src/store/features/ec/ec.selector.ts
+++ b/projects/wm-core/src/store/features/ec/ec.selector.ts
@@ -41,6 +41,9 @@ export const statsApi = createSelector(aggregations, aggregations => {
     return res;
   }
 });
+export const aggregationBucketsLayers = createSelector(aggregations, aggregations => {
+  return aggregations?.layers?.count?.buckets ?? [];
+});
 export const ecTracksLoading = createSelector(ec, state => {
   return state.ecTracksLoading;
 });
@@ -215,8 +218,8 @@ export const currentPoiProperties = createSelector(
   },
 );
 
-export const layerFeaturesCount = createSelector(confMAPLayers, allEcpoiFeatures, ecTracks, (confMAPLayers, allEcpoiFeatures, ecTracks) => {
-  return calculateLayerFeaturesCount(confMAPLayers, allEcpoiFeatures, ecTracks);
+export const layerFeaturesCount = createSelector(confMAPLayers, allEcpoiFeatures, aggregationBucketsLayers, (confMAPLayers, allEcpoiFeatures, aggregationBucketsLayers) => {
+  return calculateLayerFeaturesCount(confMAPLayers, allEcpoiFeatures, aggregationBucketsLayers);
 });
 
 export const currentRelatedPoiIndex = createSelector(

--- a/projects/wm-core/src/store/features/ec/utils.ts
+++ b/projects/wm-core/src/store/features/ec/utils.ts
@@ -1,5 +1,5 @@
 import {ILAYER} from '@wm-core/types/config';
-import {IHIT} from '@wm-core/types/elastic';
+import {IBucket} from '@wm-core/types/elastic';
 import {LayerFeaturesCount, WmFeature} from '@wm-types/feature';
 import {Feature, Geometry, LineString, Point} from 'geojson';
 
@@ -60,10 +60,10 @@ export const filterFeaturesByInputTyped = (
   return filteredFeaturesByInputTyped;
 };
 
-export const calculateLayerFeaturesCount = (layers: ILAYER[], pois:WmFeature<Point>[], tracks: IHIT[]) => {
+export const calculateLayerFeaturesCount = (layers: ILAYER[], pois:WmFeature<Point>[], aggregationBucketsLayers: IBucket[]) => {
   const layerFeaturesCount: LayerFeaturesCount = {};
 
-  if(layers?.length > 0 && (pois?.length > 0 || tracks?.length > 0)) {
+  if(layers?.length > 0 && (pois?.length > 0 || aggregationBucketsLayers?.length > 0)) {
     layers.forEach(layer => {
       const layerId = layer.id;
       const layerTaxonomies = layer.taxonomy_themes;
@@ -82,12 +82,10 @@ export const calculateLayerFeaturesCount = (layers: ILAYER[], pois:WmFeature<Poi
         }
       });
 
-      tracks.forEach(track => {
-        if (track.layers.includes(+layerId)) {
-          layerFeaturesCount[layerId].tracks++;
-        }
-      });
-
+      const layerBucket = aggregationBucketsLayers.find(bucket => bucket.key == layerId);
+      if (layerBucket) {
+        layerFeaturesCount[layerId].tracks = layerBucket.doc_count;
+      }
     });
   }
 

--- a/projects/wm-core/src/types/elastic.ts
+++ b/projects/wm-core/src/types/elastic.ts
@@ -1,4 +1,3 @@
-
 export interface IELASTIC {
   [name: string]: any;
 }
@@ -20,7 +19,29 @@ export interface IHIT {
   distanceFromCurrentLocation?: number;
 }
 
+export interface IBucket {
+  key: string | number;
+  doc_count: number;
+}
+
+export interface ICount {
+  doc_count_error_upper_bound: number;
+  sum_other_doc_count: number;
+  buckets: IBucket[];
+}
+
+export interface IAggregationDetail {
+  doc_count: number;
+  count: ICount;
+}
+
+export interface IAggregations {
+  themes: IAggregationDetail;
+  activities: IAggregationDetail;
+  layers: IAggregationDetail;
+}
+
 export interface IRESPONSE {
-  aggregations:any;
+  aggregations: IAggregations;
   hits:IHIT[];
 }


### PR DESCRIPTION
Extended the existing functionality to incorporate aggregation buckets for calculating layer features count. The changes include:

- Updated the `Ec` interface to use `IAggregations` instead of `any` for aggregations.
- Introduced a new selector `aggregationBucketsLayers` to extract bucket data.
- Modified the `calculateLayerFeaturesCount` function to utilize aggregation buckets instead of tracks.
- Added new types `IBucket`, `ICount`, `IAggregationDetail`, and `IAggregations` for structured aggregation data handling.
- Updated `IRESPONSE` to use `IAggregations` type for aggregations.

These enhancements improve the accuracy and efficiency of layer features count calculation by leveraging aggregation data.
