### PR TITLE
chore(form): ✨ add automatic title capitalization on ionChange event oc:5251

### DIFF
--- a/projects/wm-core/src/form/form.component.html
+++ b/projects/wm-core/src/form/form.component.html
@@ -70,6 +70,7 @@
               [formControlName]="field.name"
               [disabled]="disabled"
               (click)="field.name === 'title' ? selectAllTitleText($event) : null"
+              (ionChange)="field.name === 'title' ? capitalizeTitle($event) : null"
             ></ion-input>
 
             <ion-textarea

--- a/projects/wm-core/src/form/form.component.ts
+++ b/projects/wm-core/src/form/form.component.ts
@@ -139,4 +139,12 @@ export class WmFormComponent implements OnDestroy {
       this._titleFirstClick = false;
     }
   }
+
+  capitalizeTitle(event: any) {
+    const inputValue = event.target.value;
+    if (inputValue && inputValue.length === 1) {
+      const capitalizedValue = inputValue.toUpperCase();
+      this.formGroup.get('title')?.setValue(capitalizedValue, { emitEvent: false });
+    }
+  }
 }


### PR DESCRIPTION
Added a new method `capitalizeTitle` to the `WmFormComponent` to automatically capitalize the first letter of the title field when the `ionChange` event is triggered. This ensures that the title always starts with an uppercase letter if the user starts typing in lowercase. The method updates the form control value without emitting an additional event.
