### PR TITLE
chore(draw-ugc): ✨ add "draw user-generated content" component oc:5569

### DIFF
--- a/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.html
+++ b/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.html
@@ -1,0 +1,23 @@
+<div *ngIf="(showDraw$|async)">
+  <ion-button
+    color="light"
+    (click)="toggleTypeSelection()"
+    *ngIf="!(drawOpened$ | async) else drawingFeature"
+  >
+    <ion-icon slot="start" name="pencil"></ion-icon>
+    {{ 'Disegna' | translate }}
+  </ion-button>
+  <ng-template #drawingFeature>
+    <ion-button color="light" (click)="stopDrawing()">
+      {{ 'Esci' | translate }}
+    </ion-button>
+  </ng-template>
+  <div *ngIf="showDrawTypeSelection$ | async">
+    <ion-button color="light" *ngIf="showDrawPoi$ | async" (click)="toggleDrawPoiEnabled()">
+      <ion-icon name="pin-outline"></ion-icon>
+    </ion-button>
+    <ion-button color="light" *ngIf="showDrawTrack$ | async" (click)="toggleDrawTrackEnabled()">
+      <ion-icon name="analytics-outline"></ion-icon>
+    </ion-button>
+  </div>
+</div>

--- a/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.scss
+++ b/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.scss
@@ -1,0 +1,21 @@
+wm-draw-ugc-button {
+  > div {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    ion-button {
+      --background: white;
+      --box-shadow: 0px 6px 14px rgba(0, 0, 0, 0.2);
+      height: 40px;
+      margin: 0;
+    }
+    > div {
+      display: flex;
+      gap: 10px;
+
+      > ion-button {
+        flex: 1;
+      }
+    }
+  }
+}

--- a/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.ts
+++ b/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.ts
@@ -1,16 +1,13 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {DeviceService} from '@wm-core/services/device.service';
-import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {
-  confAUTHEnable,
   confShowDraw,
   confShowDrawPoi,
   confShowDrawTrack,
 } from '@wm-core/store/conf/conf.selector';
 import {
   drawTrackOpened as ActiondrawTrackOpened,
-  openLoginModal,
   startDrawUgcPoi,
   stopDrawUgcPoi,
 } from '@wm-core/store/user-activity/user-activity.action';
@@ -30,8 +27,6 @@ import {take} from 'rxjs/operators';
   encapsulation: ViewEncapsulation.None,
 })
 export class WmDrawUgcButtonComponent {
-  authEnable$ = this._store.select(confAUTHEnable);
-  isLogged$ = this._store.select(isLogged);
   drawTrackOpened$ = this._store.select(drawTrackOpened);
   drawPoiOpened$ = this._store.select(drawPoiOpened);
   drawOpened$ = this._store.select(drawOpened);
@@ -61,35 +56,19 @@ export class WmDrawUgcButtonComponent {
 
   toggleDrawTrackEnabled(): void {
     this.showDrawTypeSelection$.next(false);
-    combineLatest([this.authEnable$, this.isLogged$, this.drawTrackOpened$])
-      .pipe(take(1))
-      .subscribe(([authEnabled, isLogged, drawTrackOpened]) => {
-        this._handleAuthFlow(authEnabled, isLogged, () => {
-          this._store.dispatch(ActiondrawTrackOpened({drawTrackOpened: !drawTrackOpened}));
-        });
-      });
+    this.drawTrackOpened$.pipe(take(1)).subscribe(drawTrackOpened => {
+      this._store.dispatch(ActiondrawTrackOpened({drawTrackOpened: !drawTrackOpened}));
+    });
   }
 
   toggleDrawPoiEnabled(): void {
     this.showDrawTypeSelection$.next(false);
-    combineLatest([this.authEnable$, this.isLogged$, this.drawPoiOpened$])
-      .pipe(take(1))
-      .subscribe(([authEnabled, isLogged, drawPoiOpened]) => {
-        this._handleAuthFlow(authEnabled, isLogged, () => {
-          if (drawPoiOpened) {
-            this._store.dispatch(stopDrawUgcPoi());
-          } else {
-            this._store.dispatch(startDrawUgcPoi({ugcPoi: null}));
-          }
-        });
-      });
-  }
-
-  private _handleAuthFlow(authEnabled: boolean, isLogged: boolean, action: () => void): void {
-    if (authEnabled && !isLogged) {
-      this._store.dispatch(openLoginModal());
-    } else {
-      action();
-    }
+    this.drawPoiOpened$.pipe(take(1)).subscribe(drawPoiOpened => {
+      if (drawPoiOpened) {
+        this._store.dispatch(stopDrawUgcPoi());
+      } else {
+        this._store.dispatch(startDrawUgcPoi({ugcPoi: null}));
+      }
+    });
   }
 }

--- a/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.ts
+++ b/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.ts
@@ -1,11 +1,7 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {DeviceService} from '@wm-core/services/device.service';
-import {
-  confShowDraw,
-  confShowDrawPoi,
-  confShowDrawTrack,
-} from '@wm-core/store/conf/conf.selector';
+import {confShowDraw, confShowDrawPoi, confShowDrawTrack} from '@wm-core/store/conf/conf.selector';
 import {
   drawTrackOpened as ActiondrawTrackOpened,
   startDrawUgcPoi,
@@ -37,11 +33,11 @@ export class WmDrawUgcButtonComponent {
 
   constructor(private _store: Store, private _deviceSvc: DeviceService) {}
 
-  toggleTypeSelection() {
+  toggleTypeSelection(): void {
     this.showDrawTypeSelection$.next(!this.showDrawTypeSelection$.value);
   }
 
-  stopDrawing() {
+  stopDrawing(): void {
     this.showDrawTypeSelection$.next(false);
     combineLatest([this.drawTrackOpened$, this.drawPoiOpened$])
       .pipe(take(1))

--- a/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.ts
+++ b/projects/wm-core/src/draw-ugc-button/draw-ugc-button.component.ts
@@ -1,0 +1,95 @@
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {DeviceService} from '@wm-core/services/device.service';
+import {isLogged} from '@wm-core/store/auth/auth.selectors';
+import {
+  confAUTHEnable,
+  confShowDraw,
+  confShowDrawPoi,
+  confShowDrawTrack,
+} from '@wm-core/store/conf/conf.selector';
+import {
+  drawTrackOpened as ActiondrawTrackOpened,
+  openLoginModal,
+  startDrawUgcPoi,
+  stopDrawUgcPoi,
+} from '@wm-core/store/user-activity/user-activity.action';
+import {
+  drawOpened,
+  drawPoiOpened,
+  drawTrackOpened,
+} from '@wm-core/store/user-activity/user-activity.selector';
+import {BehaviorSubject, combineLatest} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+@Component({
+  selector: 'wm-draw-ugc-button',
+  templateUrl: './draw-ugc-button.component.html',
+  styleUrls: ['./draw-ugc-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class WmDrawUgcButtonComponent {
+  authEnable$ = this._store.select(confAUTHEnable);
+  isLogged$ = this._store.select(isLogged);
+  drawTrackOpened$ = this._store.select(drawTrackOpened);
+  drawPoiOpened$ = this._store.select(drawPoiOpened);
+  drawOpened$ = this._store.select(drawOpened);
+  showDrawPoi$ = this._store.select(confShowDrawPoi);
+  showDrawTrack$ = this._store.select(confShowDrawTrack);
+  showDraw$ = this._store.select(confShowDraw);
+  showDrawTypeSelection$ = new BehaviorSubject<boolean>(false);
+
+  constructor(private _store: Store, private _deviceSvc: DeviceService) {}
+
+  toggleTypeSelection() {
+    this.showDrawTypeSelection$.next(!this.showDrawTypeSelection$.value);
+  }
+
+  stopDrawing() {
+    this.showDrawTypeSelection$.next(false);
+    combineLatest([this.drawTrackOpened$, this.drawPoiOpened$])
+      .pipe(take(1))
+      .subscribe(([drawTrackOpened, drawPoiOpened]) => {
+        if (drawTrackOpened) {
+          this.toggleDrawTrackEnabled();
+        } else if (drawPoiOpened) {
+          this.toggleDrawPoiEnabled();
+        }
+      });
+  }
+
+  toggleDrawTrackEnabled(): void {
+    this.showDrawTypeSelection$.next(false);
+    combineLatest([this.authEnable$, this.isLogged$, this.drawTrackOpened$])
+      .pipe(take(1))
+      .subscribe(([authEnabled, isLogged, drawTrackOpened]) => {
+        this._handleAuthFlow(authEnabled, isLogged, () => {
+          this._store.dispatch(ActiondrawTrackOpened({drawTrackOpened: !drawTrackOpened}));
+        });
+      });
+  }
+
+  toggleDrawPoiEnabled(): void {
+    this.showDrawTypeSelection$.next(false);
+    combineLatest([this.authEnable$, this.isLogged$, this.drawPoiOpened$])
+      .pipe(take(1))
+      .subscribe(([authEnabled, isLogged, drawPoiOpened]) => {
+        this._handleAuthFlow(authEnabled, isLogged, () => {
+          if (drawPoiOpened) {
+            this._store.dispatch(stopDrawUgcPoi());
+          } else {
+            this._store.dispatch(startDrawUgcPoi({ugcPoi: null}));
+          }
+        });
+      });
+  }
+
+  private _handleAuthFlow(authEnabled: boolean, isLogged: boolean, action: () => void): void {
+    if (authEnabled && !isLogged) {
+      this._store.dispatch(openLoginModal());
+    } else {
+      action();
+    }
+  }
+}

--- a/projects/wm-core/src/draw-ugc/draw-ugc.component.html
+++ b/projects/wm-core/src/draw-ugc/draw-ugc.component.html
@@ -1,0 +1,26 @@
+<ng-container *ngIf="!(homeOpened$|async)">
+  <wm-form
+    [confPOIFORMS]="confFORMS$|async"
+    (formGroupEvt)="formGroup$.next($event)"
+    (isInvalidEvt)="isIvalidForm$.next($event)"
+  >
+    <wm-image-picker
+      (startAddPhotos)="startAddPhotos()"
+      (endAddPhotos)="endAddPhotos()"
+      (photosChanged)="photosChanged($event)"
+    ></wm-image-picker>
+  </wm-form>
+  <ng-container *ngIf="hasCustomTrack$|async;">
+    <ng-container *ngIf="currentUgcTrackDrawn$|async as currentUgcTrackDrawn">
+      <wm-slope-chart [currentTrack]="currentUgcTrackDrawn"></wm-slope-chart>
+      <wm-tab-detail [properties]="currentUgcTrackDrawn?.properties"></wm-tab-detail>
+      <wm-feature-useful-urls [track]="currentUgcTrackDrawn"></wm-feature-useful-urls>
+    </ng-container>
+  </ng-container>
+  <ion-button
+    expand="full"
+    (click)="saveUgc()"
+    [disabled]="isIvalidForm$|async"
+    >{{ 'salva' | wmtrans}}</ion-button
+  >
+</ng-container>

--- a/projects/wm-core/src/draw-ugc/draw-ugc.component.html
+++ b/projects/wm-core/src/draw-ugc/draw-ugc.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="!(homeOpened$|async)">
   <wm-form
-    [confPOIFORMS]="confFORMS$|async"
+    [confPOIFORMS]="currentDrawFormType$|async"
     (formGroupEvt)="formGroup$.next($event)"
     (isInvalidEvt)="isIvalidForm$.next($event)"
   >

--- a/projects/wm-core/src/draw-ugc/draw-ugc.component.scss
+++ b/projects/wm-core/src/draw-ugc/draw-ugc.component.scss
@@ -1,0 +1,8 @@
+wm-draw-ugc {
+  display: block;
+  padding: 16px;
+
+  wm-form {
+    margin: 0px;
+  }
+}

--- a/projects/wm-core/src/draw-ugc/draw-ugc.component.ts
+++ b/projects/wm-core/src/draw-ugc/draw-ugc.component.ts
@@ -1,0 +1,121 @@
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+import {UntypedFormGroup} from '@angular/forms';
+import {BehaviorSubject, EMPTY, from, Observable, of} from 'rxjs';
+import {Store} from '@ngrx/store';
+import {confPOIFORMS, confTRACKFORMS} from '@wm-core/store/conf/conf.selector';
+import {hasCustomTrack, homeOpened} from '@wm-core/store/user-activity/user-activity.selector';
+import {catchError, map, switchMap, take} from 'rxjs/operators';
+import {WmFeature, WmProperties} from '@wm-types/feature';
+import {LineString, Point} from 'geojson';
+import {currentUgcDrawn} from '@wm-core/store/features/ugc/ugc.selector';
+import {addFormError, removeFormError} from '@wm-core/utils/form';
+import {Photo} from '@capacitor/camera';
+import {DeviceService} from '@wm-core/services/device.service';
+import {generateUUID, saveUgc} from '@wm-core/utils/localForage';
+import {EnvironmentService} from '@wm-core/services/environment.service';
+import {AlertController} from '@ionic/angular';
+import {LangService} from '@wm-core/localization/lang.service';
+import {syncUgc, currentCustomTrack} from '@wm-core/store/features/ugc/ugc.actions';
+import {startDrawUgcPoi} from '@wm-core/store/user-activity/user-activity.action';
+
+@Component({
+  selector: 'wm-draw-ugc',
+  templateUrl: './draw-ugc.component.html',
+  styleUrls: ['./draw-ugc.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class WmDrawUgcComponent {
+  confFORMS$: Observable<any>;
+  homeOpened$: Observable<boolean> = this._store.select(homeOpened);
+  hasCustomTrack$: Observable<boolean> = this._store.select(hasCustomTrack);
+  currentUgcDrawn$: Observable<WmFeature<LineString | Point>> = this._store.select(currentUgcDrawn);
+  formGroup$: BehaviorSubject<UntypedFormGroup> = new BehaviorSubject<UntypedFormGroup>(null);
+  isIvalidForm$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
+
+  get currentUgcTrackDrawn$(): Observable<WmFeature<LineString>> {
+    return this.currentUgcDrawn$ as Observable<WmFeature<LineString>>;
+  }
+
+  private _photos: Photo[] = [];
+
+  constructor(
+    private _store: Store,
+    private _deviceSvc: DeviceService,
+    private _enviromentSvc: EnvironmentService,
+    private _alertCtrl: AlertController,
+    private _langSvc: LangService,
+  ) {
+    this.hasCustomTrack$.pipe(take(1)).subscribe(hasCustomTrack => {
+      if (hasCustomTrack) {
+        this.confFORMS$ = this._store.select(confTRACKFORMS);
+      } else {
+        this.confFORMS$ = this._store.select(confPOIFORMS);
+      }
+    });
+  }
+
+  startAddPhotos(): void {
+    addFormError(this.formGroup$.value, {photo: true});
+  }
+
+  endAddPhotos(): void {
+    removeFormError(this.formGroup$.value, 'photo');
+  }
+
+  photosChanged(photos: Photo[]): void {
+    this._photos = photos;
+  }
+
+  saveUgc(): void {
+    // TODO: Logica duplicata in modal-ugc-uploader.component.ts
+    this.currentUgcDrawn$
+      .pipe(
+        take(1),
+        switchMap(ugcDrawn =>
+          from(this._deviceSvc.getInfo()).pipe(
+            map(device => {
+              const ugc: WmFeature<LineString | Point> = {...ugcDrawn};
+              const ugcProperties = ugc?.properties;
+              const dateNow = new Date();
+              const formGroup = this.formGroup$.value;
+              const formGroupValue = formGroup.value;
+              const properties: WmProperties = {
+                name: formGroupValue?.title,
+                form: formGroupValue ?? undefined,
+                uuid: generateUUID(),
+                app_id: `${this._enviromentSvc.appId}`,
+                createdAt: dateNow,
+                updatedAt: dateNow,
+                media: this._photos,
+                ugcProperties,
+                device,
+              };
+
+              ugc.properties = properties;
+              return ugc;
+            }),
+          ),
+        ),
+        switchMap(feature => saveUgc(feature)),
+        switchMap(_ => {
+          this._store.dispatch(startDrawUgcPoi({ugcPoi: null}));
+          this._store.dispatch(currentCustomTrack({currentCustomTrack: null}));
+          return this._alertCtrl.create({
+            message: `${this._langSvc.instant('Il salvataggio è stato completato')}!`,
+            buttons: ['OK'],
+          });
+        }),
+        switchMap(alert => alert.present()),
+        catchError(_ => {
+          this._alertCtrl.create({
+            message: `${this._langSvc.instant(
+              'Si è verificato un errore durante il salvataggio. Riprova',
+            )}!`,
+          });
+          return EMPTY;
+        }),
+      )
+      .subscribe(() => this._store.dispatch(syncUgc()));
+  }
+}

--- a/projects/wm-core/src/draw-ugc/draw-ugc.component.ts
+++ b/projects/wm-core/src/draw-ugc/draw-ugc.component.ts
@@ -15,8 +15,11 @@ import {generateUUID, saveUgc} from '@wm-core/utils/localForage';
 import {EnvironmentService} from '@wm-core/services/environment.service';
 import {AlertController} from '@ionic/angular';
 import {LangService} from '@wm-core/localization/lang.service';
-import {syncUgc, currentCustomTrack} from '@wm-core/store/features/ugc/ugc.actions';
-import {startDrawUgcPoi} from '@wm-core/store/user-activity/user-activity.action';
+import {
+  syncUgc,
+  currentCustomTrack,
+  setCurrentUgcPoiDrawn,
+} from '@wm-core/store/features/ugc/ugc.actions';
 
 @Component({
   selector: 'wm-draw-ugc',
@@ -91,7 +94,7 @@ export class WmDrawUgcComponent {
         ),
         switchMap(feature => saveUgc(feature)),
         switchMap(_ => {
-          this._store.dispatch(startDrawUgcPoi({ugcPoi: null}));
+          this._store.dispatch(setCurrentUgcPoiDrawn({currentUgcPoiDrawn: null}));
           this._store.dispatch(currentCustomTrack({currentCustomTrack: null}));
           return this._alertCtrl.create({
             message: `${this._langSvc.instant('Il salvataggio è stato completato')}!`,

--- a/projects/wm-core/src/draw-ugc/draw-ugc.component.ts
+++ b/projects/wm-core/src/draw-ugc/draw-ugc.component.ts
@@ -2,7 +2,7 @@ import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/co
 import {UntypedFormGroup} from '@angular/forms';
 import {BehaviorSubject, EMPTY, from, Observable, of} from 'rxjs';
 import {Store} from '@ngrx/store';
-import {confPOIFORMS, confTRACKFORMS} from '@wm-core/store/conf/conf.selector';
+import {currentDrawFormType} from '@wm-core/store/user-activity/user-activity.selector';
 import {hasCustomTrack, homeOpened} from '@wm-core/store/user-activity/user-activity.selector';
 import {catchError, map, switchMap, take} from 'rxjs/operators';
 import {WmFeature, WmProperties} from '@wm-types/feature';
@@ -26,7 +26,7 @@ import {startDrawUgcPoi} from '@wm-core/store/user-activity/user-activity.action
   encapsulation: ViewEncapsulation.None,
 })
 export class WmDrawUgcComponent {
-  confFORMS$: Observable<any>;
+  currentDrawFormType$: Observable<any> = this._store.select(currentDrawFormType);
   homeOpened$: Observable<boolean> = this._store.select(homeOpened);
   hasCustomTrack$: Observable<boolean> = this._store.select(hasCustomTrack);
   currentUgcDrawn$: Observable<WmFeature<LineString | Point>> = this._store.select(currentUgcDrawn);
@@ -45,15 +45,7 @@ export class WmDrawUgcComponent {
     private _enviromentSvc: EnvironmentService,
     private _alertCtrl: AlertController,
     private _langSvc: LangService,
-  ) {
-    this.hasCustomTrack$.pipe(take(1)).subscribe(hasCustomTrack => {
-      if (hasCustomTrack) {
-        this.confFORMS$ = this._store.select(confTRACKFORMS);
-      } else {
-        this.confFORMS$ = this._store.select(confPOIFORMS);
-      }
-    });
-  }
+  ) {}
 
   startAddPhotos(): void {
     addFormError(this.formGroup$.value, {photo: true});

--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -81,15 +81,10 @@
       (click)="wmap.wmMapCloseTopRightBtns = 'wm-filters'"
     ></wm-filters>
     <wm-profile-popup top-right></wm-profile-popup>
-    <div
+    <wm-draw-ugc-button
+      *ngIf="(confShowDraw$|async) && !(isMobile$|async)"
       top-right
-      class="top-right-button"
-      expand="full"
-      *ngIf="(showDrawTrackButton$|async) && !(isMobile$|async)"
-      (click)="toggleDrawTrackEnabled();wmap.wmMapCloseTopRightBtns = 'my-paths'"
-    >
-      {{ (drawTrackOpened$|async)?'esci':'i miei percorsi'|wmtrans}}
-    </div>
+    ></wm-draw-ugc-button>
     <div class="bottom-right" bottom-right>
       <ng-content select="[bottom-right]"></ng-content>
     </div>

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -18,6 +18,7 @@ import {
   confMAP,
   confMAPLAYERS,
   confOPTIONS,
+  confShowDraw,
 } from '@wm-core/store/conf/conf.selector';
 import {
   allEcpoiFeatures,
@@ -28,12 +29,10 @@ import {
   ecPois,
 } from '@wm-core/store/features/ec/ec.selector';
 import {
-  drawTrackOpened as ActiondrawTrackOpened,
   backOfMapDetails,
   goToHome,
   openUgc,
   resetMap,
-  resetPoiFilters,
   resetTrackFilters,
   setLastFilterType,
   setLayer,
@@ -68,7 +67,6 @@ import {
 } from 'rxjs/operators';
 import {
   confJIDOUPDATETIME,
-  confShowDrawTrack,
   confAUTHEnable,
   confOPTIONSShowFeaturesInViewport,
 } from '@wm-core/store/conf/conf.selector';
@@ -100,7 +98,6 @@ import {
   ugcTracksFeatures,
 } from '@wm-core/store/features/ugc/ugc.selector';
 import {ModalController} from '@ionic/angular';
-import {ProfileAuthComponent} from '@wm-core/profile/profile-auth/profile-auth.component';
 import {WmMapTrackRelatedPoisDirective} from '@map-core/directives';
 import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {WmMapComponent} from '@map-core/components';
@@ -233,7 +230,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
   resetSelectedUgcPoi$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   resizeEVT: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   setCurrentPoiSub$: Subscription = Subscription.EMPTY;
-  showDrawTrackButton$ = this._store.select(confShowDrawTrack);
+  confShowDraw$ = this._store.select(confShowDraw);
   showMenu$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(initMenuOpened);
   toggleLayerDirective$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
   togglePoisDirective$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
@@ -536,42 +533,6 @@ export class WmGeoboxMapComponent implements OnDestroy {
       case 'ugc':
         this.toggleUgcDirective$.next(data.toggle);
     }
-  }
-
-  toggleDrawTrackEnabled(): void {
-    combineLatest([this.authEnable$, this.isLogged$, this.drawTrackOpened$])
-      .pipe(
-        take(1),
-        switchMap(([authEnabled, isLogged, drawTrackOpened]) => {
-          if (authEnabled) {
-            if (isLogged) {
-              this._store.dispatch(ActiondrawTrackOpened({drawTrackOpened: !drawTrackOpened}));
-              this._store.dispatch(currentCustomTrackAction({currentCustomTrack: null}));
-              this._store.dispatch(setLayer(null));
-              this._store.dispatch(resetPoiFilters());
-              this._store.dispatch(resetTrackFilters());
-              this.updateEcTrack();
-              return of(null);
-            } else {
-              return from(
-                this._modalCtrl.create({
-                  component: ProfileAuthComponent,
-                  componentProps: {
-                    slide1: 'assets/images/profile/logged_out_slide_1.svg',
-                    slide2: 'assets/images/profile/logged_out_slide_2.svg',
-                  },
-                  id: 'wm-profile-auth-modal',
-                }),
-              ).pipe(concatMap(modal => from(modal.present())));
-            }
-          } else {
-            this._store.dispatch(ActiondrawTrackOpened({drawTrackOpened: !drawTrackOpened}));
-            this._store.dispatch(currentCustomTrackAction({currentCustomTrack: null}));
-            return of(null);
-          }
-        }),
-      )
-      .subscribe();
   }
 
   unselectPOI(): void {

--- a/projects/wm-core/src/localization/i18n/de.ts
+++ b/projects/wm-core/src/localization/i18n/de.ts
@@ -148,9 +148,12 @@ export const wmDE = {
     '<span class="orange">Stufe 2: Abschnitte teilweise in großer Höhe (Höhe zwischen {{orange}} und {{red}} Metern)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Stufe 3: in großer Höhe (Höhe über {{red}} Metern)</span>',
-  'Un utente è già stato registrato con questa email.': 'Ein Benutzer ist bereits mit dieser E-Mail registriert.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'Die eingegebene E-Mail ist nicht korrekt. Bitte versuchen Sie es erneut.',
-  'La password inserita non è corretta. Per favore, riprova.': 'Das eingegebene Passwort ist nicht korrekt. Bitte versuchen Sie es erneut.',
+  'Un utente è già stato registrato con questa email.':
+    'Ein Benutzer ist bereits mit dieser E-Mail registriert.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    'Die eingegebene E-Mail ist nicht korrekt. Bitte versuchen Sie es erneut.',
+  'La password inserita non è corretta. Per favore, riprova.':
+    'Das eingegebene Passwort ist nicht korrekt. Bitte versuchen Sie es erneut.',
   'Errore': 'Fehler',
   'Tempo': 'Zeit',
   'Velocità media': 'Durchschnittsgeschwindigkeit',
@@ -161,10 +164,13 @@ export const wmDE = {
   'Carica': 'Hochladen',
   'Aggiornamento effettuato con successo': 'Aktualisierung erfolgreich durchgeführt',
   'Ops!': 'Ups!',
-  'Non è stato possibile aggiornare, riprova più tardi': 'Aktualisierung nicht möglich, versuchen Sie es später erneut',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    'Aktualisierung nicht möglich, versuchen Sie es später erneut',
   'Eliminazione effettuata con successo': 'Löschung erfolgreich durchgeführt',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': 'Sind Sie sicher, dass Sie diesen POI löschen möchten? Die Löschung ist irreversibel.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': 'Sind Sie sicher, dass Sie diese Strecke löschen möchten? Die Löschung ist irreversibel.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    'Sind Sie sicher, dass Sie diesen POI löschen möchten? Die Löschung ist irreversibel.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    'Sind Sie sicher, dass Sie diese Strecke löschen möchten? Die Löschung ist irreversibel.',
   'Login effettuato con successo': 'Login erfolgreich',
   'Logout effettuato con successo': 'Logout erfolgreich',
   'Ottieni indicazioni': 'Indikationen erhalten',
@@ -183,4 +189,13 @@ export const wmDE = {
   'Aggiungi': 'Hinzufügen',
   'Foto': 'Foto',
   '(max 3 photo)': '(max 3 Fotos)',
+  'salva': 'speichern',
+  'Il salvataggio è stato completato': 'Das Speichern ist erfolgreich',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'Sie ändern die Koordinaten des POI, möchten Sie fortfahren?',
+  'No': 'Nein',
+  'Sì': 'Ja',
+  'Attenzione': 'Achtung',
+  'Disegna': 'Zeichnen',
+  'Esci': 'Aus',
 };

--- a/projects/wm-core/src/localization/i18n/en.ts
+++ b/projects/wm-core/src/localization/i18n/en.ts
@@ -153,9 +153,12 @@ export const wmEN = {
     '<span class="orange">Level 2: sections partially in high altitude (altitude between {{orange}} meters and {{red}} meters)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Level 3: in high altitude (altitude above {{red}} meters)</span>',
-  'Un utente è già stato registrato con questa email.': 'A user has already been registered with this email.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'The email entered is incorrect. Please try again.',
-  'La password inserita non è corretta. Per favore, riprova.': 'The password entered is incorrect. Please try again.',
+  'Un utente è già stato registrato con questa email.':
+    'A user has already been registered with this email.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    'The email entered is incorrect. Please try again.',
+  'La password inserita non è corretta. Per favore, riprova.':
+    'The password entered is incorrect. Please try again.',
   'Errore': 'Error',
   'Tempo': 'Time',
   'Velocità media': 'Average speed',
@@ -166,10 +169,13 @@ export const wmEN = {
   'Carica': 'Upload',
   'Aggiornamento effettuato con successo': 'Application updated successfully',
   'Ops!': 'Ops!',
-  'Non è stato possibile aggiornare, riprova più tardi': 'It was not possible to update, try again later',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    'It was not possible to update, try again later',
   'Eliminazione effettuata con successo': 'Deletion successful',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': 'Are you sure you want to delete this POI? The removal is irreversible.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': 'Are you sure you want to delete this track? The removal is irreversible.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    'Are you sure you want to delete this POI? The removal is irreversible.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    'Are you sure you want to delete this track? The removal is irreversible.',
   'Login effettuato con successo': 'Login successful',
   'Logout effettuato con successo': 'Logout successful',
   'Ottieni indicazioni': 'Get indications',
@@ -189,4 +195,13 @@ export const wmEN = {
   'Aggiungi': 'Add',
   'Foto': 'Photo',
   '(max 3 photo)': '(max 3 photo)',
+  'salva': 'save',
+  'Il salvataggio è stato completato': 'The saving has been completed',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'You are modifying the coordinates of the POI, do you want to continue?',
+  'No': 'No',
+  'Sì': 'Yes',
+  'Attenzione': 'Attention',
+  'Disegna': 'Draw',
+  'Esci': 'Exit',
 };

--- a/projects/wm-core/src/localization/i18n/es.ts
+++ b/projects/wm-core/src/localization/i18n/es.ts
@@ -144,9 +144,12 @@ export const wmES = {
     '<span class="orange">Nivel 2: tramos parcialmente en alta altitud (altitud entre {{orange}} metros y {{red}} metros)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Nivel 3: en alta altitud (altitud superior a {{red}} metros)</span>',
-  'Un utente è già stato registrato con questa email.': 'Un usuario ya está registrado con esta dirección de correo electrónico.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'El correo electrónico introducido no es correcto. Por favor, inténtalo de nuevo.',
-  'La password inserita non è corretta. Per favore, riprova.': 'La contraseña introducida no es correcta. Por favor, inténtalo de nuevo.',
+  'Un utente è già stato registrato con questa email.':
+    'Un usuario ya está registrado con esta dirección de correo electrónico.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    'El correo electrónico introducido no es correcto. Por favor, inténtalo de nuevo.',
+  'La password inserita non è corretta. Per favore, riprova.':
+    'La contraseña introducida no es correcta. Por favor, inténtalo de nuevo.',
   'Errore': 'Error',
   'Tempo': 'Tiempo',
   'Velocità media': 'Velocidad media',
@@ -157,10 +160,13 @@ export const wmES = {
   'Carica': 'Cargar',
   'Aggiornamento effettuato con successo': 'Actualización realizada con éxito',
   'Ops!': '¡Ups!',
-  'Non è stato possibile aggiornare, riprova più tardi': 'No fue posible actualizar, inténtalo de nuevo más tarde',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    'No fue posible actualizar, inténtalo de nuevo más tarde',
   'Eliminazione effettuata con successo': 'Eliminación realizada con éxito',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': '¿Está seguro de que desea eliminar este POI? La eliminación es irreversible.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': '¿Está seguro de que desea eliminar esta ruta? La eliminación es irreversible.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    '¿Está seguro de que desea eliminar este POI? La eliminación es irreversible.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    '¿Está seguro de que desea eliminar esta ruta? La eliminación es irreversible.',
   'Login effettuato con successo': 'Inicio de sesión exitoso',
   'Logout effettuato con successo': 'Cierre de sesión exitoso',
   'Ottieni indicazioni': 'Obtener indicaciones',
@@ -179,4 +185,13 @@ export const wmES = {
   'Aggiungi': 'Agregar',
   'Foto': 'Foto',
   '(max 3 photo)': '(máx 3 fotos)',
+  'salva': 'guardar',
+  'Il salvataggio è stato completato': 'El guardado se ha completado',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'Estás modificando las coordenadas del POI, ¿quieres continuar?',
+  'No': 'No',
+  'Sì': 'Sí',
+  'Attenzione': 'Atención',
+  'Disegna': 'Dibujar',
+  'Esci': 'Salir',
 };

--- a/projects/wm-core/src/localization/i18n/fr.ts
+++ b/projects/wm-core/src/localization/i18n/fr.ts
@@ -126,7 +126,7 @@ export const wmFR = {
   'Galleria': 'Galerie',
   'resetta la memoria': 'Réinitialiser la mémoire',
   'rimani acceso': 'Restez connecté',
-  'forza il dispositivo a non spegnersi': 'Forcez le périphérique à ne pas s\'éteindre',
+  'forza il dispositivo a non spegnersi': "Forcez le périphérique à ne pas s'éteindre",
   'PAGINE': 'PAGES',
   'I tuoi dati': 'Vos données',
   'pages.profile.projectlink': 'Projet',
@@ -138,7 +138,7 @@ export const wmFR = {
   'la distanza espressa in metri che indica la cadenza di rilevamento posizione, più il distance filter è minore piu il consumo della batteria sarà maggiore.':
     'La distance exprimée en mètres indique la fréquence de détection de la position, plus le filtre de distance est faible, plus le consommation de la batterie sera élevée.',
   "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni":
-    'Pour enregistrer les pistes et les points d\'intérêt correctement, activez la permission de position dans les paramètres.',
+    "Pour enregistrer les pistes et les points d'intérêt correctement, activez la permission de position dans les paramètres.",
   'I miei percorsi': 'Mes parcours',
   'Sentieri': 'Sentiers',
   '<span class="green">Livello 1: tratti non interessati dall\'alta quota (quota minore di {{orange}} metri)</span>':
@@ -147,9 +147,12 @@ export const wmFR = {
     '<span class="orange">Niveau 2: sections partiellement en altitude (altitude comprise entre {{orange}} mètres et {{red}} mètres)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Niveau 3: sections en altitude (altitude supérieure à {{red}} mètres)</span>',
-  'Un utente è già stato registrato con questa email.': 'Un utilisateur a déjà été enregistré avec cet email.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'L\'email saisie est incorrecte. Veuillez réessayer.',
-  'La password inserita non è corretta. Per favore, riprova.': 'Le mot de passe saisi est incorrect. Veuillez réessayer.',
+  'Un utente è già stato registrato con questa email.':
+    'Un utilisateur a déjà été enregistré avec cet email.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    "L'email saisie est incorrecte. Veuillez réessayer.",
+  'La password inserita non è corretta. Per favore, riprova.':
+    'Le mot de passe saisi est incorrect. Veuillez réessayer.',
   'Errore': 'Erreur',
   'Tempo': 'Temps',
   'Velocità media': 'Analyse de la vitesse',
@@ -160,10 +163,13 @@ export const wmFR = {
   'Carica': 'Télécharger',
   'Aggiornamento effettuato con successo': 'Mise à jour réussie',
   'Ops!': 'Ops !',
-  'Non è stato possibile aggiornare, riprova più tardi': 'Il n\'a pas été possible de mettre à jour, essayez à nouveau plus tard',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    "Il n'a pas été possible de mettre à jour, essayez à nouveau plus tard",
   'Eliminazione effettuata con successo': 'Suppression réussie',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': 'Êtes-vous sûr de vouloir supprimer ce POI ? La suppression est irréversible.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': 'Êtes-vous sûr de vouloir supprimer cette piste ? La suppression est irréversible.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    'Êtes-vous sûr de vouloir supprimer ce POI ? La suppression est irréversible.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    'Êtes-vous sûr de vouloir supprimer cette piste ? La suppression est irréversible.',
   'Login effettuato con successo': 'Connexion réussie',
   'Logout effettuato con successo': 'Déconnexion réussie',
   'Ottieni indicazioni': 'Obtenir des indications',
@@ -182,4 +188,13 @@ export const wmFR = {
   'Aggiungi': 'Ajouter',
   'Foto': 'Photo',
   '(max 3 photo)': '(max 3 photos)',
+  'salva': 'sauvegarder',
+  'Il salvataggio è stato completato': 'La sauvegarde a été effectuée',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'Vous modifiez les coordonnées du POI, voulez-vous continuer ?',
+  'No': 'Non',
+  'Sì': 'Oui',
+  'Attenzione': 'Attention',
+  'Disegna': 'Dessiner',
+  'Esci': 'Quitter',
 };

--- a/projects/wm-core/src/localization/i18n/it.ts
+++ b/projects/wm-core/src/localization/i18n/it.ts
@@ -144,7 +144,7 @@ export const wmIT = {
   'la distanza espressa in metri che indica la cadenza di rilevamento posizione, più il distance filter è minore piu il consumo della batteria sarà maggiore.':
     'Distanza espressa in metri che indica la cadenza di rilevamento posizione, più il distance filter è minore piu il consumo della batteria sarà maggiore.',
   "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni":
-    'Per registrare tracce e poi correttamente, abilita l\'autorizzazione alla posizione nelle impostazioni',
+    "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni",
   'I miei percorsi': 'I miei percorsi',
   'Sentieri': 'Sentieri',
   '<span class="green">Livello 1: tratti non interessati dall\'alta quota (quota minore di {{orange}} metri)</span>':
@@ -153,9 +153,12 @@ export const wmIT = {
     '<span class="orange">Livello 2: tratti parzialmente in alta quota (quota compresa tra {{orange}} metri e {{red}} metri)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>',
-  'Un utente è già stato registrato con questa email.': 'Un utente è già stato registrato con questa email.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'L\'email inserita non è corretta. Per favore, riprova.',
-  'La password inserita non è corretta. Per favore, riprova.': 'La password inserita non è corretta. Per favore, riprova.',
+  'Un utente è già stato registrato con questa email.':
+    'Un utente è già stato registrato con questa email.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    "L'email inserita non è corretta. Per favore, riprova.",
+  'La password inserita non è corretta. Per favore, riprova.':
+    'La password inserita non è corretta. Per favore, riprova.',
   'Errore': 'Errore',
   'Tempo': 'Tempo',
   'Velocità media': 'Velocità media',
@@ -166,10 +169,13 @@ export const wmIT = {
   'Carica': 'Carica',
   'Aggiornamento effettuato con successo': 'Aggiornamento effettuato con successo',
   'Ops!': 'Ops!',
-  'Non è stato possibile aggiornare, riprova più tardi': 'Non è stato possibile aggiornare, riprova più tardi',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    'Non è stato possibile aggiornare, riprova più tardi',
   'Eliminazione effettuata con successo': 'Eliminazione effettuata con successo',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': 'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': 'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.',
   'Login effettuato con successo': 'Login effettuato con successo',
   'Logout effettuato con successo': 'Logout effettuato con successo',
   'Ottieni indicazioni': 'Ottieni indicazioni',
@@ -188,4 +194,13 @@ export const wmIT = {
   'Aggiungi': 'Aggiungi',
   'Foto': 'Foto',
   '(max 3 photo)': '(max 3 photo)',
+  'salva': 'salva',
+  'Il salvataggio è stato completato': 'Il salvataggio è stato completato',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'Stai modificando le coordinate del POI, vuoi continuare?',
+  'No': 'No',
+  'Sì': 'Sì',
+  'Attenzione': 'Attenzione',
+  'Disegna': 'Disegna',
+  'Esci': 'Esci',
 };

--- a/projects/wm-core/src/localization/i18n/pr.ts
+++ b/projects/wm-core/src/localization/i18n/pr.ts
@@ -145,9 +145,12 @@ export const wmPR = {
     '<span class="orange">Nível 2: seções parcialmente em alta altitude (altitude entre {{orange}} metros e {{red}} metros)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Nível 3: seções em alta altitude (altitude superior a {{red}} metros)</span>',
-  'Un utente è già stato registrato con questa email.': 'Um usuário já foi registrado com este e-mail.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'O e-mail inserido está incorreto. Por favor, tente novamente.',
-  'La password inserita non è corretta. Per favore, riprova.': 'A senha inserida está incorreta. Por favor, tente novamente.',
+  'Un utente è già stato registrato con questa email.':
+    'Um usuário já foi registrado com este e-mail.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    'O e-mail inserido está incorreto. Por favor, tente novamente.',
+  'La password inserita non è corretta. Per favore, riprova.':
+    'A senha inserida está incorreta. Por favor, tente novamente.',
   'Errore': 'Erro',
   'Tempo': ' Tempo',
   'Velocità media': 'Velocidade média',
@@ -158,10 +161,13 @@ export const wmPR = {
   'Carica': 'Carregar',
   'Aggiornamento effettuato con successo': 'Atualização realizada com sucesso',
   'Ops!': 'Ops!',
-  'Non è stato possibile aggiornare, riprova più tardi': 'It was not possible to update, try again later',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    'It was not possible to update, try again later',
   'Eliminazione effettuata con successo': 'Eliminação realizada com sucesso',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': 'Are you sure you want to delete this POI? The removal is irreversible.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': 'Are you sure you want to delete this track? The removal is irreversible.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    'Are you sure you want to delete this POI? The removal is irreversible.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    'Are you sure you want to delete this track? The removal is irreversible.',
   'Login effettuato con successo': 'Login realizado com sucesso',
   'Logout effettuato con successo': 'Logout realizado com sucesso',
   'Ottieni indicazioni': 'Obter indicações',
@@ -180,4 +186,13 @@ export const wmPR = {
   'Aggiungi': 'Adicionar',
   'Foto': 'Foto',
   '(max 3 photo)': '(máx 3 fotos)',
+  'salva': 'salvar',
+  'Il salvataggio è stato completato': 'O salvamento foi concluído',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'Você está modificando as coordenadas do POI, deseja continuar?',
+  'No': 'No',
+  'Sì': 'Sì',
+  'Attenzione': 'Atenção',
+  'Disegna': 'Desenhar',
+  'Esci': 'Sair',
 };

--- a/projects/wm-core/src/localization/i18n/sq.ts
+++ b/projects/wm-core/src/localization/i18n/sq.ts
@@ -152,9 +152,12 @@ export const wmSQ = {
     '<span class="orange">Niveli 2: seksione që nuk preken nga lartësia e madhe (lartësia midis {{orange}} metra dhe {{red}} metra)</span>',
   '<span class="red">Livello 3: in alta quota (quota superiore {{red}} metri)</span>':
     '<span class="red">Niveli 3: seksione që preken nga lartësia e madhe (lartësia më e madhe se {{red}} metra)</span>',
-  'Un utente è già stato registrato con questa email.': 'Një përdorues është tashmë regjistruar me këtë email.',
-  'L\'email inserita non è corretta. Per favore, riprova.': 'Email-i që keni futur nuk është e saktë. Ju lutem provoni përsëri.',
-  'La password inserita non è corretta. Per favore, riprova.': 'Fjalëkalimi që keni futur nuk është i saktë. Ju lutem provoni përsëri.',
+  'Un utente è già stato registrato con questa email.':
+    'Një përdorues është tashmë regjistruar me këtë email.',
+  "L'email inserita non è corretta. Per favore, riprova.":
+    'Email-i që keni futur nuk është e saktë. Ju lutem provoni përsëri.',
+  'La password inserita non è corretta. Per favore, riprova.':
+    'Fjalëkalimi që keni futur nuk është i saktë. Ju lutem provoni përsëri.',
   'Errore': 'Gabim',
   'Tempo': 'Koha',
   'Velocità media': 'Shpejtësia mesatare',
@@ -165,10 +168,13 @@ export const wmSQ = {
   'Carica': 'Ngarko',
   'Aggiornamento effettuato con successo': 'Përditësimi u krye me sukses',
   'Ops!': 'Ops!',
-  'Non è stato possibile aggiornare, riprova più tardi': 'Nuk ishte e mundur të përditësohej, provoni përsëri më vonë',
+  'Non è stato possibile aggiornare, riprova più tardi':
+    'Nuk ishte e mundur të përditësohej, provoni përsëri më vonë',
   'Eliminazione effettuata con successo': 'Fshirja u krye me sukses',
-  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.': 'Are you sure you want to delete this POI? The removal is irreversible.',
-  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.': 'A jeni të sigurt që dëshironi të fshini këtë gjurmë? Fshirja është e pakthyeshme.',
+  'Sicuro di voler eliminare questo POI? La rimozione è irreversibile.':
+    'Are you sure you want to delete this POI? The removal is irreversible.',
+  'Sicuro di voler eliminare questa traccia? La rimozione è irreversibile.':
+    'A jeni të sigurt që dëshironi të fshini këtë gjurmë? Fshirja është e pakthyeshme.',
   'Login effettuato con successo': 'Hyrja u krye me sukses',
   'Logout effettuato con successo': 'Shkëputja u krye me sukses',
   'Ottieni indicazioni': 'Merr hulumtime',
@@ -187,4 +193,13 @@ export const wmSQ = {
   'Aggiungi': 'Shto',
   'Foto': 'Foto',
   '(max 3 photo)': '(maks 3 foto)',
+  'salva': 'ruaj',
+  'Il salvataggio è stato completato': 'Ruajtja u krye me sukses',
+  'Stai modificando le coordinate del POI, vuoi continuare?':
+    'Po e ndryshoni koordinatat e POI-s, dëshironi të vazhdohet?',
+  'No': 'No',
+  'Sì': 'Po',
+  'Attenzione': 'Vëmendje',
+  'Disegna': 'Dhëni',
+  'Esci': 'Dil',
 };

--- a/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.ts
+++ b/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   ViewChild,
@@ -122,6 +121,7 @@ export class ModalUgcUploaderComponent {
   }
 
   upload(): void {
+    // TODO: Logica duplicata in draw-track.component.ts
     if (this.selectedFile$.value) {
       this.geohubId$
         .pipe(
@@ -194,14 +194,16 @@ export class ModalUgcUploaderComponent {
       delete feature.properties.id;
       delete feature.properties.uuid;
       delete feature.properties.image_gallery;
-      if(id) {
+      if (id) {
         feature.properties.onwer_id ??= id;
       }
     }
     return feature;
   }
 
-  private _deserializeKmlProperties(feature: WmFeature<LineString | Point>): WmFeature<LineString | Point> {
+  private _deserializeKmlProperties(
+    feature: WmFeature<LineString | Point>,
+  ): WmFeature<LineString | Point> {
     const isValidJSON = (value: string): boolean => {
       try {
         JSON.parse(value);
@@ -312,7 +314,9 @@ export class ModalUgcUploaderComponent {
       .subscribe();
   }
 
-  private _extractWmFeatureFromFeatureCollection(featureCollection: FeatureCollection): WmFeature<LineString | Point> | null {
+  private _extractWmFeatureFromFeatureCollection(
+    featureCollection: FeatureCollection,
+  ): WmFeature<LineString | Point> | null {
     const lineStringGpx = featureCollection?.features?.find(
       feature => feature.geometry?.type === 'LineString',
     ) as WmFeature<LineString>;
@@ -345,7 +349,9 @@ export class ModalUgcUploaderComponent {
         case 'kml':
           const kmlDoc = new DOMParser().parseFromString(content, 'text/xml');
           const kmlConverted = toGeoJSON.kml(kmlDoc);
-          geojsonFeature = this._deserializeKmlProperties(this._extractWmFeatureFromFeatureCollection(kmlConverted));
+          geojsonFeature = this._deserializeKmlProperties(
+            this._extractWmFeatureFromFeatureCollection(kmlConverted),
+          );
           if (!geojsonFeature) {
             return null;
           }

--- a/projects/wm-core/src/store/conf/conf.reducer.ts
+++ b/projects/wm-core/src/store/conf/conf.reducer.ts
@@ -49,6 +49,7 @@ const initialConfState: ICONF = {
     ],
   },
   WEBAPP: {
+    draw_poi_show: false,
     draw_track_show: false,
     editing_inline_show: false,
     splash_screen_show: false,

--- a/projects/wm-core/src/store/conf/conf.selector.ts
+++ b/projects/wm-core/src/store/conf/conf.selector.ts
@@ -106,6 +106,14 @@ export const confTHEMEVariables = createSelector(confTHEME, (theme: ITHEME) =>
   getCSSVariables(theme),
 );
 export const confShowDrawTrack = createSelector(confWEBAPP, state => state.draw_track_show);
+export const confShowDrawPoi = createSelector(confWEBAPP, state => state.draw_poi_show);
+export const confShowDraw = createSelector(
+  confShowDrawPoi,
+  confShowDrawTrack,
+  (drawPoi, drawTrack) => {
+    return drawPoi || drawTrack;
+  },
+);
 export const confShowEditingInline = createSelector(confWEBAPP, state => state.editing_inline_show);
 export const confPOIS = createSelector(confMAP, map => {
   if (map != null && map.pois != null) {
@@ -146,7 +154,10 @@ export const confOPTIONSShowFeaturesInViewport = createSelector(
   state => state.showFeaturesInViewport,
 );
 export const confOPTIONSShowMediaName = createSelector(confOPTIONS, state => state.showMediaName);
-export const confOPTIONSShowEmbeddedHtml = createSelector(confOPTIONS, state => state.showEmbeddedHtml);
+export const confOPTIONSShowEmbeddedHtml = createSelector(
+  confOPTIONS,
+  state => state.showEmbeddedHtml,
+);
 
 const getLayers = (layersID: number[], layers: ILAYER[], tracks: Hit[]): ILAYER[] => {
   return layers

--- a/projects/wm-core/src/store/features/ugc/ugc.actions.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.actions.ts
@@ -102,3 +102,7 @@ export const setCurrentUgcPoiDrawn = createAction(
   '[Ugc] Set current Ugc Poi Drawn',
   props<{currentUgcPoiDrawn: WmFeature<Point> | null}>(),
 );
+export const setCurrentUgcPoiDrawnSuccess = createAction(
+  '[Ugc] Set current Ugc Poi Drawn Success',
+  props<{currentUgcPoiDrawn: WmFeature<Point> | null}>(),
+);

--- a/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
@@ -18,7 +18,7 @@ import {
   currentCustomTrack,
   updateUgcPoiSuccess,
   deleteUgcPoiSuccess,
-  setCurrentUgcPoiDrawn,
+  setCurrentUgcPoiDrawnSuccess,
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {WmFeature} from '@wm-types/feature';
 import {Hit} from '@wm-types/elastic';
@@ -122,7 +122,7 @@ export const UgcReducer = createReducer(
     ...state,
     currentCustomTrack,
   })),
-  on(setCurrentUgcPoiDrawn, (state, {currentUgcPoiDrawn}) => ({
+  on(setCurrentUgcPoiDrawnSuccess, (state, {currentUgcPoiDrawn}) => ({
     ...state,
     currentUgcPoiDrawn,
   })),

--- a/projects/wm-core/src/store/features/ugc/ugc.selector.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.selector.ts
@@ -56,3 +56,10 @@ export const currentUgcPoiDrawn = createSelector(
 export const currentUgcPoiDrawnGeometry = createSelector(currentUgcPoiDrawn, currentUgcPoiDrawn => {
   return currentUgcPoiDrawn?.geometry ?? null;
 });
+export const currentUgcDrawn = createSelector(
+  currentCustomTrack,
+  currentUgcPoiDrawn,
+  (currentCustomTrack, currentUgcPoiDrawn) => {
+    return currentCustomTrack ?? currentUgcPoiDrawn ?? null;
+  },
+);

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -131,8 +131,10 @@ export const wmMapFeaturesInViewportFailure = createAction(
   '[User Activity] wm map features in viewport failure',
 );
 
-export const startEditUgcPoi = createAction(
-  '[User Activity] start edit ugc poi',
+export const startDrawUgcPoi = createAction(
+  '[User Activity] start draw ugc poi',
   props<{ugcPoi: WmFeature<Point>}>(),
 );
-export const stopEditUgcPoi = createAction('[User Activity] stop edit ugc poi');
+export const stopDrawUgcPoi = createAction('[User Activity] stop edit ugc poi');
+
+export const openLoginModal = createAction('[User Activity] open login modal');

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -1,7 +1,7 @@
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {currentCustomTrack, currentUgcPoi, currentUgcPoiDrawn} from '../features/ugc/ugc.selector';
 import {UserActivityState} from './user-activity.reducer';
-import {confFlowLineQuote} from '../conf/conf.selector';
+import {confFlowLineQuote, confPOIFORMS, confTRACKFORMS} from '../conf/conf.selector';
 import {WmSlopeChartFlowLineQuote} from '@wm-types/slope-chart';
 
 export const userActivity = createFeatureSelector<UserActivityState>('user-activity');
@@ -196,4 +196,13 @@ export const featuresInViewport = createSelector(userActivity, state => state.fe
 export const hasFeatureInViewport = createSelector(
   featuresInViewport,
   featuresInViewport => featuresInViewport && featuresInViewport.length > 0,
+);
+
+export const currentDrawFormType = createSelector(
+  confTRACKFORMS,
+  confPOIFORMS,
+  hasCustomTrack,
+  (trackForms, poiForms, hasCustomTrack) => {
+    return hasCustomTrack ? trackForms : poiForms;
+  },
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -1,5 +1,5 @@
 import {createFeatureSelector, createSelector} from '@ngrx/store';
-import {currentCustomTrack} from '../features/ugc/ugc.selector';
+import {currentCustomTrack, currentUgcPoi, currentUgcPoiDrawn} from '../features/ugc/ugc.selector';
 import {UserActivityState} from './user-activity.reducer';
 import {confFlowLineQuote} from '../conf/conf.selector';
 import {WmSlopeChartFlowLineQuote} from '@wm-types/slope-chart';
@@ -42,9 +42,15 @@ export const UICurrentPoiId = createSelector(
 export const drawTrackOpened = createSelector(userActivity, state =>
   state && state.drawTrackOpened ? state.drawTrackOpened : false,
 );
-
 export const drawPoiOpened = createSelector(userActivity, state =>
   state && state.drawPoiOpened ? state.drawPoiOpened : false,
+);
+export const drawOpened = createSelector(
+  drawTrackOpened,
+  drawPoiOpened,
+  (drawTrackOpened, drawPoiOpened) => {
+    return drawTrackOpened || drawPoiOpened;
+  },
 );
 
 export const filterTracks = createSelector(userActivity, state => {
@@ -85,9 +91,25 @@ export const loading = createSelector(userActivity, state => {
 });
 export const currentEcLayer = createSelector(userActivity, state => state.layer);
 
-export const homeOpened = createSelector(currentCustomTrack, hasCustomTrack => {
-  return hasCustomTrack == null;
+export const hasCustomPoi = createSelector(
+  currentUgcPoiDrawn,
+  currentUgcPoi,
+  (ugcPoiDrawn, ugcPoi) => {
+    return ugcPoiDrawn != null && ugcPoi == null;
+  },
+);
+
+export const hasCustomTrack = createSelector(currentCustomTrack, currentCustomTrack => {
+  return currentCustomTrack != null;
 });
+
+export const homeOpened = createSelector(
+  hasCustomTrack,
+  hasCustomPoi,
+  (hasCustomTrack, hasCustomPoi) => {
+    return !hasCustomTrack && !hasCustomPoi;
+  },
+);
 export const chartHoverElements = createSelector(userActivity, state => state.chartHoverElements);
 export const currentEcPoiId = createSelector(userActivity, state => state.currentEcPoiId);
 export const onlyPoisFilter = createSelector(

--- a/projects/wm-core/src/types/config.ts
+++ b/projects/wm-core/src/types/config.ts
@@ -439,6 +439,7 @@ export interface ITHEME {
 }
 
 export interface IWEBAPP {
+  draw_poi_show: boolean;
   draw_track_show: boolean;
   editing_inline_show: boolean;
   splash_screen_show: boolean;

--- a/projects/wm-core/src/utils/features.ts
+++ b/projects/wm-core/src/utils/features.ts
@@ -1,5 +1,5 @@
-import {WmFeature} from "@wm-types/feature";
-import {LineString, Point} from "geojson";
+import {WmFeature} from '@wm-types/feature';
+import {LineString, Point} from 'geojson';
 
 //TODO: spostare in wm-types
 export function isValidWmFeature(feature: WmFeature<LineString | Point>): boolean {
@@ -11,4 +11,46 @@ export function isValidWmFeature(feature: WmFeature<LineString | Point>): boolea
     Array.isArray(feature.geometry.coordinates) &&
     feature.geometry.coordinates.length > 0
   );
+}
+
+export function areFeatureGeometriesEqual(
+  feature1: WmFeature<LineString | Point>,
+  feature2: WmFeature<LineString | Point>,
+): boolean {
+  if (!isValidWmFeature(feature1) || !isValidWmFeature(feature2)) {
+    return false;
+  }
+
+  if (feature1.geometry.type !== feature2.geometry.type) {
+    return false;
+  }
+
+  const coords1 = feature1.geometry.coordinates;
+  const coords2 = feature2.geometry.coordinates;
+
+  if (coords1.length !== coords2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < coords1.length; i++) {
+    const coord1 = coords1[i];
+    const coord2 = coords2[i];
+
+    // Per Point, coord1 e coord2 sono array di numeri
+    // Per LineString, coord1 e coord2 sono array di array di numeri
+    if (Array.isArray(coord1) && Array.isArray(coord2)) {
+      if (coord1.length !== coord2.length) {
+        return false;
+      }
+      for (let j = 0; j < coord1.length; j++) {
+        if (coord1[j] !== coord2[j]) {
+          return false;
+        }
+      }
+    } else if (coord1 !== coord2) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -75,6 +75,8 @@ import {ImageDetailComponent} from './image-detail/image-detail.component';
 import {WmFeaturesInViewportComponent} from './features-in-viewport/features-in-viewport.component';
 import {WmDifficultyComponent} from './difficulty/difficulty.component';
 import {WmImagePickerComponent} from './image-picker/image-picker.component';
+import {WmDrawUgcComponent} from './draw-ugc/draw-ugc.component';
+import {WmDrawUgcButtonComponent} from './draw-ugc-button/draw-ugc-button.component';
 export const declarations = [
   WmTabDetailComponent,
   WmTabDescriptionComponent,
@@ -120,6 +122,8 @@ export const declarations = [
   WmFeaturesInViewportComponent,
   WmDifficultyComponent,
   WmImagePickerComponent,
+  WmDrawUgcComponent,
+  WmDrawUgcButtonComponent,
 ];
 const modules = [
   WmSharedModule,


### PR DESCRIPTION
Implemented a new component, `WmDrawUgcButtonComponent`, for drawing user-generated content. This includes buttons to toggle drawing modes (POI and Track) and to handle user authentication for drawing features. Added relevant HTML, SCSS, and TypeScript files for the new component. Updated the map component to use the new drawing button component, replacing the previous draw track button logic.

Additionally, modified the configuration selectors and reducers to manage new states related to drawing features and user activity actions. Updated effects to handle the opening of login modals and dispatching of actions related to drawing features. Updated the configuration interface to include a new property for showing draw POI features.
