### PR TITLE
fix(oc:8031): accept N-part hostnames in _wmpackagesRegex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,18 @@ Solo per smoke test ("il sistema è su e risponde"), non per test di logica UI.
 
 ## Features implementate
 
-| Feature | Ticket | Moduli toccati |
-|---|---|---|
-| Ricerca per layer/cammino nella home | oc:7643 | `home-result`, `ec` store (actions/reducer/effects/selectors), `layer-box`, `layer-features-counter-badge`, `user-activity.reducer` |
+| Feature | Ticket | Moduli toccati | Note |
+|---|---|---|---|
+| Fix regex hostname 5 parti | oc:8031 | `environment.service.ts`, `environment.service.spec.ts` | Regex aggiornata a `(?:\.[^.]+)+` per supportare domini Surge preview a N parti |
+| Ricerca per layer/cammino nella home | oc:7643 | `home-result`, `ec` store (actions/reducer/effects/selectors), `layer-box`, `layer-features-counter-badge`, `user-activity.reducer` | |
 
 ## Decisioni architetturali
+
+### Fix regex hostname 5 parti (oc:8031)
+
+- **`(?:\.[^.]+)+` invece di gruppi opzionali fissi**: accetta N parti TLD senza dover patchare la regex ad ogni nuovo provider o variante di dominio (es. Surge preview `pr-N.surge.sh`)
+- **Test spec su regex privata via `(service as any)`**: proprietà mantenuta `private`; guard `expect(regex).toBeDefined()` cattura rename silenziosi
+- **Rischio preesistente non affrontato**: `_assignApi()` crasha se `shardName` non è in `environment.shards` — da tracciare in ticket separato
 
 ### Tab layers nella home (oc:7643)
 

--- a/docs/features/8031-fix-environmentservice-regex-for-5-part-hostnames/notes.md
+++ b/docs/features/8031-fix-environmentservice-regex-for-5-part-hostnames/notes.md
@@ -1,0 +1,22 @@
+> Ticket: oc:8031
+
+# Notes — fix EnvironmentService regex for 5-part hostnames
+
+## Deviazioni dal piano
+
+Nessuna deviazione. Il piano è stato seguito linearmente.
+
+## Bug trovati
+
+Nessun bug aggiuntivo scoperto durante l'implementazione.
+
+## Decisioni
+
+- **Regex `(?:\.[^.]+)+` invece di gruppi opzionali fissi**: accetta N parti TLD invece di aggiungere un terzo `(?:\.[^.]+)?`. Più robusto e non richiede ulteriori patch per nuovi provider o varianti di dominio.
+- **Commento inline sulla regex**: aggiunto per documentare il formato Surge atteso (`<appId>.<shardName>[.mobile].<tld-parts…>`), così chiunque modifichi il workflow GitHub Actions sa immediatamente cosa aggiornare.
+- **Test spec solo sulla regex, non su `init()` end-to-end**: accesso tramite `(service as any)._wmpackagesRegex` con guard `expect(regex).toBeDefined()` per rilevare rename silenziosi.
+
+## Follow-up
+
+- **Guard in `_assignApi()` — rischio preesistente**: se la regex fa match ma `shardName` non è una chiave valida in `environment.shards`, `_assignApi()` crasha con `TypeError` e `init$` non emette mai `true` (app bloccata su schermata bianca). Questo bug precede questo ticket e non è aggravato dal fix, ma vale la pena aprire un ticket dedicato per aggiungere un guard del tipo `if (!this._environment.shards[this._shardName]) { this._shardName = 'geohub'; }`.
+- **`appId=NaN` nel branch `else`**: `parseInt('app', 10)` restituisce `NaN` su hostname come `app.webmapp.it`. Failure silenzioso — costruisce URL tipo `/NaN/config.json`. Anch'esso preesistente, merita un ticket separato.

--- a/docs/features/8031-fix-environmentservice-regex-for-5-part-hostnames/overview.md
+++ b/docs/features/8031-fix-environmentservice-regex-for-5-part-hostnames/overview.md
@@ -1,0 +1,37 @@
+> Ticket: oc:8031
+
+# fix EnvironmentService regex for 5-part hostnames
+
+## Cosa cambia
+
+`_wmpackagesRegex` in `EnvironmentService` viene aggiornata da una regex con gruppi opzionali fissi a una che accetta N parti di hostname (N ≥ 3), catturando sempre e solo `appId` (gruppo 1) e `shardName` (gruppo 2).
+
+## Perché
+
+I domini Surge preview generati dal workflow GitHub Actions hanno 5 parti (es. `1.camminiditalia.pr-53.surge.sh`). La regex attuale supporta al massimo 4 parti non-mobile, causando il fallback al branch `else` che forza `shardName = 'geohub'` e carica l'app sbagliata.
+
+## Requisiti
+
+- [ ] La regex aggiornata fa match su hostname a N parti (N ≥ 3), catturando `appId` e `shardName`
+- [ ] Regression: continua a fare match per hostname a 3, 4 e 4+mobile parti
+- [ ] La regex NON fa match su hostname senza `appId` numerico come prefisso (es. `app.webmapp.it`)
+- [ ] File spec `environment.service.spec.ts` creato con test case per tutti i pattern documentati
+- [ ] Lo spec accede alla regex tramite `(service as any)._wmpackagesRegex` — la proprietà rimane `private`
+
+## Rischi
+
+- **Nessun rischio di over-matching**: il prefisso `^(\d+)\.` vincola il match a hostname che iniziano con un numero. Hostname produzione come `app.webmapp.it` o `geohub.webmapp.it` non vengono toccati.
+- **Guard `_oldSubdomains` invariata**: il controllo `!this._oldSubdomains.includes(wmpackagesRegexMatch[2])` a riga 57 rimane intatto e continua a filtrare shard name legacy (`app`, `geohub`, `mobile`).
+
+## Out of scope
+
+- Test dell'`init()` end-to-end con mock di `window.location`
+- Supporto ad altri provider di preview oltre a Surge
+- Variante mobile dei domini Surge preview (`*.mobile.pr-N.surge.sh`)
+
+## Moduli toccati
+
+| File | Operazione | Repo |
+|---|---|---|
+| `projects/wm-core/src/services/environment.service.ts` | Modifica regex riga 12 | `wm-core` |
+| `projects/wm-core/src/services/environment.service.spec.ts` | Nuovo file | `wm-core` |

--- a/docs/features/8031-fix-environmentservice-regex-for-5-part-hostnames/plan.md
+++ b/docs/features/8031-fix-environmentservice-regex-for-5-part-hostnames/plan.md
@@ -1,0 +1,158 @@
+> Ticket: oc:8031
+
+# Plan — fix EnvironmentService regex for 5-part hostnames
+
+## Repo di destinazione
+
+Tutto il codice va nel submodule `wm-core` (`src/app/shared/wm-core/`).
+Il repo principale `wm-webapp` non viene toccato.
+
+---
+
+## Step 1 — Branch
+
+```bash
+cd src/app/shared/wm-core
+git checkout -b feature/oc-8031-fix-environmentservice-regex-for-5-part-hostnames
+```
+
+---
+
+## Step 2 — Fix regex
+
+**File:** `projects/wm-core/src/services/environment.service.ts`
+
+Riga 12 — sostituire:
+
+```typescript
+private _wmpackagesRegex = /^(\d+)\.([a-zA-Z0-9-]+)(?:\.mobile)?\.[^.]+(?:\.[^.]+)?$/;
+```
+
+Con:
+
+```typescript
+// matches <appId>.<shardName>[.mobile].<tld-parts…> — e.g. 1.camminiditalia.pr-53.surge.sh
+private _wmpackagesRegex = /^(\d+)\.([a-zA-Z0-9-]+)(?:\.mobile)?(?:\.[^.]+)+$/;
+```
+
+Il cambio è da `\.[^.]+(?:\.[^.]+)?$` (al massimo 2 parti TLD fisse) a `(?:\.[^.]+)+$` (una o più parti TLD, qualsiasi numero).
+
+---
+
+## Step 3 — Spec file
+
+**File nuovo:** `projects/wm-core/src/services/environment.service.spec.ts`
+
+Nessuna registrazione richiesta — `tsconfig.spec.json` usa `"**/*.spec.ts"`.
+
+Struttura dello spec:
+
+```typescript
+import {TestBed} from '@angular/core/testing';
+import {EnvironmentService} from './environment.service';
+
+describe('EnvironmentService — _wmpackagesRegex', () => {
+  let service: EnvironmentService;
+  let regex: RegExp;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({providers: [EnvironmentService]});
+    service = TestBed.inject(EnvironmentService);
+    regex = (service as any)._wmpackagesRegex as RegExp;
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('should define _wmpackagesRegex', () => {
+    expect(regex).toBeDefined();
+    expect(regex).toBeInstanceOf(RegExp);
+  });
+
+  // --- casi che devono fare match ---
+
+  it('should match 3-part hostname', () => {
+    const m = '1.camminiditalia.surge.sh'.match(regex);  // <id>.<shard>.<tld>.<ext>
+    // nota: surge.sh è TLD a 2 parti → 4 parti totali
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match 4-part hostname (webmapp.it)', () => {
+    const m = '1.camminiditalia.webmapp.it'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match 4-part hostname with .mobile', () => {
+    const m = '1.camminiditalia.mobile.webmapp.it'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match 5-part Surge preview hostname', () => {
+    const m = '1.camminiditalia.pr-53.surge.sh'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match with multi-digit appId', () => {
+    const m = '123.myapp.pr-100.surge.sh'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('123');
+    expect(m![2]).toBe('myapp');
+  });
+
+  // --- casi che NON devono fare match ---
+
+  it('should not match hostname without numeric appId prefix', () => {
+    expect('app.webmapp.it'.match(regex)).toBeNull();
+  });
+
+  it('should not match hostname starting with text', () => {
+    expect('geohub.webmapp.it'.match(regex)).toBeNull();
+  });
+
+  it('should not match localhost', () => {
+    expect('localhost'.match(regex)).toBeNull();
+  });
+
+  it('should not match bare domain without dots', () => {
+    expect('webmapp'.match(regex)).toBeNull();
+  });
+});
+```
+
+---
+
+## Step 4 — Verifica test
+
+```bash
+# dalla root di wm-core
+nvm use 22 && CI=true npx ng test wm-core --configuration=ci
+```
+
+I test esistenti (112 spec) devono continuare a passare. Il nuovo spec aggiunge ~9 test.
+
+---
+
+## Step 5 — Commit
+
+```bash
+cd src/app/shared/wm-core
+git add projects/wm-core/src/services/environment.service.ts
+git add projects/wm-core/src/services/environment.service.spec.ts
+git commit -m "fix(oc:8031): accept N-part hostnames in _wmpackagesRegex"
+```
+
+---
+
+## Note di implementazione
+
+- **Nessuna modifica al branching logic** di `init()` — solo la regex cambia.
+- Il guard `!this._oldSubdomains.includes(wmpackagesRegexMatch[2])` rimane invariato.
+- Il rischio di crash in `_assignApi()` quando `shardName` non è in `shards` è preesistente e fuori scope — tracciato nelle note della feature.

--- a/projects/wm-core/src/services/environment.service.spec.ts
+++ b/projects/wm-core/src/services/environment.service.spec.ts
@@ -1,0 +1,72 @@
+import {TestBed} from '@angular/core/testing';
+import {EnvironmentService} from './environment.service';
+
+describe('EnvironmentService — _wmpackagesRegex', () => {
+  let service: EnvironmentService;
+  let regex: RegExp;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({providers: [EnvironmentService]});
+    service = TestBed.inject(EnvironmentService);
+    regex = (service as any)._wmpackagesRegex as RegExp;
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('should define _wmpackagesRegex', () => {
+    expect(regex).toBeDefined();
+    expect(regex).toBeInstanceOf(RegExp);
+  });
+
+  it('should match 4-part hostname (surge.sh)', () => {
+    const m = '1.camminiditalia.surge.sh'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match 4-part hostname (webmapp.it)', () => {
+    const m = '1.camminiditalia.webmapp.it'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match 4-part hostname with .mobile', () => {
+    const m = '1.camminiditalia.mobile.webmapp.it'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match 5-part Surge preview hostname', () => {
+    const m = '1.camminiditalia.pr-53.surge.sh'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('1');
+    expect(m![2]).toBe('camminiditalia');
+  });
+
+  it('should match with multi-digit appId', () => {
+    const m = '123.myapp.pr-100.surge.sh'.match(regex);
+    expect(m).toBeTruthy();
+    expect(m![1]).toBe('123');
+    expect(m![2]).toBe('myapp');
+  });
+
+  it('should not match hostname without numeric appId prefix', () => {
+    expect('app.webmapp.it'.match(regex)).toBeNull();
+  });
+
+  it('should not match hostname starting with text', () => {
+    expect('geohub.webmapp.it'.match(regex)).toBeNull();
+  });
+
+  it('should not match localhost', () => {
+    expect('localhost'.match(regex)).toBeNull();
+  });
+
+  it('should not match bare domain without dots', () => {
+    expect('webmapp'.match(regex)).toBeNull();
+  });
+});

--- a/projects/wm-core/src/services/environment.service.ts
+++ b/projects/wm-core/src/services/environment.service.ts
@@ -9,7 +9,8 @@ import {filter, take} from 'rxjs/operators';
 export class EnvironmentService {
   private _environment: Environment;
   private _hostname: string;
-  private _wmpackagesRegex = /^(\d+)\.([a-zA-Z0-9-]+)(?:\.mobile)?\.[^.]+(?:\.[^.]+)?$/;
+  // matches <appId>.<shardName>[.mobile].<tld-parts…>
+  private _wmpackagesRegex = /^(\d+)\.([a-zA-Z0-9-]+)(?:\.mobile)?(?:\.[^.]+)+$/;
   private _localHostRegex = /^localhost/;
   private _appId: number;
   private _shardName: string;


### PR DESCRIPTION
## Summary

- Sostituisce i gruppi opzionali fissi `\.[^.]+(?:\.[^.]+)?$` con `(?:\.[^.]+)+$` in `_wmpackagesRegex`
- Supporta ora domini Surge preview a 5 parti (es. `1.camminiditalia.pr-53.surge.sh`) e qualsiasi numero di parti TLD future
- Aggiunge `environment.service.spec.ts` con 10 test case (match e no-match) su tutti i pattern hostname noti

## Test plan

- [x] `ng test wm-core --configuration=ci` — 122/122 SUCCESS
- [ ] Verificare manualmente aprendo un URL Surge preview reale che carichi l'app corretta (non geohub)

## Riferimento

Ticket: oc:8031

🤖 Generated with [Claude Code](https://claude.com/claude-code)