### PR TITLE
chore(ugc): ✨ add EXIF data cleaning feature to remove special characters oc:5926

### DIFF
--- a/projects/wm-core/src/store/features/ugc/ugc.service.ts
+++ b/projects/wm-core/src/store/features/ugc/ugc.service.ts
@@ -380,8 +380,11 @@ export class UgcService {
   }
 
   private _cleanExifData(feature: WmFeature<LineString | Point>): WmFeature<LineString | Point> {
-    if (feature.properties?.media) {
-      feature.properties.media = feature.properties.media.map((media: any) => {
+    // Crea una copia dell'oggetto feature
+    const cleanedFeature = structuredClone(feature);
+
+    if (cleanedFeature.properties?.media) {
+      cleanedFeature.properties.media = cleanedFeature.properties.media.map((media: any) => {
         if (media.exif) {
           // Rimuove caratteri Unicode non validi dai dati EXIF
           const cleanedExif = this._cleanObject(media.exif);
@@ -391,7 +394,7 @@ export class UgcService {
       });
     }
 
-    return feature;
+    return cleanedFeature;
   }
 
   // Funzione ricorsiva per pulire oggetti da caratteri Unicode non validi


### PR DESCRIPTION
Introduced a new method to clean EXIF data from special characters before sending it. This ensures that any Unicode characters which may cause issues are removed. This update includes:

- A `_cleanExifData` method to iterate over media properties and clean EXIF data.
- A `_cleanObject` helper function to recursively clean invalid Unicode characters from strings and objects.
