### PR TITLE
chore(track-properties): ✨ add wm-inner-component-html for excerpt display oc:6117

### DIFF
--- a/projects/wm-core/src/track-properties/track-properties.component.html
+++ b/projects/wm-core/src/track-properties/track-properties.component.html
@@ -18,6 +18,12 @@
     *ngIf="ecTrackProperties?.not_accessible != null && ecTrackProperties?.not_accessible === true"
     [alert]="ecTrackProperties?.not_accessible_message"
   ></wm-track-alert>
+  <wm-inner-component-html
+    [enableDismiss]="false"
+    *ngIf="ecTrackProperties?.excerpt as excerpt"
+    [html]="excerpt|wmtrans"
+  >
+  </wm-inner-component-html>
   <wm-track-edges [properties]="ecTrackProperties" [conf]="currentLayer$|async"></wm-track-edges>
   <wm-travel-mode></wm-travel-mode>
   <div *ngIf="flowLineQuoteShow$|async" class="wm-flowline">


### PR DESCRIPTION
Added a new `wm-inner-component-html` element to display excerpts within the track properties component. This element is conditionally rendered based on the availability of the `excerpt` property from `ecTrackProperties`. The `enableDismiss` attribute is set to false to prevent dismissal, and the content is transformed using the `wmtrans` pipe.
