### PR TITLE
chore(geobox-map): ✨ add map controls support oc:5248

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -5,6 +5,7 @@
     [wmMapPadding]="mapPadding$|async"
     [wmMapFilters]="apiElasticState$|async"
     [wmMapTranslationCallback]="translationCallback"
+    [wmMapEnableMapControls]="true"
     (wmMapOverlayEVT$)="setWmMapFeatureCollection($event)"
     [wmMapFeatureCollection]="(wmMapFeatureCollectionOverlay$|async)!= null"
     [wmMapFeatureCollectionOverlayUnselect]="wmBackOfMapDetails$|async"


### PR DESCRIPTION
Enabled map controls by adding the `wmMapEnableMapControls` binding to the component template. This enhancement provides users with additional interactive options on the geobox map, improving the overall user experience.
