### PR TITLE
chore(geolocation): 🌐 integrate current location with store oc:5741

### DIFF
--- a/projects/wm-core/src/get-directions/get-directions.component.ts
+++ b/projects/wm-core/src/get-directions/get-directions.component.ts
@@ -1,21 +1,19 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from "@angular/core";
 import {Store} from "@ngrx/store";
 import {confOPTIONS} from "@wm-core/store/conf/conf.selector";
-import {featureFirstCoordinates} from "@wm-core/store/features/features.selector";
 import {IOPTIONS} from "@wm-core/types/config";
 import {Observable} from "rxjs";
+import {startGetDirections} from "@wm-core/store/user-activity/user-activity.action";
 
 @Component({
   selector: 'wm-get-directions',
   template: `
     <ng-container *ngIf="confOPTIONS$|async as confOPTIONS">
       <ng-container *ngIf="confOPTIONS.showGetDirections">
-        <ng-container *ngIf="coordinates$|async as coordinates">
-          <ion-button color="light" mode="ios" expand="block" (click)="getDirections(coordinates)">
-            <ion-icon src="assets/direction.svg"></ion-icon>
-            <ion-label>{{'Ottieni indicazioni' | wmtrans}}</ion-label>
-          </ion-button>
-        </ng-container>
+        <ion-button color="light" mode="ios" expand="block" (click)="startGetDirections()">
+          <ion-icon src="assets/direction.svg"></ion-icon>
+          <ion-label>{{'Ottieni indicazioni' | wmtrans}}</ion-label>
+        </ion-button>
       </ng-container>
     </ng-container>
   `,
@@ -32,21 +30,20 @@ import {Observable} from "rxjs";
           }
         }
       }
+      ion-modal {
+        --border-radius: 16px;
+      }
     `
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 export class GetDirectionsComponent {
-  coordinates$ = this._store.select(featureFirstCoordinates);
   confOPTIONS$: Observable<IOPTIONS> = this._store.select(confOPTIONS);
 
   constructor(private _store: Store) {}
 
-  getDirections(coordinates: number[]) {
-    if (coordinates && coordinates.length >= 2) {
-      const url = `https://www.google.com/maps/dir/?api=1&destination=${coordinates[1]},${coordinates[0]}`;
-      window.open(url, '_blank');
-    }
+  startGetDirections() {
+    this._store.dispatch(startGetDirections());
   }
 }

--- a/projects/wm-core/src/localization/i18n/de.ts
+++ b/projects/wm-core/src/localization/i18n/de.ts
@@ -198,4 +198,7 @@ export const wmDE = {
   'joelette': 'joelette',
   'mtb': 'MTB',
   'mountain-bike': 'Mountainbike',
+  "Ottieni le indicazioni su Google Maps": "Indikationen auf Google Maps erhalten",
+  "Per il punto di partenza": "Für den Startpunkt",
+  "Per il punto più vicino in linea d'aria": "Für den nächsten Punkt in Luftlinie",
 };

--- a/projects/wm-core/src/localization/i18n/en.ts
+++ b/projects/wm-core/src/localization/i18n/en.ts
@@ -204,4 +204,7 @@ export const wmEN = {
   'joelette': 'joelette',
   'mtb': 'MTB',
   'mountain-bike': 'Mountain bike',
+  "Ottieni le indicazioni su Google Maps": "Get directions on Google Maps",
+  "Per il punto di partenza": "For the start point",
+  "Per il punto più vicino in linea d'aria": "For the nearest point in line of sight",
 };

--- a/projects/wm-core/src/localization/i18n/es.ts
+++ b/projects/wm-core/src/localization/i18n/es.ts
@@ -194,4 +194,7 @@ export const wmES = {
   'joelette': 'Joëlette',
   'mtb': 'MTB',
   'mountain-bike': 'Bicicleta de montaña',
+  "Ottieni le indicazioni su Google Maps": "Obtener indicaciones en Google Maps",
+  "Per il punto di partenza": "Para el punto de partida",
+  "Per il punto più vicino in linea d'aria": "Para el punto más cercano en línea de vista",
 };

--- a/projects/wm-core/src/localization/i18n/fr.ts
+++ b/projects/wm-core/src/localization/i18n/fr.ts
@@ -197,4 +197,7 @@ export const wmFR = {
   'joelette': 'Joëlette',
   'mtb': 'MTB',
   'mountain-bike': 'Vélo de montagne',
+  "Ottieni le indicazioni su Google Maps": "Obtenir des indications sur Google Maps",
+  "Per il punto di partenza": "Pour le point de départ",
+  "Per il punto più vicino in linea d'aria": "Pour le point le plus proche en ligne d'air",
 };

--- a/projects/wm-core/src/localization/i18n/it.ts
+++ b/projects/wm-core/src/localization/i18n/it.ts
@@ -203,4 +203,7 @@ export const wmIT = {
   'joelette': 'Joelette',
   'mtb': 'MTB',
   'mountain-bike': 'Mountain bike',
+  "Ottieni le indicazioni su Google Maps": "Ottieni le indicazioni su Google Maps",
+  "Per il punto di partenza": "Per il punto di partenza",
+  "Per il punto più vicino in linea d'aria": "Per il punto più vicino in linea d'aria",
 };

--- a/projects/wm-core/src/localization/i18n/pr.ts
+++ b/projects/wm-core/src/localization/i18n/pr.ts
@@ -195,4 +195,7 @@ export const wmPR = {
   'joelette': 'Joëlette',
   'mtb': 'MTB',
   'mountain-bike': 'Bicicleta de montaña',
+  "Ottieni le indicazioni su Google Maps": "Obter indicações no Google Maps",
+  "Per il punto di partenza": "Para o ponto de partida",
+  "Per il punto più vicino in linea d'aria": "Para o ponto mais próximo em linha de visão",
 };

--- a/projects/wm-core/src/localization/i18n/sq.ts
+++ b/projects/wm-core/src/localization/i18n/sq.ts
@@ -202,4 +202,7 @@ export const wmSQ = {
   'joelette': 'Joëlette',
   'mtb': 'MTB',
   'mountain-bike': 'Biçikletë malore',
+  "Ottieni le indicazioni su Google Maps": "Merr hulumtime në Google Maps",
+  "Per il punto di partenza": "Për pikën e nisjes",
+  "Per il punto più vicino in linea d'aria": "Për pikën më të afërt në vijë të shikimit",
 };

--- a/projects/wm-core/src/modal-get-directions/modal-get-directions.component.ts
+++ b/projects/wm-core/src/modal-get-directions/modal-get-directions.component.ts
@@ -1,0 +1,64 @@
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from "@angular/core";
+import {Store} from "@ngrx/store";
+import {ModalController} from "@ionic/angular";
+
+@Component({
+  selector: 'wm-modal-get-directions',
+  template: `
+    <ion-content>
+      <ion-label>{{"Ottieni le indicazioni su Google Maps" | wmtrans}}</ion-label>
+      <ion-list lines="none">
+        <ion-item>
+          <ion-button mode="ios"color="light" expand="block" (click)="getDirections('start')">
+            <ion-icon name="flag-outline"></ion-icon>
+            {{"Per il punto di partenza" | wmtrans}}
+          </ion-button>
+        </ion-item>
+        <ion-item>
+          <ion-button mode="ios" color="light" expand="block" (click)="getDirections('nearest')">
+            <ion-icon name="pin-outline"></ion-icon>
+            {{"Per il punto più vicino in linea d'aria" | wmtrans}}
+          </ion-button>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  `,
+  styles: [
+    `
+      wm-modal-get-directions {
+        ion-label {
+          display: block;
+          text-align: center;
+          margin: 16px;
+          padding-top: 10px;
+        }
+        ion-list {
+          ion-item {
+            ion-button {
+              width: 100%;
+              height: 45px;
+              text-transform: none;
+              font-size: 14px;
+              margin-bottom: 16px;
+              --box-shadow: none;
+              --border-radius: 25px;
+
+              ion-icon {
+                margin-right: 12px;
+              }
+            }
+          }
+        }
+      }
+    `
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ModalGetDirectionsComponent {
+  constructor(private _store: Store, private _modalController: ModalController) {}
+
+  getDirections(type: 'start' | 'nearest') {
+    this._modalController.dismiss(type);
+  }
+}

--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -12,7 +12,9 @@ import {WmFeature} from '@wm-types/feature';
 import {DeviceService} from './device.service';
 import {CStopwatch} from '@wm-core/utils/cstopwatch';
 import {getDistance} from 'ol/sphere';
-import {filter, map, startWith, defaultIfEmpty} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
+import {Store} from '@ngrx/store';
+import {setCurrentLocation} from '@wm-core/store/user-activity/user-activity.action';
 
 @Injectable({
   providedIn: 'root',
@@ -34,7 +36,7 @@ export class GeolocationService {
   );
   onRecord$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
-  constructor(private _deviceService: DeviceService) {
+  constructor(private _deviceService: DeviceService, private _store: Store) {
     if (!this._deviceService.isBrowser) {
       App.addListener('appStateChange', async ({isActive}) => {
         if (isActive) {
@@ -227,6 +229,8 @@ export class GeolocationService {
         : this._calculateSpeed(this._currentLocation, location);
     this._currentLocation = location;
     this.onLocationChange.next(location);
+    //TODO: fare refactor utilizzando currentLocation dello store e non onLocationChange
+    this._store.dispatch(setCurrentLocation({location}));
   }
 
   private _getWatcherOptions(accuracy: 'high' | 'low'): WatcherOptions {

--- a/projects/wm-core/src/store/features/features.selector.ts
+++ b/projects/wm-core/src/store/features/features.selector.ts
@@ -21,7 +21,7 @@ import {
   ugcPoiFeatures,
   ugcTracks,
 } from './ugc/ugc.selector';
-import {GeoJSON} from 'ol/format';
+import {getClosestPoint} from '@map-core/utils/geometry';
 
 export const countAll = createSelector(countEcAll, countUgcAll, ugcOpened, (ec, ugc, ugcOpened) =>
   ugcOpened ? ugc : ec,
@@ -72,18 +72,15 @@ export const featureOpened = createSelector(track, poi, (track, poi) => {
 });
 export const trackFirstCoordinates = createSelector(
   track,
+  track => track?.geometry?.coordinates?.[0] ?? null,
+);
+export const trackNearestCoordinates = createSelector(
+  track,
   currentLocation,
   (track, currentLocation) => {
-    const geometry = track?.geometry;
-    if(!geometry) return null;
+    if(!currentLocation) return null;
 
-    if(!currentLocation) return geometry.coordinates?.[0] ?? null;
-
-    const currentCoord: [number, number] = [currentLocation.longitude, currentLocation.latitude];
-    const format = new GeoJSON();
-    const geometryOl = format.readGeometry(geometry);
-
-    return geometryOl.getClosestPoint(currentCoord);
+    return getClosestPoint(track, [currentLocation.longitude, currentLocation.latitude]);
   },
 );
 export const poiFirstCoordinates = createSelector(

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -5,6 +5,7 @@ import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {MultiPolygon, Point} from 'geojson';
 import {mapDetailsStatus} from './user-activity.reducer';
 import {Hit} from '@wm-types/elastic';
+import {Location} from '@capacitor-community/background-geolocation';
 
 export const openUgc = createAction('[User Activity] Open User Generated Content');
 export const closeUgc = createAction('[User Activity] Close User Generated Content');
@@ -119,3 +120,5 @@ export const wmMapFeaturesInViewport = createAction('[User Activity] wm map feat
 export const wmMapFeaturesInViewportSuccess = createAction('[User Activity] wm map features in viewport success', props<{featuresInViewport: Hit[]}>());
 export const wmMapFeaturesInViewportFailure = createAction('[User Activity] wm map features in viewport failure');
 export const setHomeResultTabSelected = createAction('[User Activity] set home result tab selected', props<{tab: 'tracks' | 'pois' | null}>());
+
+export const setCurrentLocation = createAction('[User Activity] set current location', props<{location: Location}>());

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -122,3 +122,6 @@ export const wmMapFeaturesInViewportFailure = createAction('[User Activity] wm m
 export const setHomeResultTabSelected = createAction('[User Activity] set home result tab selected', props<{tab: 'tracks' | 'pois' | null}>());
 
 export const setCurrentLocation = createAction('[User Activity] set current location', props<{location: Location}>());
+
+export const startGetDirections = createAction('[User Activity] get directions');
+export const getDirections = createAction('[User Activity] get directions success', props<{coordinates: number[]}>());

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -28,10 +28,12 @@ import {
   loadHitmapFeaturesSuccess,
   wmMapFeaturesInViewportSuccess,
   setHomeResultTabSelected,
+  setCurrentLocation,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {Hit} from '@wm-types/elastic';
+import {Location} from '@capacitor-community/background-geolocation';
 
 export const key = 'userActivity';
 export type mapDetailsStatus = 'open' | 'onlyTitle' | 'background' | 'full';
@@ -56,6 +58,7 @@ export interface UserActivityState {
   featuresInViewport: Hit[];
   wmMapHitmapFeatures: WmFeature<MultiPolygon>[];
   homeResultTabSelected: 'tracks' | 'pois' | null;
+  currentLocation?: Location;
 }
 
 export interface UserAcitivityRootState {
@@ -294,6 +297,13 @@ export const userActivityReducer = createReducer(
     return {
       ...state,
       homeResultTabSelected: tab,
+    };
+  }),
+
+  on(setCurrentLocation, (state, {location}) => {
+    return {
+      ...state,
+      currentLocation: location,
     };
   }),
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -175,3 +175,5 @@ export const homeResultTabSelected = createSelector(
   userActivity,
   state => state.homeResultTabSelected,
 );
+
+export const currentLocation = createSelector(userActivity, state => state.currentLocation);

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -75,6 +75,7 @@ import {ImageDetailComponent} from './image-detail/image-detail.component';
 import {WmFeaturesInViewportComponent} from './features-in-viewport/features-in-viewport.component';
 import {WmDifficultyComponent} from './difficulty/difficulty.component';
 import {WmImagePickerComponent} from './image-picker/image-picker.component';
+import {ModalGetDirectionsComponent} from './modal-get-directions/modal-get-directions.component';
 export const declarations = [
   WmTabDetailComponent,
   WmTabDescriptionComponent,
@@ -120,6 +121,7 @@ export const declarations = [
   WmFeaturesInViewportComponent,
   WmDifficultyComponent,
   WmImagePickerComponent,
+  ModalGetDirectionsComponent,
 ];
 const modules = [
   WmSharedModule,


### PR DESCRIPTION
Added functionality to dispatch the current location to the store using NgRx. This allows for better state management of the geolocation data.

- Removed unused `defaultIfEmpty` import from `rxjs/operators`.
- Added `setCurrentLocation` action in `user-activity.action.ts`.
- Updated `UserActivityState` and `userActivityReducer` to include `currentLocation`.
- Modified selectors to use the current location from the store.
- Updated `GeolocationService` to dispatch the current location to the store when it changes.

TODO: Refactor to use the `currentLocation` from the store instead of `onLocationChange`.
