### PR TITLE
fix(geobox-map): 🐛 correct typo in variable names and add new functionality oc:6003

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -3,7 +3,7 @@
     #wmap
     [wmMapConf]="confMap$|async"
     [wmMapPadding]="mapPadding$|async"
-    [wmMapDisableFitView]="enableRecoderPanel$|async"
+    [wmMapDisableFitView]="enableRecorderPanel$|async"
     [wmMapFilters]="apiElasticState$|async"
     [wmMapTranslationCallback]="translationCallback"
     [wmMapEnableMapControls]="true"
@@ -16,10 +16,11 @@
     (wmMapFeatureCollectionLayerSelected)="selectedLayerById($event);wmap.wmMapCloseTopRightBtnsEVT$.emit('')"
     (wmMapFeatureCollectionPopup)="openPopup($event);wmap.wmMapCloseTopRightBtnsEVT$.emit('')"
     (wmMapEmptyClickEVT$)="openPopup(null)"
-    [wmMapGeojson]="(enableRecoderPanel$|async) ? (recordedTrack$|async) : null"
+    [wmMapGeojson]="(enableTrackRecorderPanel$|async) ? (recordedTrack$|async) : null"
     wmMapPosition
     [wmMapPositioncurrentLocation]="currentPosition$|async"
     [wmMapPositionCenter]="centerPositionEvt$|async"
+    [wmMapPositionZoomCurrentLocation]="enablePoiRecorderPanel$|async"
     [wmMapPositionfocus]="wmMapPositionfocus$|async"
     wmMapCustomTracks
     [wmMapCustomTrackDrawTrack]="drawTrackOpened$|async"

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -82,7 +82,9 @@ import {
   drawPoiOpened,
   drawTrackOpened,
   ecLayer,
-  enableRecoderPanel,
+  enableRecorderPanel,
+  enableTrackRecorderPanel,
+  enablePoiRecorderPanel,
   focusPosition,
   inputTyped,
   loading,
@@ -165,6 +167,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
   authEnable$: Observable<boolean> = this._store.select(confAUTHEnable);
   caretOutLine$: Observable<'caret-back-outline' | 'caret-forward-outline'>;
   centerPositionEvt$: BehaviorSubject<boolean> = new BehaviorSubject<boolean | null>(null);
+  zoomPositionEvt$: BehaviorSubject<boolean> = new BehaviorSubject<boolean | null>(null);
   confHOME$: Observable<IHOME[]> = this._store.select(confHOME);
   confJIDOUPDATETIME$: Observable<any> = this._store.select(confJIDOUPDATETIME);
   confMap$: Observable<any> = this._store.select(confMAP);
@@ -231,7 +234,9 @@ export class WmGeoboxMapComponent implements OnDestroy {
       return poi;
     }),
   );
-  enableRecoderPanel$: Observable<boolean> = this._store.select(enableRecoderPanel);
+  enableTrackRecorderPanel$: Observable<boolean> = this._store.select(enableTrackRecorderPanel);
+  enablePoiRecorderPanel$: Observable<boolean> = this._store.select(enablePoiRecorderPanel);
+  enableRecorderPanel$: Observable<boolean> = this._store.select(enableRecorderPanel);
   overlayFeatureCollections$ = this._store.select(hitMapFeatureCollection);
   poiFilterIdentifiers$: Observable<string[]> = this._store.select(poiFilterIdentifiers);
   poiIDs$: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
@@ -267,7 +272,9 @@ export class WmGeoboxMapComponent implements OnDestroy {
     wmMapHitMapChangeFeatureId,
   );
   wmBackOfMapDetails$: Observable<boolean> = this._actions$.pipe(ofType(backOfMapDetails));
-  zoomFeaturesInViewport$: Observable<ZoomFeaturesInViewport> = this._store.select(confZoomFeaturesInViewport);
+  zoomFeaturesInViewport$: Observable<ZoomFeaturesInViewport> = this._store.select(
+    confZoomFeaturesInViewport,
+  );
   constructor(
     private _route: ActivatedRoute,
     private _cdr: ChangeDetectorRef,
@@ -370,7 +377,7 @@ export class WmGeoboxMapComponent implements OnDestroy {
       this.toggleUgcDirective$.pipe(startWith(true)),
     ]).pipe(map(([isLogged, toggleUgcDirective]) => !(isLogged && toggleUgcDirective)));
 
-    this.enableRecoderPanel$.subscribe(enable => {
+    this.enableTrackRecorderPanel$.subscribe(enable => {
       if (!enable) {
         this._linestring = new olLinestring([]);
         this.recordedTrack$.next(null);
@@ -378,20 +385,24 @@ export class WmGeoboxMapComponent implements OnDestroy {
     });
 
     combineLatest([
-      this.currentPosition$.pipe(distinctUntilChanged((prev, curr) => prev?.latitude === curr?.latitude && prev?.longitude === curr?.longitude)),
-      this.enableRecoderPanel$.pipe(startWith(false))
-    ]).subscribe(([loc, enableRecoderPanel]) => {
-      if(loc == null) return null;
-      if(enableRecoderPanel) {
+      this.currentPosition$.pipe(
+        distinctUntilChanged(
+          (prev, curr) => prev?.latitude === curr?.latitude && prev?.longitude === curr?.longitude,
+        ),
+      ),
+      this.enableTrackRecorderPanel$.pipe(startWith(false)),
+    ]).subscribe(([loc, enableTrackRecorderPanel]) => {
+      if (loc == null) return null;
+      if (enableTrackRecorderPanel) {
         const coordinate = fromLonLat([loc.longitude, loc.latitude]);
         this._linestring.appendCoordinate(coordinate);
         const featureCollection = new Collection([new Feature({geometry: this._linestring})]);
         const geojson = new GeoJSON({featureProjection: 'EPSG:3857'}).writeFeaturesObject(
           featureCollection.getArray(),
         );
-        this.recordedTrack$.next(geojson)
+        this.recordedTrack$.next(geojson);
       }
-    })
+    });
   }
 
   featuresInViewport(features: FeatureLike[]): void {
@@ -410,13 +421,13 @@ export class WmGeoboxMapComponent implements OnDestroy {
     this._geolocationSvc.startNavigation();
     combineLatest([
       this.wmMapPositionfocus$.pipe(take(1)),
-      this.enableRecoderPanel$.pipe(take(1))
-    ]).subscribe(([wmMapPositionfocus, enableRecoderPanel]) => {
+      this.enableTrackRecorderPanel$.pipe(take(1)),
+    ]).subscribe(([wmMapPositionfocus, enableTrackRecorderPanel]) => {
       let focus = true;
-      if(enableRecoderPanel) {
-        this.centerPositionEvt$.next((!this.centerPositionEvt$.value)||false)
+      if (enableTrackRecorderPanel) {
+        this.centerPositionEvt$.next(!this.centerPositionEvt$.value || false);
       } else {
-        focus = !wmMapPositionfocus
+        focus = !wmMapPositionfocus;
       }
       this._store.dispatch(setFocusPosition({focusPosition: focus}));
     });

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -388,10 +388,6 @@ export class WmGeoboxMapComponent implements OnDestroy {
             return EMPTY;
           }
           return this.currentPosition$.pipe(
-            distinctUntilChanged(
-              (prev, curr) =>
-                prev?.latitude === curr?.latitude && prev?.longitude === curr?.longitude,
-            ),
             takeUntil(this.enableTrackRecorderPanel$.pipe(filter(enabled => !enabled))),
           );
         }),

--- a/projects/wm-core/src/store/features/features.selector.ts
+++ b/projects/wm-core/src/store/features/features.selector.ts
@@ -1,7 +1,7 @@
 import {createSelector} from '@ngrx/store';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
-import {currentLocation, ecLayer, enableRecoderPanel, ugcOpened} from '../user-activity/user-activity.selector';
+import {currentLocation, ecLayer, enableRecorderPanel, ugcOpened} from '../user-activity/user-activity.selector';
 import {
   countEcAll,
   countEcPois,
@@ -95,8 +95,8 @@ export const featureFirstCoordinates = createSelector(
 export const showFeaturesInViewport = createSelector(
   featureOpened,
   ecLayer,
-  enableRecoderPanel,
-  (featureOpened, ecLayer, enableRecoderPanel) => {
-    return featureOpened == false && ecLayer == null && enableRecoderPanel == false;
+  enableRecorderPanel,
+  (featureOpened, ecLayer, enableRecorderPanel) => {
+    return featureOpened == false && ecLayer == null && enableRecorderPanel == false;
   },
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -146,6 +146,8 @@ export const startGetDirections = createAction('[User Activity] get directions')
 export const getDirections = createAction('[User Activity] get directions success', props<{coordinates: number[]}>());
 export const openLoginModal = createAction('[User Activity] open login modal');
 
-export const setEnableRecoderPanel = createAction('[User Activity] set enable register panel', props<{enable: boolean}>());
+export const setEnableTrackRecorderPanel = createAction('[User Activity] set enable register panel', props<{enable: boolean}>());
 export const setOnRecord = createAction('[User Activity] set on record', props<{onRecord: boolean}>());
 export const setFocusPosition = createAction('[User Activity] set focus position', props<{focusPosition: boolean}>());
+export const setEnablePoiRecorderPanel = createAction('[User Activity] set enable poi recorder panel', props<{enable: boolean}>());
+

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -30,9 +30,10 @@ import {
   drawPoiOpened,
   setHomeResultTabSelected,
   setCurrentLocation,
-  setEnableRecoderPanel,
+  setEnableTrackRecorderPanel,
   setOnRecord,
   setFocusPosition,
+  setEnablePoiRecorderPanel,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
@@ -64,7 +65,8 @@ export interface UserActivityState {
   wmMapHitmapFeatures: WmFeature<MultiPolygon>[];
   homeResultTabSelected: 'tracks' | 'pois' | null;
   currentLocation?: Location;
-  enableRecoderPanel: boolean;
+  enableTrackRecoderPanel: boolean;
+  enablePoiRecorderPanel: boolean;
   onRecord: boolean;
   focusPosition: boolean;
 }
@@ -89,7 +91,8 @@ const initialState: UserActivityState = {
   wmMapHitmapFeatures: [],
   featuresInViewport: [],
   homeResultTabSelected: 'tracks',
-  enableRecoderPanel: false,
+  enableTrackRecoderPanel: false,
+  enablePoiRecorderPanel: false,
   onRecord: false,
   focusPosition: false,
 };
@@ -325,10 +328,10 @@ export const userActivityReducer = createReducer(
     };
   }),
 
-  on(setEnableRecoderPanel, (state, {enable}) => {
+  on(setEnableTrackRecorderPanel, (state, {enable}) => {
     return {
       ...state,
-      enableRecoderPanel: enable,
+      enableTrackRecoderPanel: enable,
     };
   }),
 
@@ -343,6 +346,13 @@ export const userActivityReducer = createReducer(
     return {
       ...state,
       focusPosition,
+    };
+  }),
+
+  on(setEnablePoiRecorderPanel, (state, {enable}) => {
+    return {
+      ...state,
+      enablePoiRecorderPanel: enable,
     };
   }),
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -213,6 +213,15 @@ export const currentDrawFormType = createSelector(
   },
 );
 
-export const enableRecoderPanel = createSelector(userActivity, state => state.enableRecoderPanel);
+export const enableTrackRecorderPanel = createSelector(userActivity, state => state.enableTrackRecoderPanel);
+export const enablePoiRecorderPanel = createSelector(userActivity, state => state.enablePoiRecorderPanel);
+export const enableRecorderPanel = createSelector(
+  enableTrackRecorderPanel,
+  enablePoiRecorderPanel,
+  (enableTrackRecorderPanel, enablePoiRecorderPanel) => {
+    return enableTrackRecorderPanel || enablePoiRecorderPanel;
+  },
+);
 export const onRecord = createSelector(userActivity, state => state.onRecord);
 export const focusPosition = createSelector(userActivity, state => state.focusPosition);
+


### PR DESCRIPTION
Corrected the typo in variable names from "Recoder" to "Recorder" across the component HTML and TypeScript files. Introduced new observables and actions for enabling track and POI recorder panels. Updated selectors and reducers accordingly to manage the new state variables and ensure proper functionality. This refactor improves code readability and functionality by accurately representing the feature's purpose and enhancing the component's capabilities.
