### PR TITLE
refactor(ec.service): ♻️ enhance track retrieval with local cache support oc:7222

### DIFF
--- a/projects/wm-core/src/store/features/ec/ec.service.spec.ts
+++ b/projects/wm-core/src/store/features/ec/ec.service.spec.ts
@@ -1,0 +1,103 @@
+import {HttpClient} from '@angular/common/http';
+import {of, throwError} from 'rxjs';
+
+import {EcService} from './ec.service';
+import {WmFeature} from '@wm-types/feature';
+import {LineString} from 'geojson';
+import {synchronizedEctrack} from '@wm-core/utils/localForage';
+
+describe('EcService - getEcTrack (offline cache behaviour)', () => {
+  let service: EcService;
+  let httpClientSpy: any;
+
+  const createMockTrack = (id: number): WmFeature<LineString> => ({
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: [
+        [11.0, 46.0],
+        [11.1, 46.1],
+      ],
+    },
+    properties: {
+      id,
+      name: 'Test track',
+    } as any,
+  });
+
+  beforeEach(async () => {
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+    const environmentMock: any = {
+      awsApi: 'https://test-aws.com',
+      elasticApi: 'https://elastic.test',
+      appId: null,
+    };
+
+    // Pulisce lo store delle ec-tracks prima di ogni test
+    await synchronizedEctrack.clear();
+
+    service = new EcService(httpClientSpy, environmentMock);
+  });
+
+  it('dovrebbe emettere la track da cache e non andare in errore se la HTTP fallisce ma esiste cachedTrack', async () => {
+    const cachedTrack = createMockTrack(123);
+    await synchronizedEctrack.setItem('123', cachedTrack);
+
+    // Simula errore HTTP
+    httpClientSpy.get.and.returnValue(
+      throwError(() => new Error('Server error')),
+    );
+
+    const emissions: WmFeature<LineString>[] = [];
+    let error: any = null;
+
+    await new Promise<void>(resolve => {
+      service.getEcTrack(123).subscribe({
+        next: value => emissions.push(value),
+        error: e => {
+          error = e;
+          resolve();
+        },
+        complete: () => resolve(),
+      });
+    });
+
+    // Deve aver emesso solo la track in cache
+    expect(emissions.length).toBe(1);
+    expect(emissions[0]).toEqual(cachedTrack);
+    // Nessun errore propagato allo stream
+    expect(error).toBeNull();
+  });
+
+  it('dovrebbe emettere solo la track remota e non salvare nel localForage se non esiste cachedTrack', async () => {
+    const remoteTrack = createMockTrack(456);
+
+    // Nessuna track salvata in cache per questo id
+    httpClientSpy.get.and.returnValue(of(remoteTrack));
+
+    const emissions: WmFeature<LineString>[] = [];
+    let error: any = null;
+
+    await new Promise<void>(resolve => {
+      service.getEcTrack(456).subscribe({
+        next: value => emissions.push(value),
+        error: e => {
+          error = e;
+          resolve();
+        },
+        complete: () => resolve(),
+      });
+    });
+
+    // Deve aver emesso solo la track remota
+    expect(emissions.length).toBe(1);
+    expect(emissions[0]).toEqual(remoteTrack);
+    expect(error).toBeNull();
+
+    // Verifica che la track non sia stata salvata nel localForage
+    const stored = await synchronizedEctrack.getItem('456');
+    expect(stored).toBeNull();
+  });
+});
+
+

--- a/projects/wm-core/src/store/features/ec/ec.service.ts
+++ b/projects/wm-core/src/store/features/ec/ec.service.ts
@@ -8,7 +8,7 @@ import {Observable, of} from 'rxjs';
 import {distinctUntilChanged, shareReplay, take} from 'rxjs/operators';
 import {Response} from '@wm-types/elastic';
 import {Filter, SliderFilter} from '../../../types/config';
-import {synchronizedApi} from '@wm-core/utils/localForage';
+import {synchronizedApi, getEcTrack as getEcTrackFromLocalForage, saveEcTrack} from '@wm-core/utils/localForage';
 import {WmFeature} from '@wm-types/feature';
 import {EnvironmentService} from '@wm-core/services/environment.service';
 @Injectable({
@@ -36,7 +36,42 @@ export class EcService {
     if (id == null) return of(null);
     if (+id > -1) {
       const url = `${this._environmentSvc.awsApi}/tracks/${id}.json`;
-      return this._http.get<WmFeature<LineString>>(url);
+
+      return new Observable<WmFeature<LineString>>(observer => {
+        // Prima cerca la track nel localForage (ec-tracks synchronized)
+        getEcTrackFromLocalForage(`${id}`).then(cachedTrack => {
+          // Se ci sono dati in cache locale, emettili subito
+          if (cachedTrack) {
+            observer.next(cachedTrack);
+          }
+
+          // Effettua la richiesta HTTP per ottenere la versione aggiornata
+          this._http
+            .get<WmFeature<LineString>>(url)
+            .pipe(take(1))
+            .subscribe(
+              remoteTrack => {
+                if (remoteTrack) {
+                  // Aggiorna il localForage solo se la track era già stata scaricata dall'utente
+                  if (cachedTrack) {
+                    saveEcTrack(`${id}`, remoteTrack).catch(err =>
+                      console.warn('getEcTrack: Failed to update localForage cache', err),
+                    );
+                  }
+                  observer.next(remoteTrack);
+                }
+                observer.complete();
+              },
+              error => {
+                if (!cachedTrack) {
+                  observer.error(error); // Errore solo se non ci sono dati in cache
+                } else {
+                  observer.complete(); // Completa senza errore se esiste la cache
+                }
+              },
+            );
+        });
+      });
     }
   }
 

--- a/projects/wm-core/src/store/features/ec/ec.service.ts
+++ b/projects/wm-core/src/store/features/ec/ec.service.ts
@@ -36,6 +36,7 @@ export class EcService {
     if (id == null) return of(null);
     if (+id > -1) {
       const url = `${this._environmentSvc.awsApi}/tracks/${id}.json`;
+      const lastModifiedKey = `${url}-last-modified`;
 
       return new Observable<WmFeature<LineString>>(observer => {
         // Prima cerca la track nel localForage (ec-tracks synchronized)
@@ -47,19 +48,39 @@ export class EcService {
 
           // Effettua la richiesta HTTP per ottenere la versione aggiornata
           this._http
-            .get<WmFeature<LineString>>(url)
+            .get<WmFeature<LineString>>(url, {
+              observe: 'response',
+              headers: (() => {
+                const cachedLastModified = localStorage.getItem(lastModifiedKey);
+                return cachedTrack && cachedLastModified ? {'If-Modified-Since': cachedLastModified} : {};
+              })(),
+            })
             .pipe(take(1))
             .subscribe(
-              remoteTrack => {
-                if (remoteTrack) {
-                  // Aggiorna il localForage solo se la track era già stata scaricata dall'utente
-                  if (cachedTrack) {
-                    saveEcTrack(`${id}`, remoteTrack).catch(err =>
-                      console.warn('getEcTrack: Failed to update localForage cache', err),
-                    );
+              response => {
+                const lastModified = response.headers.get('last-modified');
+
+                if (response.status === 200) {
+                  const remoteTrack = response.body;
+
+                  if (remoteTrack) {
+                    // Aggiorna il localForage solo se la track era già stata scaricata dall'utente
+                    if (cachedTrack) {
+                      saveEcTrack(`${id}`, remoteTrack).catch(err =>
+                        console.warn('getEcTrack: Failed to update localForage cache', err),
+                      );
+                    }
+
+                    if (lastModified) {
+                      localStorage.setItem(lastModifiedKey, lastModified);
+                    }
+
+                    observer.next(remoteTrack);
                   }
-                  observer.next(remoteTrack);
+                } else if (response.status === 304) {
+                  console.log(`No changes detected for track ${id}, using cached data.`);
                 }
+
                 observer.complete();
               },
               error => {


### PR DESCRIPTION
Updated the EcService to improve track retrieval by first checking localForage for cached track data before making an HTTP request. If cached data is available, it is emitted immediately, while the HTTP request fetches the latest version. This change optimizes performance and user experience by reducing unnecessary network calls and ensuring timely access to track information.
