### PR TITLE
chore(tab-description): ✨ enhance line height and max height handling oc:7281

### DIFF
--- a/projects/wm-core/src/tab-description/tab-description.component.scss
+++ b/projects/wm-core/src/tab-description/tab-description.component.scss
@@ -3,6 +3,8 @@ wm-tab-description{
   margin: var(--wm-feature-details-margin);
 
   .webmapp-pageroute-tabdescription-description {
+    // default line-height (0.875rem) sovrascrivibile via variabile CSS
+    --wm-description-line-height: 0.875rem;
     // padding: 10px;
     // padding-bottom: 0;
     padding-top: 10px;
@@ -10,13 +12,13 @@ wm-tab-description{
     color: var(--wm-feature-details-description-color);
     overflow: hidden;
     transition: max-height .4s ease-in-out;
-    max-height: calc(var(--wm-max-description-lines) * 16.8px);
+    max-height: calc(var(--wm-max-description-lines) * var(--wm-description-line-height));
     display: -webkit-box;
     -webkit-line-clamp: var(--wm-max-description-lines);
     -webkit-box-orient: vertical;
 
     &.expanded {
-      max-height: 2000px !important;
+      max-height: 5000px !important;
       -webkit-line-clamp: unset;
     }
   }

--- a/projects/wm-core/src/tab-description/tab-description.component.ts
+++ b/projects/wm-core/src/tab-description/tab-description.component.ts
@@ -5,6 +5,7 @@ import {
   ViewEncapsulation,
   ElementRef,
   ViewChild,
+  AfterViewInit,
 } from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {LangService} from '@wm-core/localization/lang.service';
@@ -22,7 +23,7 @@ type TranslationValue = string | Record<string, string | null> | null | undefine
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class WmTabDescriptionComponent {
+export class WmTabDescriptionComponent implements AfterViewInit {
   htmlDescription$: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
   @Input() set description(value: TranslationValue) {
@@ -35,8 +36,22 @@ export class WmTabDescriptionComponent {
   isExpanded$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   showExpandButton$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
-  constructor(public domSanitazer: DomSanitizer, private _langSvc: LangService) {
+  constructor(public domSanitazer: DomSanitizer, private _langSvc: LangService) {}
+
+  ngAfterViewInit() {
+    // imposta il numero massimo di righe come variabile globale
     document.documentElement.style.setProperty('--wm-max-description-lines', `${MAX_LINES}`);
+
+    const element = this.descriptionElement?.nativeElement as HTMLElement | undefined;
+    if (element) {
+      const computedLineHeight = window.getComputedStyle(element).lineHeight;
+
+      // se la line-height è valorizzata, usala come variabile CSS locale
+      if (computedLineHeight && computedLineHeight !== 'normal') {
+        element.style.setProperty('--wm-description-line-height', computedLineHeight);
+      }
+    }
+
     this._checkIfContentIsTruncated();
   }
 


### PR DESCRIPTION
- Introduced a default line height variable for the tab description component, allowing for customizable line height via CSS variables.
- Updated the max height calculation to utilize the new line height variable, improving flexibility in content display.
- Implemented AfterViewInit lifecycle hook to dynamically set the line height based on computed styles, ensuring accurate rendering of descriptions.
