### PR TITLE
refactor(home): ♻️ update UGC logic and remove redundant effect oc:5911

### DIFF
--- a/projects/wm-core/src/home/home.component.ts
+++ b/projects/wm-core/src/home/home.component.ts
@@ -30,7 +30,7 @@ import {
   ISLUGBOX,
 } from '@wm-core/types/config';
 import {WmInnerHtmlComponent} from '@wm-core/inner-html/inner-html.component';
-import {countUgcAll} from '@wm-core/store/features/ugc/ugc.selector';
+import {countUgcAll, countUgcTracks} from '@wm-core/store/features/ugc/ugc.selector';
 import {
   currentEcLayer,
   showResult,
@@ -188,6 +188,11 @@ export class WmHomeComponent implements AfterContentInit {
   setUgc(): void {
     this._store.dispatch(openUgc());
     this._store.dispatch(setMapDetailsStatus({status: 'open'}));
+    this._store.select(countUgcTracks).pipe(take(1)).subscribe(countTracks => {
+      if (countTracks > 0) {
+        this._store.dispatch(setHomeResultTabSelected({tab: 'tracks'}));
+      }
+    });
   }
 
   togglePoiFilter(filterIdentifier: string, idx?: number): void {

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -266,13 +266,6 @@ export class UserActivityEffects {
     ),
   );
 
-  setHomeResultTabToTrackWhenOpenUgc$ = createEffect(() =>
-    this._actions$.pipe(
-      ofType(openUgc),
-      map(() => setHomeResultTabSelected({tab: 'tracks'})),
-    ),
-  );
-
   startGetDirections$ = createEffect(() =>
     this._actions$.pipe(
       ofType(startGetDirections),


### PR DESCRIPTION
Revised the `setUgc` method in `home.component.ts` to include a check for the number of UGC tracks. If tracks are present, the "tracks" tab is set as selected. Removed the redundant effect `setHomeResultTabToTrackWhenOpenUgc` from `user-activity.effects.ts` as it is no longer necessary with the updated logic in the component.
