### PR TITLE
refactor(icons): ♻️ convert svg rendering to wm-icon component oc:6351

### DIFF
--- a/projects/wm-core/src/box/search-box/search-box.component.html
+++ b/projects/wm-core/src/box/search-box/search-box.component.html
@@ -47,11 +47,7 @@
     <ng-container *ngIf="icons$ | async as icons">
       <ng-container *ngFor="let item of data?.taxonomyActivities">
         <div class="wm-box-taxonomy" *ngIf="data.taxonomyIcons?.[item] as taxonomyIcon">
-          <div
-            *ngIf="taxonomyIcon.icon_name && icons?.[taxonomyIcon.icon_name]"
-            appBuildSvg
-            [svg]="icons[taxonomyIcon.icon_name]"
-          ></div>
+          <wm-icon [iconData]="taxonomyIcon"></wm-icon>
         </div>
       </ng-container>
     </ng-container>

--- a/projects/wm-core/src/filters/filters.component.html
+++ b/projects/wm-core/src/filters/filters.component.html
@@ -29,8 +29,8 @@
         <ion-item class="wm-selected-filters">
           <ng-container *ngFor="let f of poiFilters$|async">
             <ion-chip class="wm-active-filter" (click)="removePoiFilter(f)">
-              <ng-container *ngIf="f.icon != null;else imgT">
-                <div appBuildSvg class="wm-filter-icon" [svg]="f.icon"></div>
+              <ng-container *ngIf="f?.icon_name != null || f?.icon != null;else imgT">
+                <wm-icon [iconData]="f"></wm-icon>
               </ng-container>
               <ng-template #imgT>
                 <img [src]="f.identifier" />
@@ -41,9 +41,7 @@
           </ng-container>
           <ng-container *ngFor="let f of trackFilters$|async">
             <ion-chip class="wm-active-filter" (click)="removeTrackFilter(f)">
-              <ng-container *ngIf="f.icon != null">
-                <div appBuildSvg class="wm-filter-icon" [svg]="f.icon" [color]="f.color"></div>
-              </ng-container>
+              <wm-icon [iconData]="f"></wm-icon>
               <ion-label>{{f.name|wmtrans}}{{f|wmUnits}}</ion-label>
               <ion-icon name="close"></ion-icon>
             </ion-chip>

--- a/projects/wm-core/src/filters/filters.component.scss
+++ b/projects/wm-core/src/filters/filters.component.scss
@@ -81,6 +81,9 @@ wm-filters {
         margin-left: -7px;
         margin-top: -4px;
       }
+      wm-icon {
+        height: 100%;
+      }
     }
   }
 }

--- a/projects/wm-core/src/filters/filters.module.ts
+++ b/projects/wm-core/src/filters/filters.module.ts
@@ -7,6 +7,7 @@ import {SelectFilterComponent} from './select-filter/select-filter.component';
 import {StatusFilterComponent} from './status-filter/status-filter.component';
 import {SliderFilterComponent} from './slider-filter/slider-filter.component';
 import {SliderFilterMeasurePipe} from './slider-filter/slider-filter-measure.pipe';
+import {WmSharedModule} from '../shared/shared.module';
 const components = [
   FiltersComponent,
   SelectFilterComponent,
@@ -16,7 +17,7 @@ const components = [
 ];
 @NgModule({
   declarations: components,
-  imports: [CommonModule, IonicModule, WmPipeModule],
+  imports: [CommonModule, IonicModule, WmPipeModule, WmSharedModule],
   exports: components,
 })
 export class WmFiltersModule {}

--- a/projects/wm-core/src/filters/select-filter/select-filter.component.html
+++ b/projects/wm-core/src/filters/select-filter/select-filter.component.html
@@ -17,24 +17,13 @@
                 (click)="addPoiFilter(option)"
                 color="{{option.identifier|isSelected:(poiFilters)}}"
               >
-                <ng-container *ngIf="icons$ | async as icons; esle optionIcon">
-                  <div
-                    appBuildSvg
-                    *ngIf="icons?.[option?.icon_name] as icon; else legacyIcon"
-                    [svg]="icon"
-                  ></div>
-                  <!-- TODO: [icon_name] da rimuovere una volta rigenerate tutte le tracce -->
-                  <ng-template #legacyIcon>
-                    <div appBuildSvg *ngIf="option.icon != null" [svg]="option.icon"></div>
-                  </ng-template>
+                <ng-container
+                  *ngIf="(option?.icon_name != null) || (option?.icon != null); else imgT"
+                >
+                  <wm-icon [iconData]="option"></wm-icon>
                 </ng-container>
-                <ng-template #optionIcon>
-                  <ng-container *ngIf="option.icon != null;else imgT">
-                    <div appBuildSvg [svg]="option.icon"></div>
-                  </ng-container>
-                  <ng-template #imgT>
-                    <img [src]="option.identifier" />
-                  </ng-template>
+                <ng-template #imgT>
+                  <img [src]="option.identifier" />
                 </ng-template>
                 <ion-label>{{option.name|wmtrans}}</ion-label>
                 <span class="wm-filters-count">

--- a/projects/wm-core/src/filters/select-filter/select-filter.component.scss
+++ b/projects/wm-core/src/filters/select-filter/select-filter.component.scss
@@ -41,6 +41,12 @@ wm-select-filter {
         margin-left: -7px;
         margin-top: -4px;
       }
+      wm-icon {
+        height: 100%;
+        svg {
+          height: 100%;
+        }
+      }
     }
   }
 }

--- a/projects/wm-core/src/filters/select-filter/select-filter.component.ts
+++ b/projects/wm-core/src/filters/select-filter/select-filter.component.ts
@@ -1,10 +1,6 @@
 import {Component, Host, Input, ViewEncapsulation} from '@angular/core';
 import {FiltersComponent} from '../filters.component';
 import {SelectFilter, SelectFilterOption} from '../../types/config';
-import {Store} from '@ngrx/store';
-import {Observable} from 'rxjs';
-import {ICONS} from '@wm-types/config';
-import {icons} from '@wm-core/store/icons/icons.selector';
 
 @Component({
   selector: 'wm-select-filter',
@@ -16,9 +12,7 @@ export class SelectFilterComponent {
   @Input() filter: SelectFilter;
   @Input() filterName: string;
 
-  icons$: Observable<ICONS> = this._store.select(icons);
-
-  constructor(@Host() public parent: FiltersComponent, private _store: Store) {}
+  constructor(@Host() public parent: FiltersComponent) {}
 
   addPoiFilter(filter: SelectFilterOption): void {
     this.parent.addPoisFilter({...filter, ...{type: 'select'}});

--- a/projects/wm-core/src/filters/status-filter/status-filter.component.html
+++ b/projects/wm-core/src/filters/status-filter/status-filter.component.html
@@ -30,8 +30,8 @@
         </ng-container>
         <ng-container *ngFor="let f of poiFilters$|async">
           <ion-chip (click)="removePoiFilter(f.identifier)">
-            <ng-container *ngIf="f.icon != null;else imgT">
-              <div class="wm-status-filter-icn" appBuildSvg [svg]="f.icon"></div>
+            <ng-container *ngIf="(f.icon_name != null) || (f.icon != null);else imgT">
+              <wm-icon [iconData]="f"></wm-icon>
             </ng-container>
             <ng-template #imgT>
               <img [src]="f.identifier" />

--- a/projects/wm-core/src/filters/status-filter/status-filter.component.scss
+++ b/projects/wm-core/src/filters/status-filter/status-filter.component.scss
@@ -11,12 +11,6 @@ wm-status-filter {
     align-items: stretch;
     max-height: 200px;
     overflow: auto;
-    .wm-status-filter-icn {
-      height: 17px;
-      * {
-        height: 100%;
-      }
-    }
     ion-chip {
       order: 0;
       flex: 1 1 auto;
@@ -41,6 +35,12 @@ wm-status-filter {
         display: block;
         margin-left: -7px;
         margin-top: -4px;
+      }
+      wm-icon {
+        height: 100%;
+        div[appBuildSvg] {
+          height: 100%;
+        }
       }
     }
   }

--- a/projects/wm-core/src/poi-types-badges/poi-types-badges.component.ts
+++ b/projects/wm-core/src/poi-types-badges/poi-types-badges.component.ts
@@ -1,17 +1,12 @@
 import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
-import {Store} from '@ngrx/store';
-import {icons} from '@wm-core/store/icons/icons.selector';
-import {Observable} from 'rxjs';
 
 @Component({
   selector: 'wm-poi-types-badges',
   template: `
     <ng-container *ngIf="poiTypes as poiTypes">
       <div *ngFor="let poiType of poiTypes">
-        <ng-container *ngIf="icons$ | async as icons">
-          <div appBuildSvg *ngIf="icons?.[poiType.icon_name] as svgIcon" [svg]="svgIcon"></div>
-        </ng-container>
+        <wm-icon [iconData]="poiType"></wm-icon>
         <span>{{poiType.name | wmtrans}}</span>
       </div>
     </ng-container>
@@ -63,9 +58,8 @@ import {Observable} from 'rxjs';
 })
 export class PoiTypesBadgesComponent {
   @Input() poiTypes: any;
-  icons$: Observable<{[key: string]: string}> = this._store.select(icons);
 
-  constructor(private _sanitizer: DomSanitizer, private _store: Store) {}
+  constructor(private _sanitizer: DomSanitizer) {}
 
   sanitize(html: string) {
     return this._sanitizer.bypassSecurityTrustHtml(html);

--- a/projects/wm-core/src/shared/shared.module.ts
+++ b/projects/wm-core/src/shared/shared.module.ts
@@ -4,12 +4,14 @@ import {NgModule} from '@angular/core';
 import {IonicModule} from '@ionic/angular';
 import {WmImgComponent} from './img/img.component';
 import {UgcSynchronizedBadgeComponent} from './ugc-synchronized-badge/ugc-synchronized-badge.component';
+import {WmIconComponent} from '../wm-icon/wm-icon.component';
+import {WmPipeModule} from '../pipes/pipe.module';
 
-const declarations = [WmImgComponent, UgcSynchronizedBadgeComponent];
+const declarations = [WmImgComponent, UgcSynchronizedBadgeComponent, WmIconComponent];
 
 @NgModule({
   declarations,
-  imports: [CommonModule, IonicModule],
+  imports: [CommonModule, IonicModule, WmPipeModule],
   exports: [...declarations],
 })
 export class WmSharedModule {}

--- a/projects/wm-core/src/store/conf/conf.reducer.ts
+++ b/projects/wm-core/src/store/conf/conf.reducer.ts
@@ -159,28 +159,6 @@ export const confReducer = createReducer(
   on(loadConfSuccess, (state, {conf}) => {
     localStorage.setItem('appname', state.APP.name);
     let MAP = {...state.MAP, ...{...conf.MAP}};
-    if (conf.APP.geohubId === 3) {
-      let res = {};
-      const mockedMapLayers = conf.MAP?.layers?.map((layer: ILAYER) => {
-        const edgesObj = layer.edges ?? {};
-        const edgesKeys = Object.keys(edgesObj);
-        edgesKeys.forEach(edgeKey => {
-          let edgeObj = edgesObj[edgeKey];
-          const nextCrossroads = isCrossroads(edgesObj, +edgeKey, 'prev');
-          const prevCrossroads = isCrossroads(edgesObj, +edgeKey, 'next');
-          // @ts-ignore
-          res[edgeKey] = {
-            ...edgeObj,
-            nextCrossroads,
-            prevCrossroads,
-          };
-        });
-
-        return {...layer, ...{edges: res}};
-      });
-
-      MAP = {...state.MAP, ...{...conf.MAP, ...{layers: mockedMapLayers}}};
-    }
     if (MAP != null) {
       if (MAP.controls) {
         MAP.controls = {...addIdToControls(MAP.controls)};

--- a/projects/wm-core/src/store/conf/conf.reducer.ts
+++ b/projects/wm-core/src/store/conf/conf.reducer.ts
@@ -161,7 +161,7 @@ export const confReducer = createReducer(
     let MAP = {...state.MAP, ...{...conf.MAP}};
     if (conf.APP.geohubId === 3) {
       let res = {};
-      const mockedMapLayers = conf.MAP.layers.map((layer: ILAYER) => {
+      const mockedMapLayers = conf.MAP?.layers?.map((layer: ILAYER) => {
         const edgesObj = layer.edges ?? {};
         const edgesKeys = Object.keys(edgesObj);
         edgesKeys.forEach(edgeKey => {

--- a/projects/wm-core/src/tab-howto/tab-howto.component.html
+++ b/projects/wm-core/src/tab-howto/tab-howto.component.html
@@ -5,17 +5,7 @@
       <div class="webmapp-walkability" *ngIf="taxonomy.activity as activity">
         <ng-container *ngFor="let item of activity">
           <div class="webmapp-walkability-box">
-            <ng-container *ngIf="icons$ | async as icons">
-              <div
-                appBuildSvg
-                *ngIf="icons?.[item?.icon_name] as icon; else legacyIcon"
-                [svg]="icon"
-              ></div>
-              <!-- TODO: [icon_name] da rimuovere una volta rigenerate tutte le tracce -->
-              <ng-template #legacyIcon>
-                <div appBuildSvg *ngIf="item.icon != null" [svg]="item.icon"></div>
-              </ng-template>
-            </ng-container>
+            <wm-icon [iconData]="item"></wm-icon>
             <span class="webmapp-walkability-label">{{item.name|wmtrans}}</span>
           </div>
         </ng-container>

--- a/projects/wm-core/src/tab-howto/tab-howto.component.scss
+++ b/projects/wm-core/src/tab-howto/tab-howto.component.scss
@@ -47,15 +47,17 @@ wm-tab-howto {
         flex-grow: 0;
         margin: 8px 0px;
       }
-      > div {
-        svg {
-          height: unset;
+      wm-icon {
+        > div {
+          svg {
+            height: unset;
 
-          circle {
-            fill: transparent;
-          }
-          g {
-            fill: #ff8128;
+            circle {
+              fill: transparent;
+            }
+            g {
+              fill: #ff8128;
+            }
           }
         }
       }

--- a/projects/wm-core/src/tab-howto/tab-howto.component.ts
+++ b/projects/wm-core/src/tab-howto/tab-howto.component.ts
@@ -1,9 +1,6 @@
 import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 import {WmProperties} from '@wm-types/feature';
 import {Store} from '@ngrx/store';
-import {icons} from '@wm-core/store/icons/icons.selector';
-import {ICONS} from '@wm-types/config';
-import {Observable} from 'rxjs';
 
 @Component({
   selector: 'wm-tab-howto',
@@ -18,8 +15,6 @@ export class WmTabHowtoComponent {
     this.properties = {...this.properties, ...{identifier: form.activity, label: form.title}};
   }
   @Input() properties: WmProperties;
-
-  icons$: Observable<ICONS> = this._store.select(icons);
 
   constructor(private _store: Store) {}
 }

--- a/projects/wm-core/src/track-related-poi/track-related-poi.component.html
+++ b/projects/wm-core/src/track-related-poi/track-related-poi.component.html
@@ -11,22 +11,7 @@
           <img class="webmapp-track-poi-img" [src]="properties.feature_image?.sizes?.['108x148']" />
         </ng-container>
         <ng-template #svgTemplate>
-          <ng-container *ngIf="icons$|async as icons; else noImage">
-            <div
-              *ngIf="icons[properties?.taxonomy?.poi_type?.icon_name] != null; else legacyIcon"
-              appBuildSvg
-              class="wm-filter-icon"
-              [svg]="icons[properties?.taxonomy?.poi_type?.icon_name]"
-            ></div>
-            <!-- TODO: [icon_name] da rimuovere una volta rigenerate tutte le tracce -->
-            <ng-template #legacyIcon>
-              <div
-                appBuildSvg
-                *ngIf="properties?.taxonomy?.poi_type?.icon != null; else noImage"
-                [svg]="properties?.taxonomy?.poi_type?.icon"
-              ></div>
-            </ng-template>
-          </ng-container>
+          <wm-icon [iconData]="properties?.taxonomy?.poi_type"></wm-icon>
         </ng-template>
         <ng-template #noImage>
           <img class="webmapp-track-poi-img" [src]="defaultPhotoPath" />

--- a/projects/wm-core/src/track-related-poi/track-related-poi.component.scss
+++ b/projects/wm-core/src/track-related-poi/track-related-poi.component.scss
@@ -87,7 +87,7 @@ wm-track-related-poi {
       .webmapp-track-poi-distance-from-current-location {
         font-size: 12px;
         color: var(--ion-text-color);
-        span{
+        span {
           font-weight: 700;
         }
       }
@@ -112,8 +112,9 @@ wm-track-related-poi {
       flex: 0 1 auto;
       align-self: auto;
     }
-    .wm-filter-icon {
+    wm-icon {
       height: 100%;
+      display: flex;
       svg {
         height: 100%;
         padding: 4px;

--- a/projects/wm-core/src/track-related-poi/track-related-poi.component.ts
+++ b/projects/wm-core/src/track-related-poi/track-related-poi.component.ts
@@ -17,8 +17,6 @@ import {Observable, BehaviorSubject, combineLatest, of} from 'rxjs';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
 import {map, switchMap} from 'rxjs/operators';
-import {ICONS} from '@wm-types/config';
-import {icons} from '@wm-core/store/icons/icons.selector';
 
 export const MAX_VISIBLE_POIS = 4;
 @Component({
@@ -37,7 +35,6 @@ export class TrackRelatedPoiComponent {
   currentRelatedEcPid$ = this._store.select(currentEcRelatedPoiId);
   defaultPhotoPath = '/assets/icon/no-photo.svg';
   isExpanded$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  icons$: Observable<ICONS> = this._store.select(icons);
   pois$: Observable<WmFeature<Point>[]> = this._store.select(currentEcRelatedPois).pipe(
     switchMap(pois =>
       pois?.length ? combineLatest([

--- a/projects/wm-core/src/wm-icon/wm-icon.component.ts
+++ b/projects/wm-core/src/wm-icon/wm-icon.component.ts
@@ -1,0 +1,29 @@
+import {Component, Input} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {icons} from '@wm-core/store/icons/icons.selector';
+import {ICONS} from '@wm-types/config';
+import {Observable} from 'rxjs';
+
+@Component({
+  selector: 'wm-icon',
+  template: `
+  <ng-container *ngIf="icons$ | async as icons; else legacyIcon">
+    <div
+      appBuildSvg
+      *ngIf="icons?.[iconData?.icon_name] as icon; else legacyIcon"
+      [svg]="icon"
+    ></div>
+  </ng-container>
+    <ng-template #legacyIcon>
+      <div appBuildSvg *ngIf="iconData?.icon != null" [svg]="iconData.icon"></div>
+    </ng-template>
+  `,
+  styles: [],
+})
+export class WmIconComponent {
+  @Input() iconData: any;
+
+  icons$: Observable<ICONS> = this._store.select(icons);
+
+  constructor(private _store: Store) {}
+}


### PR DESCRIPTION
Replaced inline SVG rendering logic in multiple components with a reusable `wm-icon` component to streamline icon handling. This change affects several components including `search-box`, `filters`, `select-filter`, `status-filter`, `poi-types-badges`, `tab-howto`, and `track-related-poi`.

- Introduced `wm-icon` component with logic to select and render icons based on data.
- Removed redundant SVG rendering logic from the affected components.
- Updated the respective HTML and SCSS files to accommodate the changes.
- Added `WmIconComponent` to `WmSharedModule`.

These changes aim to reduce code duplication and improve maintainability by centralizing icon rendering logic.
