### PR TITLE
chore(map): 🌍 add tile download feature with bounding box management oc:5578

### DIFF
--- a/projects/wm-core/src/geobox-map/geobox-map.component.html
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.html
@@ -72,6 +72,12 @@
     [wmMapDrawUgcPoiEnabled]="drawPoiOpened$|async"
     [wmMapDrawUgcPoiPoi]="currentUgcPoiDrawn$|async"
     (wmMapDrawUgcPoiEvt)="updateUgcPoiDrawn($event)"
+    wmMapTilesDownload
+    [wmMapTilesBoundingBoxes]="boundingBoxes$|async"
+    [wmMapTilesDownloadShow]="enableTilesDownload$|async"
+    (wmMapTilesBoundingBox)="setWmMapTilesBoundingBox($event)"
+    (wmMapTilesZoomDisableDownloadButton)="setWmMapTilesDisableDownloadButton($event)"
+    (wmMapTilesDelete)="deleteBoundingBox($event)"
   >
     <wm-filters
       top-right

--- a/projects/wm-core/src/localization/i18n/de.ts
+++ b/projects/wm-core/src/localization/i18n/de.ts
@@ -230,4 +230,7 @@ export const wmDE = {
   "environmental-education": "Umweltbildung",
   "eating-sleeping": "Essen und Schlafen",
   "by-car": "Auto",
+  'Eliminazione': 'Löschen',
+  'Elimina': 'Löschen',
+  'Sei sicuro di voler eliminare questi dati?': 'Sind Sie sicher, dass Sie diese Daten löschen möchten?',
 };

--- a/projects/wm-core/src/localization/i18n/en.ts
+++ b/projects/wm-core/src/localization/i18n/en.ts
@@ -237,4 +237,7 @@ export const wmEN = {
   "environmental-education": "Environmental Education",
   "eating-sleeping": "Eating and Sleeping",
   "by-car": "By Car",
+  'Eliminazione': 'Deletion',
+  'Elimina': 'Delete',
+  'Sei sicuro di voler eliminare questi dati?': 'Are you sure you want to delete this data?',
 };

--- a/projects/wm-core/src/localization/i18n/es.ts
+++ b/projects/wm-core/src/localization/i18n/es.ts
@@ -226,4 +226,7 @@ export const wmES = {
   "environmental-education": "Educación ambiental",
   "eating-sleeping": "Comer y dormir",
   "by-car": "En coche",
+  'Eliminazione': 'Eliminación',
+  'Elimina': 'Eliminar',
+  'Sei sicuro di voler eliminare questi dati?': '¿Está seguro de que desea eliminar estos datos?',
 };

--- a/projects/wm-core/src/localization/i18n/fr.ts
+++ b/projects/wm-core/src/localization/i18n/fr.ts
@@ -229,4 +229,7 @@ export const wmFR = {
   "environmental-education": "Éducation environnementale",
   "eating-sleeping": "Manger et dormir",
   "by-car": "En voiture",
+  'Eliminazione': 'Suppression',
+  'Elimina': 'Supprimer',
+  'Sei sicuro di voler eliminare questi dati?': 'Êtes-vous sûr de vouloir supprimer ces données ?',
 };

--- a/projects/wm-core/src/localization/i18n/it.ts
+++ b/projects/wm-core/src/localization/i18n/it.ts
@@ -235,4 +235,7 @@ export const wmIT = {
   "environmental-education": "Educazione ambientale",
   "eating-sleeping": "Mangiare e dormire",
   "by-car": "In macchina",
+  'Eliminazione': 'Eliminazione',
+  'Elimina': 'Elimina',
+  'Sei sicuro di voler eliminare questi dati?': 'Sei sicuro di voler eliminare questi dati?',
 };

--- a/projects/wm-core/src/localization/i18n/pr.ts
+++ b/projects/wm-core/src/localization/i18n/pr.ts
@@ -227,4 +227,7 @@ export const wmPR = {
   "environmental-education": "Educação ambiental",
   "eating-sleeping": "Comer e dormir",
   "by-car": "Em carro",
+  'Eliminazione': 'Exclusão',
+  'Elimina': 'Excluir',
+  'Sei sicuro di voler eliminare questi dati?': 'Tem certeza de que deseja excluir estes dados?',
 };

--- a/projects/wm-core/src/localization/i18n/sq.ts
+++ b/projects/wm-core/src/localization/i18n/sq.ts
@@ -234,4 +234,7 @@ export const wmSQ = {
   "environmental-education": "Edukimi ambientale",
   "eating-sleeping": "Mëngjes dhe mëngjes",
   "by-car": "Me makinë",
+  'Eliminazione': 'Fshirje',
+  'Elimina': 'Fshij',
+  'Sei sicuro di voler eliminare questi dati?': 'A jeni të sigurt që dëshironi të fshini këto të dhëna?',
 };

--- a/projects/wm-core/src/store/features/features.selector.ts
+++ b/projects/wm-core/src/store/features/features.selector.ts
@@ -1,7 +1,12 @@
 import {createSelector} from '@ngrx/store';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
-import {currentLocation, ecLayer, enableRecorderPanel, ugcOpened} from '../user-activity/user-activity.selector';
+import {currentLocation,
+  ecLayer,
+  enableRecorderPanel,
+  enableTilesDownload,
+  ugcOpened,
+} from '../user-activity/user-activity.selector';
 import {
   countEcAll,
   countEcPois,
@@ -96,7 +101,13 @@ export const showFeaturesInViewport = createSelector(
   featureOpened,
   ecLayer,
   enableRecorderPanel,
-  (featureOpened, ecLayer, enableRecorderPanel) => {
-    return featureOpened == false && ecLayer == null && enableRecorderPanel == false;
+  enableTilesDownload,
+  (featureOpened, ecLayer, enableRecorderPanel, enableTilesDownload) => {
+    return (
+      featureOpened == false &&
+      ecLayer == null &&
+      enableRecorderPanel == false &&
+      enableTilesDownload == false
+    );
   },
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.action.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.action.ts
@@ -151,3 +151,12 @@ export const setOnRecord = createAction('[User Activity] set on record', props<{
 export const setFocusPosition = createAction('[User Activity] set focus position', props<{focusPosition: boolean}>());
 export const setEnablePoiRecorderPanel = createAction('[User Activity] set enable poi recorder panel', props<{enable: boolean}>());
 
+export const setEnableTilesDownload = createAction('[User Activity] set enable tiles download', props<{enableTilesDownload: boolean}>());
+export const setDisableTilesDownloadButton = createAction(
+  '[User Activity] set disable tiles download button',
+  props<{disableTilesDownloadButton: boolean}>(),
+);
+export const setWmMapTilesBoundingBox = createAction(
+  '[User Activity] set wm map tiles bounding box',
+  props<{wmMapTilesBoundingBox: WmFeature<MultiPolygon> | null}>(),
+);

--- a/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.reducer.ts
@@ -34,6 +34,9 @@ import {
   setOnRecord,
   setFocusPosition,
   setEnablePoiRecorderPanel,
+  setEnableTilesDownload,
+  setWmMapTilesBoundingBox,
+  setDisableTilesDownloadButton,
 } from './user-activity.action';
 import {currentEcPoiId} from '../features/ec/ec.actions';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
@@ -69,6 +72,9 @@ export interface UserActivityState {
   enablePoiRecorderPanel: boolean;
   onRecord: boolean;
   focusPosition: boolean;
+  enableTilesDownload: boolean;
+  disableTilesDownloadButton: boolean;
+  wmMapTilesBoundingBox?: WmFeature<MultiPolygon>;
 }
 
 export interface UserAcitivityRootState {
@@ -95,6 +101,8 @@ const initialState: UserActivityState = {
   enablePoiRecorderPanel: false,
   onRecord: false,
   focusPosition: false,
+  enableTilesDownload: false,
+  disableTilesDownloadButton: false,
 };
 
 function extractFilterTaxonomies(layer) {
@@ -353,6 +361,25 @@ export const userActivityReducer = createReducer(
     return {
       ...state,
       enablePoiRecorderPanel: enable,
+    };
+  }),
+
+  on(setEnableTilesDownload, (state, {enableTilesDownload}) => {
+    return {
+      ...state,
+      enableTilesDownload,
+    };
+  }),
+  on(setWmMapTilesBoundingBox, (state, {wmMapTilesBoundingBox}) => {
+    return {
+      ...state,
+      wmMapTilesBoundingBox,
+    };
+  }),
+  on(setDisableTilesDownloadButton, (state, {disableTilesDownloadButton}) => {
+    return {
+      ...state,
+      disableTilesDownloadButton,
     };
   }),
 );

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -225,3 +225,12 @@ export const enableRecorderPanel = createSelector(
 export const onRecord = createSelector(userActivity, state => state.onRecord);
 export const focusPosition = createSelector(userActivity, state => state.focusPosition);
 
+export const enableTilesDownload = createSelector(userActivity, state => state.enableTilesDownload);
+export const disableTilesDownloadButton = createSelector(
+  userActivity,
+  state => state.disableTilesDownloadButton,
+);
+export const wmMapTilesBoundingBox = createSelector(
+  userActivity,
+  state => state.wmMapTilesBoundingBox,
+);


### PR DESCRIPTION
This update introduces the ability to download map tiles by managing bounding boxes. Users can now select areas on the map for downloading tiles. The feature includes:

- UI elements for enabling tile downloads and displaying bounding boxes.
- Functions for setting bounding boxes and disabling/enabling download buttons.
- A delete confirmation dialog for removing bounding boxes with multi-language support.
- State management for enabling and disabling tile downloads, handling bounding boxes, and related UI changes.
- Updated localization files to support new strings in multiple languages.
