### PR TITLE
chore(localForage): 🔧 remove unused synchronizedEctrack.clear() call oc: 5673

### DIFF
--- a/projects/wm-core/src/utils/localForage.ts
+++ b/projects/wm-core/src/utils/localForage.ts
@@ -6,7 +6,6 @@ import {IUser} from '@wm-core/store/auth/auth.model';
 
 export async function clearUgcData(): Promise<void> {
   await Promise.all([
-    synchronizedEctrack.clear(),
     synchronizedImg.clear(),
     synchronizedUgcTrack.clear(),
     synchronizedUgcPoi.clear(),


### PR DESCRIPTION
Removed the `synchronizedEctrack.clear()` call from the `clearUgcData` function as it is not being used. This change helps in cleaning up the code by removing redundant operations.
