### PR TITLE
chore(map): 🗺️ add focus position and recording panel functionality oc: 5239

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -20,7 +20,7 @@
     wmMapPosition
     [wmMapPositioncurrentLocation]="currentPosition$|async"
     [wmMapPositionCenter]="centerPositionEvt$|async"
-    [wmMapPositionfocus]="focusPosition$|async"
+    [wmMapPositionfocus]="wmMapPositionfocus$|async"
     wmMapCustomTracks
     [wmMapCustomTrackDrawTrack]="drawTrackOpened$|async"
     [wmMapCustomTrackDrawTrackHost]="graphhopperHost$|async"

--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -3,6 +3,7 @@
     #wmap
     [wmMapConf]="confMap$|async"
     [wmMapPadding]="mapPadding$|async"
+    [wmMapDisableFitView]="enableRecoderPanel$|async"
     [wmMapFilters]="apiElasticState$|async"
     [wmMapTranslationCallback]="translationCallback"
     [wmMapEnableMapControls]="true"
@@ -15,10 +16,11 @@
     (wmMapFeatureCollectionLayerSelected)="selectedLayerById($event);wmap.wmMapCloseTopRightBtnsEVT$.emit('')"
     (wmMapFeatureCollectionPopup)="openPopup($event);wmap.wmMapCloseTopRightBtnsEVT$.emit('')"
     (wmMapEmptyClickEVT$)="openPopup(null)"
+    [wmMapGeojson]="(enableRecoderPanel$|async) ? (recordedTrack$|async) : null"
     wmMapPosition
     [wmMapPositioncurrentLocation]="currentPosition$|async"
     [wmMapPositionCenter]="centerPositionEvt$|async"
-    [wmMapPositionfocus]="wmMapPositionfocus$|async"
+    [wmMapPositionfocus]="focusPosition$|async"
     wmMapCustomTracks
     [wmMapCustomTrackDrawTrack]="drawTrackOpened$|async"
     [wmMapCustomTrackDrawTrackHost]="graphhopperHost$|async"

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -179,7 +179,6 @@ export class WmGeoboxMapComponent implements OnDestroy {
   currentPoi$ = this._store.select(poi);
   currentPoiNextID$: BehaviorSubject<number> = new BehaviorSubject<number>(-1);
   currentPoiPrevID$: BehaviorSubject<number> = new BehaviorSubject<number>(-1);
-  focusPosition$: Observable<boolean> = this._store.select(focusPosition);
   currentPosition$: Observable<any> = this._store.select(currentLocation);
   currentRelatedPoi$ = this._store.select(currentEcRelatedPoi);
   currentRelatedPoiID$ = this._store.select(currentEcRelatedPoiId);
@@ -268,7 +267,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
     null,
   );
   wmMapHitMapUrl$: Observable<string | null> = this.confMap$.pipe(map(conf => conf?.hitMapUrl));
-  wmMapPositionfocus$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  wmMapPositionfocus$: Observable<boolean> = this._store.select(focusPosition);
   wmMapUgcDisableLayers$: Observable<boolean>;
   wmMapHitMapChangeFeatureById$: Observable<number> = this._store.select(
     wmMapHitMapChangeFeatureId,
@@ -379,10 +378,10 @@ export class WmGeoboxMapComponent implements OnDestroy {
 
     combineLatest([
       this.currentPosition$.pipe(distinctUntilChanged((prev, curr) => prev?.latitude === curr?.latitude && prev?.longitude === curr?.longitude)),
-      this.focusPosition$.pipe(startWith(false))
-    ]).subscribe(([loc, focusPosition]) => {
+      this.wmMapPositionfocus$.pipe(startWith(false))
+    ]).subscribe(([loc, wmMapPositionfocus]) => {
       if(loc == null) return null;
-      if(focusPosition || this.recordedTrack$.value == null) {
+      if(wmMapPositionfocus || this.recordedTrack$.value == null) {
         const coordinate = fromLonLat([loc.longitude, loc.latitude]);
         this._linestring.appendCoordinate(coordinate);
         const featureCollection = new Collection([new Feature({geometry: this._linestring})]);
@@ -409,14 +408,14 @@ export class WmGeoboxMapComponent implements OnDestroy {
   navigation(): void {
     this._geolocationSvc.startNavigation();
     combineLatest([
-      this.focusPosition$.pipe(take(1)),
+      this.wmMapPositionfocus$.pipe(take(1)),
       this.enableRecoderPanel$.pipe(take(1))
-    ]).subscribe(([focusPosition, enableRecoderPanel]) => {
+    ]).subscribe(([wmMapPositionfocus, enableRecoderPanel]) => {
       let focus = true;
       if(enableRecoderPanel) {
         this.centerPositionEvt$.next((!this.centerPositionEvt$.value)||false)
       } else {
-        focus = !focusPosition
+        focus = !wmMapPositionfocus
       }
       this._store.dispatch(setFocusPosition({focusPosition: focus}));
     });

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -235,6 +235,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
     tap(enable => {
       if(!enable) {
         this._linestring = new olLinestring([]);
+        this.recordedTrack$.next(null);
       }
     })
   );
@@ -378,10 +379,10 @@ export class WmGeoboxMapComponent implements OnDestroy {
 
     combineLatest([
       this.currentPosition$.pipe(distinctUntilChanged((prev, curr) => prev?.latitude === curr?.latitude && prev?.longitude === curr?.longitude)),
-      this.wmMapPositionfocus$.pipe(startWith(false))
-    ]).subscribe(([loc, wmMapPositionfocus]) => {
+      this.enableRecoderPanel$.pipe(startWith(false))
+    ]).subscribe(([loc, enableRecoderPanel]) => {
       if(loc == null) return null;
-      if(wmMapPositionfocus || this.recordedTrack$.value == null) {
+      if(enableRecoderPanel) {
         const coordinate = fromLonLat([loc.longitude, loc.latitude]);
         this._linestring.appendCoordinate(coordinate);
         const featureCollection = new Collection([new Feature({geometry: this._linestring})]);

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -231,14 +231,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
       return poi;
     }),
   );
-  enableRecoderPanel$: Observable<boolean> = this._store.select(enableRecoderPanel).pipe(
-    tap(enable => {
-      if(!enable) {
-        this._linestring = new olLinestring([]);
-        this.recordedTrack$.next(null);
-      }
-    })
-  );
+  enableRecoderPanel$: Observable<boolean> = this._store.select(enableRecoderPanel);
   overlayFeatureCollections$ = this._store.select(hitMapFeatureCollection);
   poiFilterIdentifiers$: Observable<string[]> = this._store.select(poiFilterIdentifiers);
   poiIDs$: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
@@ -376,6 +369,13 @@ export class WmGeoboxMapComponent implements OnDestroy {
       this.isLogged$.pipe(startWith(false)),
       this.toggleUgcDirective$.pipe(startWith(true)),
     ]).pipe(map(([isLogged, toggleUgcDirective]) => !(isLogged && toggleUgcDirective)));
+
+    this.enableRecoderPanel$.subscribe(enable => {
+      if (!enable) {
+        this._linestring = new olLinestring([]);
+        this.recordedTrack$.next(null);
+      }
+    });
 
     combineLatest([
       this.currentPosition$.pipe(distinctUntilChanged((prev, curr) => prev?.latitude === curr?.latitude && prev?.longitude === curr?.longitude)),

--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -194,14 +194,23 @@ export class GeolocationService {
 
   private _startWebWatcher(accuracy: 'high' | 'low'): void {
     this._webWatcherId = navigator.geolocation.watchPosition(
-      res =>
+      res => {
         this._onLocationUpdate({
           latitude: res.coords.latitude,
           longitude: res.coords.longitude,
           altitude: res.coords.altitude ?? 0,
           accuracy: res.coords.accuracy,
           time: res.timestamp,
-        } as any),
+        } as any);
+
+        if (this._mode === 'recording' && this._recordedFeature) {
+          this._recordedFeature.geometry.coordinates.push([
+            res.coords.longitude,
+            res.coords.latitude,
+            res.coords.altitude ?? 0,
+          ]);
+        }
+      },
       () => {},
       {enableHighAccuracy: accuracy === 'high'},
     );

--- a/projects/wm-core/src/store/features/features.selector.ts
+++ b/projects/wm-core/src/store/features/features.selector.ts
@@ -1,7 +1,7 @@
 import {createSelector} from '@ngrx/store';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
-import {currentLocation, ecLayer, ugcOpened} from '../user-activity/user-activity.selector';
+import {currentLocation, ecLayer, enableRecoderPanel, ugcOpened} from '../user-activity/user-activity.selector';
 import {
   countEcAll,
   countEcPois,
@@ -95,7 +95,8 @@ export const featureFirstCoordinates = createSelector(
 export const showFeaturesInViewport = createSelector(
   featureOpened,
   ecLayer,
-  (featureOpened, ecLayer) => {
-    return featureOpened == false && ecLayer == null;
+  enableRecoderPanel,
+  (featureOpened, ecLayer, enableRecoderPanel) => {
+    return featureOpened == false && ecLayer == null && enableRecoderPanel == false;
   },
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -145,3 +145,7 @@ export const setCurrentLocation = createAction('[User Activity] set current loca
 export const startGetDirections = createAction('[User Activity] get directions');
 export const getDirections = createAction('[User Activity] get directions success', props<{coordinates: number[]}>());
 export const openLoginModal = createAction('[User Activity] open login modal');
+
+export const setEnableRecoderPanel = createAction('[User Activity] set enable register panel', props<{enable: boolean}>());
+export const setOnRecord = createAction('[User Activity] set on record', props<{onRecord: boolean}>());
+export const setFocusPosition = createAction('[User Activity] set focus position', props<{focusPosition: boolean}>());

--- a/projects/wm-core/src/store/user-activity/user-activity.effects.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.effects.ts
@@ -24,6 +24,8 @@ import {
   openUgc,
   getDirections,
   startGetDirections,
+  setFocusPosition,
+  setOnRecord,
 } from './user-activity.action';
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
@@ -341,6 +343,13 @@ export class UserActivityEffects {
         ),
       ),
     {dispatch: false},
+  );
+
+  setOnRecord$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(setOnRecord),
+      map(({onRecord}) => setFocusPosition({focusPosition: onRecord})),
+    ),
   );
 
   constructor(

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -30,6 +30,9 @@ import {
   drawPoiOpened,
   setHomeResultTabSelected,
   setCurrentLocation,
+  setEnableRecoderPanel,
+  setOnRecord,
+  setFocusPosition,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
@@ -61,6 +64,9 @@ export interface UserActivityState {
   wmMapHitmapFeatures: WmFeature<MultiPolygon>[];
   homeResultTabSelected: 'tracks' | 'pois' | null;
   currentLocation?: Location;
+  enableRecoderPanel: boolean;
+  onRecord: boolean;
+  focusPosition: boolean;
 }
 
 export interface UserAcitivityRootState {
@@ -83,6 +89,9 @@ const initialState: UserActivityState = {
   wmMapHitmapFeatures: [],
   featuresInViewport: [],
   homeResultTabSelected: 'tracks',
+  enableRecoderPanel: false,
+  onRecord: false,
+  focusPosition: false,
 };
 
 function extractFilterTaxonomies(layer) {
@@ -313,6 +322,27 @@ export const userActivityReducer = createReducer(
     return {
       ...state,
       currentLocation: location,
+    };
+  }),
+
+  on(setEnableRecoderPanel, (state, {enable}) => {
+    return {
+      ...state,
+      enableRecoderPanel: enable,
+    };
+  }),
+
+  on(setOnRecord, (state, {onRecord}) => {
+    return {
+      ...state,
+      onRecord,
+    };
+  }),
+
+  on(setFocusPosition, (state, {focusPosition}) => {
+    return {
+      ...state,
+      focusPosition,
     };
   }),
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -212,3 +212,7 @@ export const currentDrawFormType = createSelector(
     return hasCustomTrack ? trackForms : poiForms;
   },
 );
+
+export const enableRecoderPanel = createSelector(userActivity, state => state.enableRecoderPanel);
+export const onRecord = createSelector(userActivity, state => state.onRecord);
+export const focusPosition = createSelector(userActivity, state => state.focusPosition);


### PR DESCRIPTION
Added new functionalities to the geobox map component including focus position and recording panel toggles. Updated HTML to bind new observables for map control parameters. Refactored TypeScript to manage state and integrate with GeolocationService. Introduced new actions and effects for handling recording state and focus position. Modified reducer and selectors to manage corresponding states.

- Added `[wmMapDisableFitView]` and `[wmMapGeojson]` bindings to HTML.
- Introduced `focusPosition$`, `enableRecoderPanel$`, and `recordedTrack$` observables.
- Updated GeolocationService to dispatch actions for recording state changes.
- Created new actions: `setEnableRecoderPanel`, `setOnRecord`, and `setFocusPosition`.
- Added effects to handle side effects of recording state changes.
- Enhanced reducer and selectors for new states: `enableRecoderPanel`, `onRecord`, and `focusPosition`.

This enhancement allows better user control over focus positioning and track recording within the map interface.
