### PR TITLE
feat(map): ✨ add zoom features in viewport functionality oc:5742

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -31,6 +31,7 @@
     [wmMapLayerEnableFeaturesInViewport]="confOPTIONSShowFeaturesInViewport$|async"
     [wmMapLayerShowFeaturesInViewport]="showFeaturesInViewport$|async"
     [wmMapLayerDisableLayers]="wmMapEcTracksDisableLayer$|async"
+    [wmMapLayerZoomFeaturesInViewport]="zoomFeaturesInViewport$|async"
     (colorSelectedFromLayerEVT)="trackColor$.next($event)"
     (featuresInViewportEVT)="featuresInViewport($event)"
     wmMapPois

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -18,6 +18,7 @@ import {
   confMAP,
   confMAPLAYERS,
   confOPTIONS,
+  confZoomFeaturesInViewport,
 } from '@wm-core/store/conf/conf.selector';
 import {
   allEcpoiFeatures,
@@ -110,6 +111,7 @@ import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
 import {EnvironmentService} from '@wm-core/services/environment.service';
 import {FeatureLike} from 'ol/Feature';
+import {ZoomFeaturesInViewport} from '@wm-types/config';
 
 const initPadding = [10, 10, 10, 10];
 const initMenuOpened = true;
@@ -250,6 +252,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
     wmMapHitMapChangeFeatureId,
   );
   wmBackOfMapDetails$: Observable<boolean> = this._actions$.pipe(ofType(backOfMapDetails));
+  zoomFeaturesInViewport$: Observable<ZoomFeaturesInViewport> = this._store.select(confZoomFeaturesInViewport);
   constructor(
     private _route: ActivatedRoute,
     private _cdr: ChangeDetectorRef,

--- a/projects/wm-core/src/store/conf/conf.selector.ts
+++ b/projects/wm-core/src/store/conf/conf.selector.ts
@@ -148,6 +148,15 @@ export const confOPTIONSShowFeaturesInViewport = createSelector(
 export const confOPTIONSShowMediaName = createSelector(confOPTIONS, state => state.showMediaName);
 export const confOPTIONSShowEmbeddedHtml = createSelector(confOPTIONS, state => state.showEmbeddedHtml);
 
+export const confZoomFeaturesInViewport = createSelector(confOPTIONS, state => {
+  const minZoomFeaturesInViewport = state.minZoomFeaturesInViewport;
+  const maxZoomFeaturesInViewport = state.maxZoomFeaturesInViewport;
+  return {
+    minZoomFeaturesInViewport,
+    maxZoomFeaturesInViewport,
+  }
+});
+
 const getLayers = (layersID: number[], layers: ILAYER[], tracks: Hit[]): ILAYER[] => {
   return layers
     .filter(l => layersID.indexOf(+l.id) > -1)

--- a/projects/wm-core/src/types/config.ts
+++ b/projects/wm-core/src/types/config.ts
@@ -323,7 +323,9 @@ export interface IOPTIONS {
   highlightReadMoreButton: boolean;
   mapAttributions?: IMAPATTRIBUTION[];
   maxFitZoom?: number;
+  maxZoomFeaturesInViewport?: number;
   minDynamicOverlayLayersZoom: number;
+  minZoomFeaturesInViewport?: number;
   passwordRecoveryUrl: string;
   poiIconRadius: number;
   poiIconZoom: number;


### PR DESCRIPTION
Introduced the ability to zoom features within the viewport in the Geobox Map component.

- Added `[wmMapLayerZoomFeaturesInViewport]` binding to the HTML template.
- Implemented `zoomFeaturesInViewport$` observable in the component TypeScript file.
- Created a `confZoomFeaturesInViewport` selector to fetch min and max zoom settings from the store.
- Updated the `IOPTIONS` interface to include `maxZoomFeaturesInViewport` and `minZoomFeaturesInViewport` properties.

This enhancement allows for better control over feature visibility at different zoom levels, enhancing the user's map interaction experience.
