### PR TITLE
refactor(features-in-viewport): 🔄 make sliderOptions observable oc:6000

### DIFF
--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.html
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="featuresInViewport$ | async as featuresInViewport">
   <ion-slides
-    [options]="sliderOptions"
+    [options]="sliderOptions$|async"
     [ngClass]="{'slide-in': featuresInViewport.length > 0}"
     #slider
   >

--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.ts
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.ts
@@ -18,31 +18,23 @@ export class WmFeaturesInViewportComponent {
 
   constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {
     this.sliderOptions$ = this.featuresInViewport$.pipe(
-      map(features => {
-        if (features.length === 1) {
-          return {
-            slidesPerView: 1.2,
-            spaceBetween: 0,
-            slidesOffsetBefore: 0,
-            slidesOffsetAfter: 0,
-            centeredSlides: true,
-            freeMode: true,
-          };
-        } else {
-          return {
-            slidesPerView: 1.2,
-            spaceBetween: 16,
-            slidesOffsetBefore: 16,
-            slidesOffsetAfter: 16,
-            centeredSlides: false,
-            freeMode: true,
-          };
-        }
-      })
+      map(features => this._getSliderOptions(features.length))
     );
   }
 
   setTrack(id: number): void {
     this._urlHandlerSvc.setTrack(id);
+  }
+
+  private _getSliderOptions(featureCount: number): any {
+    const isSingleFeature = featureCount === 1;
+    return {
+      slidesPerView: 1.2,
+      spaceBetween: isSingleFeature ? 0 : 16,
+      slidesOffsetBefore: isSingleFeature ? 0 : 16,
+      slidesOffsetAfter: isSingleFeature ? 0 : 16,
+      centeredSlides: isSingleFeature,
+      freeMode: true,
+    };
   }
 }

--- a/projects/wm-core/src/features-in-viewport/features-in-viewport.component.ts
+++ b/projects/wm-core/src/features-in-viewport/features-in-viewport.component.ts
@@ -3,6 +3,7 @@ import {Store} from '@ngrx/store';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {featuresInViewport} from '@wm-core/store/user-activity/user-activity.selector';
 import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 
 @Component({
   selector: 'wm-features-in-viewport',
@@ -13,15 +14,33 @@ import {Observable} from 'rxjs';
 })
 export class WmFeaturesInViewportComponent {
   featuresInViewport$: Observable<any[]> = this._store.select(featuresInViewport);
-  sliderOptions: any = {
-    slidesPerView: 1.2,
-    spaceBetween: 16,
-    slidesOffsetBefore: 16,
-    slidesOffsetAfter: 16,
-    freeMode: true,
-  };
+  sliderOptions$: Observable<any>;
 
-  constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {}
+  constructor(private _store: Store, private _urlHandlerSvc: UrlHandlerService) {
+    this.sliderOptions$ = this.featuresInViewport$.pipe(
+      map(features => {
+        if (features.length === 1) {
+          return {
+            slidesPerView: 1.2,
+            spaceBetween: 0,
+            slidesOffsetBefore: 0,
+            slidesOffsetAfter: 0,
+            centeredSlides: true,
+            freeMode: true,
+          };
+        } else {
+          return {
+            slidesPerView: 1.2,
+            spaceBetween: 16,
+            slidesOffsetBefore: 16,
+            slidesOffsetAfter: 16,
+            centeredSlides: false,
+            freeMode: true,
+          };
+        }
+      })
+    );
+  }
 
   setTrack(id: number): void {
     this._urlHandlerSvc.setTrack(id);


### PR DESCRIPTION
Changed sliderOptions to an observable sliderOptions$ to dynamically adjust slide settings based on the number of features in the viewport. This allows for different configurations when there is only one feature compared to multiple features. The adjustment includes changes to properties like `slidesPerView`, `spaceBetween`, `slidesOffsetBefore`, `slidesOffsetAfter`, and `centeredSlides`.
