### PR TITLE
chore(image-picker): ✨ add readonlyPhotos support and improve photo handling oc:5240

### DIFF
--- a/projects/wm-core/src/image-picker/image-picker.component.html
+++ b/projects/wm-core/src/image-picker/image-picker.component.html
@@ -69,9 +69,10 @@
         <ion-icon
           name="close-outline"
           class="wm-image-picker-remove"
-          (click)="remove(idx)"
+          (click)="remove(idx, image)"
         >
         </ion-icon>
+        <wm-ugc-synchronized-badge [properties]="image"></wm-ugc-synchronized-badge>
         <ng-container *ngIf="image as photoProp">
           <wm-img
             class="wm-image-picker-image"

--- a/projects/wm-core/src/image-picker/image-picker.component.scss
+++ b/projects/wm-core/src/image-picker/image-picker.component.scss
@@ -70,6 +70,21 @@ wm-image-picker {
       z-index: 1;
     }
 
+    wm-ugc-synchronized-badge {
+      display: flex;
+      position: absolute;
+      bottom: 5px;
+      right: 5px;
+      background: white;
+      padding: 2px;
+      border-radius: 50%;
+      z-index: 1;
+      > ion-icon {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
     .wm-image-picker-add {
       font-size: 45px;
       color: var(--wm-color-dark);

--- a/projects/wm-core/src/image-picker/image-picker.component.ts
+++ b/projects/wm-core/src/image-picker/image-picker.component.ts
@@ -1,9 +1,13 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, ViewEncapsulation, OnDestroy} from '@angular/core';
 import {Photo} from '@capacitor/camera';
 import {Md5} from 'ts-md5';
 import {CameraService} from '@wm-core/services/camera.service';
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, combineLatest, Subscription} from 'rxjs';
+import {map} from 'rxjs/operators';
+import {Media} from '@wm-types/feature';
 import {MAX_PHOTOS} from '@wm-core/constants/media';
+import { Store } from '@ngrx/store';
+import { deleteUgcMedia } from '@wm-core/store/features/ugc/ugc.actions';
 
 @Component({
   selector: 'wm-image-picker',
@@ -12,16 +16,32 @@ import {MAX_PHOTOS} from '@wm-core/constants/media';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
-export class WmImagePickerComponent {
+export class WmImagePickerComponent implements OnDestroy {
   @Output() photosChanged = new EventEmitter<Photo[]>();
   @Output() startAddPhotos = new EventEmitter<void>();
   @Output() endAddPhotos = new EventEmitter<void>();
   @Input() maxPhotos = MAX_PHOTOS;
+  @Input() set synchronizedPhotos(synchronizedPhotos: Media[]) {
+    this._synchronizedPhotos$.next(synchronizedPhotos);
+  }
 
-  photos: BehaviorSubject<Photo[]> = new BehaviorSubject<Photo[]>([]);
+  private _synchronizedPhotos$ = new BehaviorSubject<Media[]>([]);
+  private _localPhotos$ = new BehaviorSubject<Media[]>([]);
+  private _combinedPhotosSubscription$: Subscription;
 
+  photos: BehaviorSubject<Media[]> = new BehaviorSubject<Media[]>([]);
 
-  constructor(private _cameraSvc: CameraService, private _cdr: ChangeDetectorRef) {}
+  constructor(private _cameraSvc: CameraService, private _cdr: ChangeDetectorRef, private _store: Store) {
+    this._combinedPhotosSubscription$ = combineLatest([
+      this._localPhotos$,
+      this._synchronizedPhotos$
+    ]).pipe(
+      map(([localPhotos, synchronizedPhotos]) => [...localPhotos, ...synchronizedPhotos])
+    ).subscribe(combinedPhotos => {
+      this.photos.next(combinedPhotos);
+      this.photosChanged.emit(combinedPhotos);
+    });
+  }
 
   async addPhotosFromLibrary(): Promise<void> {
     this.startAddPhotos.emit();
@@ -34,7 +54,11 @@ export class WmImagePickerComponent {
         const md5 = Md5.hashStr(JSON.stringify(photoData));
 
         let exists: boolean = false;
-        for (let p of this.photos.value) {
+        const currentLocalPhotos = this._localPhotos$.value;
+        for (let p of currentLocalPhotos) {
+          if (p.id) {
+            continue;
+          }
           const pData = await this._cameraSvc.getPhotoData(p.webPath);
           const pictureMd5 = Md5.hashStr(JSON.stringify(pData));
           if (md5 === pictureMd5) {
@@ -43,27 +67,37 @@ export class WmImagePickerComponent {
           }
         }
 
-        if (this.photos.value.length < this.maxPhotos && !exists) {
-          this.photos.next([...this.photos.value, libraryItemCopy]);
-          this.photosChanged.emit(this.photos.value);
+        if (currentLocalPhotos.length < this.maxPhotos && !exists) {
+          this._localPhotos$.next([...currentLocalPhotos, libraryItemCopy]);
         }
       }),
     );
 
     this.endAddPhotos.emit();
-    this._cdr.detectChanges(); // Forza il refresh della view per abilitare il pulsante di salvataggio
   }
 
   async takePhoto(): Promise<void> {
     const photo = await this._cameraSvc.shotPhoto();
-    this.photos.next([...this.photos.value, photo]);
-    this.photosChanged.emit(this.photos.value);
+    const currentLocalPhotos = this._localPhotos$.value;
+    this._localPhotos$.next([...currentLocalPhotos, photo]);
   }
 
-  remove(idx: number): void {
+  remove(idx: number, media: Media): void {
     if (idx > -1) {
-      this.photos.next(this.photos.value.filter((_, i) => i !== idx));
-      this.photosChanged.emit(this.photos.value);
+      if (media.id) {
+        this._store.dispatch(deleteUgcMedia({media}));
+      } else {
+        const currentLocalPhotos = this._localPhotos$.value;
+        this._localPhotos$.next(
+          currentLocalPhotos.filter((_, i) => i !== idx)
+        );
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this._combinedPhotosSubscription$) {
+      this._combinedPhotosSubscription$.unsubscribe();
     }
   }
 }

--- a/projects/wm-core/src/store/features/ugc/ugc.actions.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.actions.ts
@@ -1,5 +1,5 @@
 import {createAction, props} from '@ngrx/store';
-import {WmFeature} from '@wm-types/feature';
+import {Media, WmFeature} from '@wm-types/feature';
 import {LineString, Point} from 'geojson';
 export const syncUgc = createAction('[Ugc] Sync');
 
@@ -96,4 +96,11 @@ export const updateUgcPoiFailure = createAction(
 export const currentCustomTrack = createAction(
   '[Ugc] Set current Custom Track',
   props<{currentCustomTrack: WmFeature<LineString> | null}>(),
+);
+
+export const deleteUgcMedia = createAction('[Ugc] Delete Ugc Media', props<{media: Media}>());
+export const deleteUgcMediaSuccess = createAction('[Ugc] Delete Ugc Media Success', props<{media: Media}>());
+export const deleteUgcMediaFailure = createAction(
+  '[Ugc] Delete Ugc Media Failure',
+  props<{error: string}>(),
 );

--- a/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
@@ -18,6 +18,7 @@ import {
   currentCustomTrack,
   updateUgcPoiSuccess,
   deleteUgcPoiSuccess,
+  deleteUgcMediaSuccess,
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {WmFeature} from '@wm-types/feature';
 import {Hit} from '@wm-types/elastic';
@@ -119,6 +120,34 @@ export const UgcReducer = createReducer(
     ...state,
     currentCustomTrack,
   })),
+  on(deleteUgcMediaSuccess, (state, {media}) => {
+    if(state.currentUgcPoi) {
+      const ugcPoi = {
+        ...state.currentUgcPoi,
+        properties: {
+          ...state.currentUgcPoi.properties,
+          media: state.currentUgcPoi.properties?.media?.filter(m => m.webPath !== media.webPath) ?? [],
+        },
+      }
+      return {
+        ...state,
+        currentUgcPoi: ugcPoi,
+      };
+    } else if(state.currentUgcTrack) {
+      const ugcTrack = {
+        ...state.currentUgcTrack,
+        properties: {
+          ...state.currentUgcTrack.properties,
+          media: state.currentUgcTrack.properties?.media?.filter(m => m.webPath !== media.webPath) ?? [],
+        },
+      }
+      return {
+        ...state,
+        currentUgcTrack: ugcTrack,
+      };
+    }
+    return state;
+  }),
 );
 export function wmFeatureToHits(features: WmFeature<LineString | Point>[]): Hit[] {
   const hits: Hit[] = [];

--- a/projects/wm-core/src/store/features/ugc/ugc.selector.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.selector.ts
@@ -35,6 +35,10 @@ export const currentUgcTrackProperties = createSelector(
   currentUgcTrack,
   track => track?.properties,
 );
+export const currentUgcTrackId = createSelector(
+  currentUgcTrackProperties,
+  currentUgcTrackProperties => currentUgcTrackProperties?.id ?? currentUgcTrackProperties?.uuid ?? null,
+);
 export const currentUgcPoi = createSelector(ugc, state => state.currentUgcPoi);
 export const currentUgcPoiProperties = createSelector(currentUgcPoi, poi => poi?.properties);
 export const currentUgcPoiId = createSelector(

--- a/projects/wm-core/src/store/features/ugc/ugc.service.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.service.ts
@@ -340,17 +340,25 @@ export class UgcService {
     }
   }
 
-  updateApiPoi(poi: WmFeature<Point>): Observable<any> {
-    return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/poi/edit`, poi);
+  async updateApiPoi(poi: WmFeature<Point>): Promise<any> {
+    if (poi != null) {
+      const data = await this._buildFormData(poi);
+      return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/poi/edit`, data).toPromise();
+    }
+    return Promise.resolve(null);
   }
 
-  updateApiTrack(track: WmFeature<LineString>): Observable<any> {
-    return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/track/edit`, track);
+  async updateApiTrack(track: WmFeature<LineString>): Promise<any> {
+    if (track != null) {
+      const data = await this._buildFormData(track);
+      return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/track/edit`, data).toPromise();
+    }
+    return Promise.resolve(null);
   }
 
   private async _buildFormData(feature: WmFeature<LineString | Point>): Promise<FormData> {
     const {properties} = feature;
-    const photoFeatures = properties?.media ?? [];
+    const photoFeatures = properties?.media?.filter(p => !p.id) ?? [];
     const data = new FormData();
     data.append('feature', JSON.stringify(feature));
     for (let [index, photo] of photoFeatures.entries()) {

--- a/projects/wm-core/src/store/features/ugc/ugc.service.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.service.ts
@@ -343,7 +343,7 @@ export class UgcService {
   async updateApiPoi(poi: WmFeature<Point>): Promise<any> {
     if (poi != null) {
       const data = await this._buildFormData(poi);
-      return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/poi/edit`, data).toPromise();
+      return this._http.post(`${this._environmentSvc.origin}/api/v3/ugc/poi/edit`, data).toPromise();
     }
     return Promise.resolve(null);
   }
@@ -351,7 +351,7 @@ export class UgcService {
   async updateApiTrack(track: WmFeature<LineString>): Promise<any> {
     if (track != null) {
       const data = await this._buildFormData(track);
-      return this._http.post(`${this._environmentSvc.origin}/api/v2/ugc/track/edit`, data).toPromise();
+      return this._http.post(`${this._environmentSvc.origin}/api/v3/ugc/track/edit`, data).toPromise();
     }
     return Promise.resolve(null);
   }

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.html
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.html
@@ -11,12 +11,17 @@
     </ion-toolbar>
   </ion-header>
   <div #content id="wm-ugc-poi-details-content">
-    <wm-form
-      *ngIf="isEditing$|async; else viewData"
-      [confPOIFORMS]="confPOIFORMS$|async"
-      [init]="currentUgcPoiProperties?.form"
-      (formGroupEvt)="fg = $event"
-    ></wm-form>
+    <ng-container *ngIf="isEditing$|async; else viewData">
+      <wm-form
+        [confPOIFORMS]="confPOIFORMS$|async"
+        [init]="currentUgcPoiProperties?.form"
+        (formGroupEvt)="fg = $event"
+      ></wm-form>
+      <wm-image-picker
+        [synchronizedPhotos]="currentUgcPoiProperties?.media ?? []"
+        (photosChanged)="photosChanged($event)"
+      ></wm-image-picker>
+    </ng-container>
     <ng-template #viewData>
       <ng-container *ngIf="currentUgcPoiProperties?.form as form">
         <wm-form

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
@@ -12,7 +12,7 @@ import {Store} from '@ngrx/store';
 import {BehaviorSubject, from, Observable, of} from 'rxjs';
 import {switchMap, take} from 'rxjs/operators';
 import {Point} from 'geojson';
-import {WmFeature} from '@wm-types/feature';
+import {Media, WmFeature} from '@wm-types/feature';
 import {LangService} from '@wm-core/localization/lang.service';
 import {deleteUgcPoi, updateUgcPoi} from '@wm-core/store/features/ugc/ugc.actions';
 import {UntypedFormGroup} from '@angular/forms';
@@ -39,6 +39,8 @@ export class UgcPoiPropertiesComponent {
   currentUgcPoiProperties$ = this._store.select(currentUgcPoiProperties);
   fg: UntypedFormGroup;
   isEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  private _photos: Media[] = [];
 
   slideOptions = {
     allowTouchMove: false,
@@ -105,6 +107,7 @@ export class UgcPoiPropertiesComponent {
             name: this.fg.value.title,
             form: this.fg.value,
             updatedAt: new Date(),
+            media: this._photos ?? currentUgcPoi?.properties?.media ?? [],
           },
         };
 
@@ -112,5 +115,9 @@ export class UgcPoiPropertiesComponent {
         this.isEditing$.next(false);
       }
     });
+  }
+
+  photosChanged(photos: Media[]): void {
+    this._photos = photos;
   }
 }

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
@@ -107,7 +107,7 @@ export class UgcPoiPropertiesComponent {
             name: this.fg.value.title,
             form: this.fg.value,
             updatedAt: new Date(),
-            media: this._photos ?? currentUgcPoi?.properties?.media ?? [],
+            media: this._photos ?? [],
           },
         };
 

--- a/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.html
+++ b/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.html
@@ -15,13 +15,17 @@
     </ion-toolbar>
   </ion-header>
   <div #content id="wm-ugc-track-details-content">
-    <wm-form
-      *ngIf="isEditing$|async; else viewData"
-      [confPOIFORMS]="confTRACKFORMS$|async"
-      [init]="track?.properties?.form"
-      (formGroupEvt)="fg = $event"
-    ></wm-form>
-
+    <ng-container *ngIf="isEditing$|async; else viewData">
+      <wm-form
+        [confPOIFORMS]="confTRACKFORMS$|async"
+        [init]="track?.properties?.form"
+        (formGroupEvt)="fg = $event"
+      ></wm-form>
+      <wm-image-picker
+        [synchronizedPhotos]="track?.properties?.media ?? []"
+        (photosChanged)="photosChanged($event)"
+      ></wm-image-picker>
+    </ng-container>
     <ng-template #viewData>
       <wm-slope-chart
         *ngIf="track != null"

--- a/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
+++ b/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
@@ -137,7 +137,7 @@ export class UgcTrackPropertiesComponent {
           ...this.track?.properties,
           name: this.fg.value.title,
           form: this.fg.value,
-          media: this._photos ?? this.track?.properties?.media ?? [],
+          media: this._photos ?? [],
           updatedAt: new Date(),
         },
       };

--- a/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
+++ b/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
@@ -14,7 +14,7 @@ import {Store} from '@ngrx/store';
 import {BehaviorSubject, from, Observable} from 'rxjs';
 import {tap} from 'rxjs/operators';
 import {LineString} from 'geojson';
-import {WmFeature} from '@wm-types/feature';
+import {Media, WmFeature} from '@wm-types/feature';
 import {LangService} from '@wm-core/localization/lang.service';
 import {deleteUgcTrack, updateUgcTrack} from '@wm-core/store/features/ugc/ugc.actions';
 import {UntypedFormGroup} from '@angular/forms';
@@ -60,6 +60,8 @@ export class UgcTrackPropertiesComponent {
     loop: true,
   };
   track: WmFeature<LineString>;
+
+  private _photos: Media[] = [];
 
   constructor(
     private _store: Store,
@@ -114,6 +116,10 @@ export class UgcTrackPropertiesComponent {
     this._store.dispatch(trackElevationChartHoverElemenents({elements: event}));
   }
 
+  photosChanged(photos: Media[]): void {
+    this._photos = photos;
+  }
+
   removeUgcTrackFromUrl(): void {
     this._urlHandlerSvc.updateURL({ugc_track: undefined});
   }
@@ -131,6 +137,7 @@ export class UgcTrackPropertiesComponent {
           ...this.track?.properties,
           name: this.fg.value.title,
           form: this.fg.value,
+          media: this._photos ?? this.track?.properties?.media ?? [],
           updatedAt: new Date(),
         },
       };


### PR DESCRIPTION
Enhanced the `WmImagePickerComponent` to support `readonlyPhotos` input, allowing pre-existing photos to be displayed and managed separately from newly added photos. This ensures that photos with an `id` are treated as immutable and not duplicated when adding new photos.

Changes include:
- Updated `image-picker.component.html` to conditionally display the remove icon only for photos without an `id`.
- Introduced `readonlyPhotos` input and a `showPhotos$` observable for better photo management in `image-picker.component.ts`.
- Modified `ugc.service.ts` to filter out photos with an `id` before processing.
- Updated UGC POI and Track property components to integrate the image picker with the new `readonlyPhotos` functionality, ensuring that `media` property is correctly updated with changes.

This enhancement allows for a seamless integration of existing photos with new additions, providing a more robust user experience when managing images.

chore(image-picker): ✨ add synchronized badge and delete functionality for UGC media

Updated the image picker component to include a synchronized badge for images and handle deletion of UGC media. Added a new action, effects, and selectors to manage media deletion using NgRx.

- Introduced `synchronizedPhotos` input to handle synchronized media.
- Added `wm-ugc-synchronized-badge` to display a badge on synchronized images.
- Modified the `remove` method to dispatch a `deleteUgcMedia` action for media with an ID.
- Added corresponding NgRx actions: `deleteUgcMedia`, `deleteUgcMediaSuccess`, and `deleteUgcMediaFailure`.
- Implemented effects to handle media deletion API calls and success/failure notifications using Ionic alerts.
- Adjusted selectors to manage current UGC features.

This change enhances the image picker by providing visual feedback for synchronized images and allowing users to delete media with persistence through the backend.

chore(image-picker): ✨ enhance photo management with BehaviorSubject

Introduce `BehaviorSubject` for managing local and synchronized photos separately within the `WmImagePickerComponent`. This approach leverages `combineLatest` to merge both local and synchronized photos streams, ensuring a consolidated view of all photos. The component now implements `OnDestroy` to handle subscription clean-up, preventing memory leaks. Additionally, the logic for adding and removing photos has been updated to interact with the new subjects, ensuring consistent state management.

fix(ugc): 🐛 update UGC reducer and effects for media deletion

Enhance the UGC handling by updating the reducer and effects to properly manage media deletion. When a media item is deleted, the `deleteUgcMediaSuccess` action now carries the media information, allowing the reducer to update the current UGC state accurately. The effects have been adjusted to ensure synchronization actions follow successful deletions, maintaining consistency in the application's state. Additionally, selectors have been introduced to easily access UGC entities' IDs.
