### PR TITLE
refactor(ugc): ♻️ add null check and rename action for clarity oc:5914

### DIFF
--- a/projects/wm-core/src/store/features/ugc/ugc.effects.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.effects.ts
@@ -419,6 +419,7 @@ export class UgcEffects {
   setCurrentUgcPoiDrawn$ = createEffect(() =>
     this._actions$.pipe(
       ofType(setCurrentUgcPoiDrawn),
+      filter(({currentUgcPoiDrawn}) => currentUgcPoiDrawn != null),
       withLatestFrom(this._store.select(currentUgcPoi)),
       switchMap(([{currentUgcPoiDrawn}, currentUgcPoi]) => {
         if (currentUgcPoi && !areFeatureGeometriesEqual(currentUgcPoiDrawn, currentUgcPoi)) {

--- a/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.reducer.ts
@@ -19,7 +19,7 @@ import {
   updateUgcPoiSuccess,
   deleteUgcPoiSuccess,
   deleteUgcMediaSuccess,
-  setCurrentUgcPoiDrawn,
+  setCurrentUgcPoiDrawnSuccess,
 } from '@wm-core/store/features/ugc/ugc.actions';
 import {WmFeature} from '@wm-types/feature';
 import {Hit} from '@wm-types/elastic';
@@ -151,7 +151,7 @@ export const UgcReducer = createReducer(
     }
     return state;
   }),
-  on(setCurrentUgcPoiDrawn, (state, {currentUgcPoiDrawn}) => ({
+  on(setCurrentUgcPoiDrawnSuccess, (state, {currentUgcPoiDrawn}) => ({
     ...state,
     currentUgcPoiDrawn,
   })),


### PR DESCRIPTION
Added a filter to ensure `currentUgcPoiDrawn` is not null before proceeding with the effect in `ugc.effects.ts`. This prevents unnecessary operations when the value is null.

In `ugc.reducer.ts`, renamed the action from `setCurrentUgcPoiDrawn` to `setCurrentUgcPoiDrawnSuccess` for better semantic clarity, reflecting the successful setting of the UGC POI as drawn. This change helps maintain consistency and improves code readability.
