### PR TITLE
refactor(home-result): ♻️ replace showResultType$ with homeResultTabSelected$ oc:5634

### DIFF
--- a/projects/wm-core/src/home/home-result/home-result.component.html
+++ b/projects/wm-core/src/home/home-result/home-result.component.html
@@ -23,7 +23,7 @@
 </ng-container>
 <ng-template #noDownload>
   <ng-container *ngIf="(countAll$|async)>0;">
-    <ion-segment [value]="showResultType$|async" (ionChange)="changeResultType($event)">
+    <ion-segment [value]="homeResultTabSelected$|async" (ionChange)="changeResultType($event)">
       <ng-container *ngIf="tracks$|async as tracks">
         <ion-segment-button value="tracks" *ngIf="tracks.length > 0 &&  showTracks$|async">
           <ion-label>
@@ -53,8 +53,8 @@
   </ng-container>
 
   <div class="wm-home-content">
-    <ng-container *ngIf="showResultType$|async as showResulType;">
-      <ng-container *ngIf="showResulType === 'tracks'|| showResulType == null">
+    <ng-container *ngIf="homeResultTabSelected$|async as homeResultTabSelected;">
+      <ng-container *ngIf="homeResultTabSelected === 'tracks'|| homeResultTabSelected == null">
         <ng-container *ngIf="tracksLoading$|async">
           <ion-list *ngFor="let idx of [1,1,1,1,1,1,1]">
             <ion-list-header>
@@ -94,7 +94,7 @@
           </ng-container>
         </ng-container>
       </ng-container>
-      <div class="pois" *ngIf="showResulType === 'pois'|| showResulType === 'all'">
+      <div class="pois" *ngIf="homeResultTabSelected === 'pois'">
         <wm-poi-box
           *ngFor="let c of pois$|async|wmSort:'properties.updatedAt':false"
           [data]="c"

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -118,3 +118,4 @@ export const loadHitmapFeaturesFail = createAction('[User Activity] Load configu
 export const wmMapFeaturesInViewport = createAction('[User Activity] wm map features in viewport', props<{featureIds: number[]}>());
 export const wmMapFeaturesInViewportSuccess = createAction('[User Activity] wm map features in viewport success', props<{featuresInViewport: Hit[]}>());
 export const wmMapFeaturesInViewportFailure = createAction('[User Activity] wm map features in viewport failure');
+export const setHomeResultTabSelected = createAction('[User Activity] set home result tab selected', props<{tab: 'tracks' | 'pois' | null}>());

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -9,6 +9,7 @@ import {
   loadHitmapFeaturesSuccess,
   openUgcUploader,
   resetPoiFilters,
+  setHomeResultTabSelected,
   setLayer,
   setMapDetailsStatus,
   toggleTrackFilter,
@@ -60,10 +61,10 @@ export class UserActivityEffects {
   backOfMapDetails$ = createEffect(() =>
     this._actions$.pipe(
       ofType(backOfMapDetails),
-      map(() => {
+      mergeMap(() => {
         const removeLatest = this._urlHandlerSvc.removeLatest();
         if (removeLatest) {
-          return setMapDetailsStatus({status: 'background'});
+          return [setHomeResultTabSelected({tab: null}), setMapDetailsStatus({status: 'background'})];
         } else {
           return;
         }
@@ -82,6 +83,7 @@ export class UserActivityEffects {
           resetTrackFilters(),
           resetPoiFilters(),
           closeUgc(),
+          setHomeResultTabSelected({tab: null}),
           setMapDetailsStatus({status: 'background'}),
         ),
       ),

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -27,10 +27,11 @@ import {
   setMapDetailsStatus,
   loadHitmapFeaturesSuccess,
   wmMapFeaturesInViewportSuccess,
+  setHomeResultTabSelected,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
-import {set} from 'ol/transform';
+
 import {Hit} from '@wm-types/elastic';
 
 export const key = 'userActivity';
@@ -55,6 +56,7 @@ export interface UserActivityState {
   wmMapHitMapChangeFeatureById?: number;
   featuresInViewport: Hit[];
   wmMapHitmapFeatures: WmFeature<MultiPolygon>[];
+  homeResultTabSelected: 'tracks' | 'pois';
 }
 
 export interface UserAcitivityRootState {
@@ -75,6 +77,7 @@ const initialState: UserActivityState = {
   wmMapHitMapChangeFeatureById: null,
   wmMapHitmapFeatures: [],
   featuresInViewport: [],
+  homeResultTabSelected: null,
 };
 
 function extractFilterTaxonomies(layer) {
@@ -287,5 +290,12 @@ export const userActivityReducer = createReducer(
       featuresInViewport,
     };
     return newState;
+  }),
+
+  on(setHomeResultTabSelected, (state, {tab}) => {
+    return {
+      ...state,
+      homeResultTabSelected: tab,
+    };
   }),
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -168,3 +168,5 @@ export const currentHitmapFeature = createSelector(
 
 export const featuresInViewport = createSelector(userActivity, state => state.featuresInViewport);
 export const hasFeatureInViewport = createSelector(featuresInViewport, featuresInViewport => featuresInViewport && featuresInViewport.length > 0);
+
+export const homeResultTabSelected = createSelector(userActivity, state => state.homeResultTabSelected);


### PR DESCRIPTION
Replaced the `showResultType$` BehaviorSubject with the `homeResultTabSelected$` observable, which is now sourced from the ngrx store. This change simplifies the state management by utilizing centralized state handling through ngrx.

- Updated HTML template to use `homeResultTabSelected$` for conditional rendering.
- Incorporated `setHomeResultTabSelected` action for updating the selected tab in the store.
- Adjusted subscriptions and related logic in `home-result.component.ts` to accommodate the new state management approach.
- Modified the user activity reducer to handle `setHomeResultTabSelected` action.
- Added necessary effects and selectors for managing the selected tab state.

This refactor enhances the maintainability and scalability of the component's state management by leveraging ngrx store capabilities.

fix(user-activity): 🐛 add missing action to reset home result tab

Added the `setHomeResultTabSelected({tab: null})` action to the UserActivityEffects to ensure that the home result tab is reset properly when user activity effects are triggered. This change helps maintain consistency in the application state.
