### PR TITLE
chore(image-picker): ✨ add readonlyPhotos support and improve photo handling oc:5240

### DIFF
--- a/projects/wm-core/src/image-picker/image-picker.component.html
+++ b/projects/wm-core/src/image-picker/image-picker.component.html
@@ -67,6 +67,7 @@
     <ion-col size="4" *ngFor="let image of photos;let idx = index">
       <div class="wm-image-picker-imagecontainer">
         <ion-icon
+          *ngIf="image?.id == null"
           name="close-outline"
           class="wm-image-picker-remove"
           (click)="remove(idx)"

--- a/projects/wm-core/src/image-picker/image-picker.component.ts
+++ b/projects/wm-core/src/image-picker/image-picker.component.ts
@@ -3,6 +3,7 @@ import {Photo} from '@capacitor/camera';
 import {Md5} from 'ts-md5';
 import {CameraService} from '@wm-core/services/camera.service';
 import {BehaviorSubject} from 'rxjs';
+import {Media} from '@wm-types/feature';
 import {MAX_PHOTOS} from '@wm-core/constants/media';
 
 @Component({
@@ -17,9 +18,15 @@ export class WmImagePickerComponent {
   @Output() startAddPhotos = new EventEmitter<void>();
   @Output() endAddPhotos = new EventEmitter<void>();
   @Input() maxPhotos = MAX_PHOTOS;
+  @Input() set readonlyPhotos(readonlyPhotos: Media[]) {
+    this.photos.next([
+      ...this.photos.value,
+      ...readonlyPhotos,
+    ]);
+  }
 
-  photos: BehaviorSubject<Photo[]> = new BehaviorSubject<Photo[]>([]);
-
+  photos: BehaviorSubject<Media[]> = new BehaviorSubject<Media[]>([]);
+  showPhotos$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor(private _cameraSvc: CameraService, private _cdr: ChangeDetectorRef) {}
 
@@ -35,6 +42,9 @@ export class WmImagePickerComponent {
 
         let exists: boolean = false;
         for (let p of this.photos.value) {
+          if (p.id) {
+            continue;
+          }
           const pData = await this._cameraSvc.getPhotoData(p.webPath);
           const pictureMd5 = Md5.hashStr(JSON.stringify(pData));
           if (md5 === pictureMd5) {

--- a/projects/wm-core/src/store/features/ugc/ugc.service.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.service.ts
@@ -340,17 +340,25 @@ export class UgcService {
     }
   }
 
-  updateApiPoi(poi: WmFeature<Point>): Observable<any> {
-    return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/poi/edit`, poi);
+  async updateApiPoi(poi: WmFeature<Point>): Promise<any> {
+    if (poi != null) {
+      const data = await this._buildFormData(poi);
+      return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/poi/edit`, data).toPromise();
+    }
+    return Promise.resolve(null);
   }
 
-  updateApiTrack(track: WmFeature<LineString>): Observable<any> {
-    return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/track/edit`, track);
+  async updateApiTrack(track: WmFeature<LineString>): Promise<any> {
+    if (track != null) {
+      const data = await this._buildFormData(track);
+      return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/track/edit`, data).toPromise();
+    }
+    return Promise.resolve(null);
   }
 
   private async _buildFormData(feature: WmFeature<LineString | Point>): Promise<FormData> {
     const {properties} = feature;
-    const photoFeatures = properties?.media ?? [];
+    const photoFeatures = properties?.media?.filter(p => !p.id) ?? [];
     const data = new FormData();
     data.append('feature', JSON.stringify(feature));
     for (let [index, photo] of photoFeatures.entries()) {

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.html
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.html
@@ -11,12 +11,17 @@
     </ion-toolbar>
   </ion-header>
   <div #content id="wm-ugc-poi-details-content">
-    <wm-form
-      *ngIf="isEditing$|async; else viewData"
-      [confPOIFORMS]="confPOIFORMS$|async"
-      [init]="currentUgcPoiProperties?.form"
-      (formGroupEvt)="fg = $event"
-    ></wm-form>
+    <ng-container *ngIf="isEditing$|async; else viewData">
+      <wm-form
+        [confPOIFORMS]="confPOIFORMS$|async"
+        [init]="currentUgcPoiProperties?.form"
+        (formGroupEvt)="fg = $event"
+      ></wm-form>
+      <wm-image-picker
+        [readonlyPhotos]="currentUgcPoiProperties?.media ?? []"
+        (photosChanged)="photosChanged($event)"
+      ></wm-image-picker>
+    </ng-container>
     <ng-template #viewData>
       <ng-container *ngIf="currentUgcPoiProperties?.form as form">
         <wm-form

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
@@ -12,7 +12,7 @@ import {Store} from '@ngrx/store';
 import {BehaviorSubject, from, Observable, of} from 'rxjs';
 import {switchMap, take} from 'rxjs/operators';
 import {Point} from 'geojson';
-import {WmFeature} from '@wm-types/feature';
+import {Media, WmFeature} from '@wm-types/feature';
 import {LangService} from '@wm-core/localization/lang.service';
 import {deleteUgcPoi, updateUgcPoi} from '@wm-core/store/features/ugc/ugc.actions';
 import {UntypedFormGroup} from '@angular/forms';
@@ -39,6 +39,8 @@ export class UgcPoiPropertiesComponent {
   currentUgcPoiProperties$ = this._store.select(currentUgcPoiProperties);
   fg: UntypedFormGroup;
   isEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  private _photos: Media[] = [];
 
   slideOptions = {
     allowTouchMove: false,
@@ -105,6 +107,7 @@ export class UgcPoiPropertiesComponent {
             name: this.fg.value.title,
             form: this.fg.value,
             updatedAt: new Date(),
+            media: this._photos ?? currentUgcPoi?.properties?.media ?? [],
           },
         };
 
@@ -112,5 +115,9 @@ export class UgcPoiPropertiesComponent {
         this.isEditing$.next(false);
       }
     });
+  }
+
+  photosChanged(photos: Media[]): void {
+    this._photos = photos;
   }
 }

--- a/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.html
+++ b/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.html
@@ -15,13 +15,17 @@
     </ion-toolbar>
   </ion-header>
   <div #content id="wm-ugc-track-details-content">
-    <wm-form
-      *ngIf="isEditing$|async; else viewData"
-      [confPOIFORMS]="confTRACKFORMS$|async"
-      [init]="track?.properties?.form"
-      (formGroupEvt)="fg = $event"
-    ></wm-form>
-
+    <ng-container *ngIf="isEditing$|async; else viewData">
+      <wm-form
+        [confPOIFORMS]="confTRACKFORMS$|async"
+        [init]="track?.properties?.form"
+        (formGroupEvt)="fg = $event"
+      ></wm-form>
+      <wm-image-picker
+        [readonlyPhotos]="track?.properties?.media ?? []"
+        (photosChanged)="photosChanged($event)"
+      ></wm-image-picker>
+    </ng-container>
     <ng-template #viewData>
       <wm-slope-chart
         *ngIf="track != null"

--- a/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
+++ b/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
@@ -14,7 +14,7 @@ import {Store} from '@ngrx/store';
 import {BehaviorSubject, from, Observable} from 'rxjs';
 import {tap} from 'rxjs/operators';
 import {LineString} from 'geojson';
-import {WmFeature} from '@wm-types/feature';
+import {Media, WmFeature} from '@wm-types/feature';
 import {LangService} from '@wm-core/localization/lang.service';
 import {deleteUgcTrack, updateUgcTrack} from '@wm-core/store/features/ugc/ugc.actions';
 import {UntypedFormGroup} from '@angular/forms';
@@ -60,6 +60,8 @@ export class UgcTrackPropertiesComponent {
     loop: true,
   };
   track: WmFeature<LineString>;
+
+  private _photos: Media[] = [];
 
   constructor(
     private _store: Store,
@@ -114,6 +116,10 @@ export class UgcTrackPropertiesComponent {
     this._store.dispatch(trackElevationChartHoverElemenents({elements: event}));
   }
 
+  photosChanged(photos: Media[]): void {
+    this._photos = photos;
+  }
+
   removeUgcTrackFromUrl(): void {
     this._urlHandlerSvc.updateURL({ugc_track: undefined});
   }
@@ -131,6 +137,7 @@ export class UgcTrackPropertiesComponent {
           ...this.track?.properties,
           name: this.fg.value.title,
           form: this.fg.value,
+          media: this._photos ?? this.track?.properties?.media ?? [],
           updatedAt: new Date(),
         },
       };


### PR DESCRIPTION
Enhanced the `WmImagePickerComponent` to support `readonlyPhotos` input, allowing pre-existing photos to be displayed and managed separately from newly added photos. This ensures that photos with an `id` are treated as immutable and not duplicated when adding new photos.

Changes include:
- Updated `image-picker.component.html` to conditionally display the remove icon only for photos without an `id`.
- Introduced `readonlyPhotos` input and a `showPhotos$` observable for better photo management in `image-picker.component.ts`.
- Modified `ugc.service.ts` to filter out photos with an `id` before processing.
- Updated UGC POI and Track property components to integrate the image picker with the new `readonlyPhotos` functionality, ensuring that `media` property is correctly updated with changes.

This enhancement allows for a seamless integration of existing photos with new additions, providing a more robust user experience when managing images.
