### PR TITLE
fix(auth): 🐛 ensure email is in lowercase during login and signup oc:5238

### DIFF
--- a/projects/wm-core/src/store/auth/auth.effects.ts
+++ b/projects/wm-core/src/store/auth/auth.effects.ts
@@ -67,7 +67,7 @@ export class AuthEffects {
     return this._actions$.pipe(
       ofType(AuthActions.loadSignIns),
       switchMap(action =>
-        this._authSvc.login(action.email, action.password).pipe(
+        this._authSvc.login(action.email?.toLowerCase(), action.password).pipe(
           map(user => {
             saveAuth(user);
             return AuthActions.loadSignInsSuccess({user});
@@ -83,7 +83,7 @@ export class AuthEffects {
     return this._actions$.pipe(
       ofType(AuthActions.loadSignUps),
       switchMap(action =>
-        this._authSvc.signUp(action.name, action.email, action.password).pipe(
+        this._authSvc.signUp(action.name, action.email?.toLowerCase(), action.password).pipe(
           map(user => {
             saveAuth(user);
             return AuthActions.loadSignUpsSuccess({user});

--- a/projects/wm-core/src/store/auth/auth.effects.ts
+++ b/projects/wm-core/src/store/auth/auth.effects.ts
@@ -67,7 +67,7 @@ export class AuthEffects {
     return this._actions$.pipe(
       ofType(AuthActions.loadSignIns),
       switchMap(action =>
-        this._authSvc.login(action.email?.toLowerCase(), action.password).pipe(
+        this._authSvc.login(action.email, action.password).pipe(
           map(user => {
             saveAuth(user);
             return AuthActions.loadSignInsSuccess({user});
@@ -83,7 +83,7 @@ export class AuthEffects {
     return this._actions$.pipe(
       ofType(AuthActions.loadSignUps),
       switchMap(action =>
-        this._authSvc.signUp(action.name, action.email?.toLowerCase(), action.password).pipe(
+        this._authSvc.signUp(action.name, action.email, action.password).pipe(
           map(user => {
             saveAuth(user);
             return AuthActions.loadSignUpsSuccess({user});

--- a/projects/wm-core/src/store/auth/auth.service.ts
+++ b/projects/wm-core/src/store/auth/auth.service.ts
@@ -25,6 +25,8 @@ export class AuthService {
       switchMap(confApp => {
         const sku = confApp.sku;
         const appId = confApp.id ?? confApp.geohubId;
+        email = email?.toLowerCase();
+
         return this._http.post(`${this._environmentSvc.origin}/api/auth/login`, {
           email,
           password,
@@ -49,6 +51,8 @@ export class AuthService {
       switchMap(confApp => {
         const sku = confApp.sku;
         const appId = confApp.id ?? confApp.geohubId;
+        email = email?.toLowerCase();
+
         return this._http.post(`${this._environmentSvc.origin}/api/auth/signup`, {
           name,
           email,


### PR DESCRIPTION
Convert the email to lowercase before passing it to the login and sign-up methods to ensure consistency and prevent issues related to case-sensitivity. This change helps in avoiding potential mismatches or errors when users input their email in different cases.
