### PR TITLE
chore(slider-filter): ✨ emit lastFilterTypeEvt for both number and range values oc:5634

### DIFF
--- a/projects/wm-core/src/filters/slider-filter/slider-filter.component.ts
+++ b/projects/wm-core/src/filters/slider-filter/slider-filter.component.ts
@@ -39,8 +39,10 @@ export class SliderFilterComponent implements OnDestroy {
   onIonChange(ev: Event): void {
     this.currentValue = (ev as RangeCustomEvent).detail.value as SliderFilter;
     if (typeof this.currentValue === 'number') {
+      this.parent.lastFilterTypeEvt.emit('tracks');
       this.parent.filterTracksEvt.emit({...this.filter, ...{min: this.currentValue}});
     } else {
+      this.parent.lastFilterTypeEvt.emit('tracks');
       this.parent.filterTracksEvt.emit({
         ...this.filter,
         ...{lower: this.currentValue.lower, upper: this.currentValue.upper},

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -16,6 +16,7 @@ import {
   toggleTrackFilterByIdentifier,
   updateTrackFilter,
   setHomeResultTabSelected,
+  openUgc,
 } from './user-activity.action';
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
@@ -182,15 +183,16 @@ export class UserActivityEffects {
     ),
   );
 
-  setHomeResultTabWhenLastFilterTypePois$ = createEffect(() =>
+  setHomeResultTabWhenLastFilterTypeChanged$ = createEffect(() =>
     this._store.select(lastFilterType).pipe(
-      filter(lastFilterType => lastFilterType === 'pois'),
-      map(() => setHomeResultTabSelected({tab: 'pois'})),
+      filter(lastFilterType => lastFilterType != null),
+      map((lastFilterType) => setHomeResultTabSelected({tab: lastFilterType})),
     ),
   );
 
   setHomeResultTabWhenTracksCountIsZero$ = createEffect(() =>
     this._store.select(countTracks).pipe(
+      skip(1),
       filter(trackCount => trackCount === 0),
       map(() => setHomeResultTabSelected({tab: 'pois'})),
     ),
@@ -199,6 +201,13 @@ export class UserActivityEffects {
   setHomeResultTabToTracksWhenOpenDownloads$ = createEffect(() =>
     this._actions$.pipe(
       ofType(openDownloads),
+      map(() => setHomeResultTabSelected({tab: 'tracks'})),
+    ),
+  );
+
+  setHomeResultTabToTrackWhenOpenUgc$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(openUgc),
       map(() => setHomeResultTabSelected({tab: 'tracks'})),
     ),
   );


### PR DESCRIPTION
This update ensures that the `lastFilterTypeEvt` event is emitted when the slider filter's value changes, regardless of whether the value is a single number or a range. This provides more consistent behavior in tracking filter changes.

feat(user-activity): ✨ add effect to set home result tab when UGC is opened

Added a new effect `setHomeResultTabToTrackWhenOpenUgc$` that updates the home result tab to 'tracks' when the `openUgc` action is triggered. This ensures that the user interface reflects the appropriate context when user-generated content is accessed.

Additionally, the effect `setHomeResultTabWhenLastFilterTypeChanged$` was updated to handle any non-null `lastFilterType`, providing dynamic tab selection based on the last filter type used. Also modified `setHomeResultTabWhenTracksCountIsZero$` to skip the initial emission.
