### PR TITLE
feat(config): ✨ add show_track_direction_arrow option to IMAP interface oc: 5743

### DIFF
--- a/projects/wm-core/src/types/config.ts
+++ b/projects/wm-core/src/types/config.ts
@@ -291,6 +291,7 @@ export interface IMAP {
   start_end_icons_show?: boolean;
   tiles: {[name: string]: string}[];
   tracks?: any[];
+  show_track_direction_arrow?: boolean;
 }
 
 export interface IMAPATTRIBUTION {


### PR DESCRIPTION
Added a new optional boolean property `show_track_direction_arrow` to the `IMAP` interface. This property allows configuration for displaying direction arrows on tracks.
