### PR TITLE
feat(oc:8115): add PosthogContextService to auto-enrich PostHog events with context

### DIFF
--- a/docs/features/8115-posthog/notes.md
+++ b/docs/features/8115-posthog/notes.md
@@ -1,0 +1,55 @@
+> Ticket: oc:8115
+
+# Notes — oc:8115 PostHog Context Enrichment
+
+## Deviazioni dal piano
+
+### D1 — Navigation events in `geobox-map.component.ts` invece di `GeolocationService`
+
+**Piano:** catturare `navigationStarted`/`navigationStopped` in `GeolocationService.onModeChange$`.
+
+**Implementato:** eventi catturati nel metodo `navigation()` di `geobox-map.component.ts`, sulla base del toggle `focus` (focus=true → `navigationStarted`, focus=false → `navigationStopped`).
+
+**Motivazione:** la navigazione intesa nel ticket è il "centra su posizione" (focus sulla posizione GPS), non una modalità di navigazione GPS distinta. Il metodo `navigation()` in `geobox-map` è il punto di ingresso esatto di questa azione utente. L'approccio via `onModeChange$` avrebbe catturato transizioni di modalità non correlate.
+
+---
+
+### D2 — Rinominazione `ec_poi_id` / `ec_track_id` → `poi_id` / `track_id`
+
+**Piano (overview.md):** proprietà `ec_poi_id` e `ec_track_id`.
+
+**Implementato:** `poi_id` e `track_id` (senza prefisso `ec_`).
+
+**Motivazione:** le chiavi UGC usano già il prefisso (`ugc_poi_id`, `ugc_track_id`). Le chiavi EC senza prefisso sono più leggibili nei dashboard PostHog e simmetriche con la convenzione esistente.
+
+---
+
+### D3 — Modifica `wm-types` (inizialmente "Out of scope")
+
+**Piano (overview.md):** `wm-types` indicato come out of scope.
+
+**Implementato:** `WmPosthogProps` in `wm-types/src/posthog.ts` aggiornato da `Record<string, any>` a interfaccia con proprietà tipate note (context props + event-specific props).
+
+**Motivazione:** tipare le proprietà in `wm-types` (livello base della dipendenza) garantisce type safety su tutti i call site senza duplicare la definizione. Il rischio era zero — modifica additiva, retrocompatibile via index signature poi rimossa a favore di proprietà esplicite.
+
+---
+
+### D4 — Recording events in `GeolocationService` (conforme al piano)
+
+Nessuna deviazione. `recordingStarted`/`recordingStopped` sono catturati su `onModeChange.pipe(pairwise())` come pianificato.
+
+---
+
+## Fix post-review
+
+### F1 — `implements WmPosthogClient` aggiunto
+
+`PosthogContextService` dichiarava implicitamente la stessa firma di `WmPosthogClient` senza dichiararla. Aggiunto `implements WmPosthogClient` per garantire che TypeScript segnali eventuali drift futuri dell'interfaccia.
+
+### F2 — Subscription NgRx con `takeUntilDestroyed`
+
+La subscription `combineLatest` nel costruttore non aveva cleanup. Aggiunto `DestroyRef` e `.pipe(takeUntilDestroyed(this._destroyRef))`.
+
+### F3 — Proprietà GPS collassate in `user_location` (oggetto)
+
+Invece di proprietà flat `user_lat`, `user_lng`, `user_accuracy`, si usa un singolo oggetto `user_location: {latitude, longitude, accuracy?}`. PostHog serializza gli oggetti come JSON; i campi sono accessibili con dot notation nei filtri del dashboard. Scelta privilegiata per contesto descrittivo, non per segmentazione per coorte.

--- a/docs/features/8115-posthog/overview.md
+++ b/docs/features/8115-posthog/overview.md
@@ -1,0 +1,77 @@
+> Ticket: oc:8115
+
+# PostHog — arricchimento eventi con contesto standard
+
+## Cosa cambia
+
+Ogni evento PostHog catturato dall'app riceve automaticamente un set di proprietà di contesto
+standard (posizione utente, layer/POI/track selezionati) senza che i siti di chiamata debbano
+fare nulla di diverso. Vengono inoltre aggiunti quattro nuovi eventi per tracciare l'inizio e la
+fine delle sessioni di navigazione e registrazione traccia.
+
+## Perché
+
+Il team analytics non può correlare gli eventi (es. `filterUsed`, `trackDownloaded`) al contesto
+geografico e di selezione in cui sono avvenuti. L'obiettivo è arricchire ogni evento con le
+informazioni disponibili (posizione GPS, layer/track/POI attivo) per abilitare analisi di funnel
+e segmentazione geografica.
+
+## Requisiti
+
+- [ ] Creare `PosthogContextService` in wm-core che implementa `WmPosthogClient` e funge da
+      wrapper trasparente intorno a `PosthogCapacitorClient`
+- [ ] Il wrapper legge in modo sincrono (snapshot da subscription) le seguenti proprietà di
+      contesto e le aggiunge a ogni `capture()`:
+  - `user_lat`, `user_lng` — da `GeolocationService.location.latitude/longitude`
+  - `user_accuracy` — da `GeolocationService.location.accuracy` (opzionale)
+  - `layer_id` — da selettore `currentEcLayer` → `layer.id` (se presente)
+  - `ec_poi_id` — da selettore `currentEcPoiId` (se presente)
+  - `ugc_poi_id` — da selettore `currentUgcPoiId` (se presente)
+  - `ec_track_id` — da selettore `currentEcTrack` → `properties.id` (se presente)
+  - `ugc_track_id` — da selettore `currentUgcTrackId` (se presente)
+- [ ] Solo i campi con valore definito e non-null vengono inclusi (nessun `null` esplicito)
+- [ ] L'arricchimento si applica a **tutti** gli eventi, nuovi e preesistenti, indiscriminatamente
+- [ ] Sostituire il provider `POSTHOG_CLIENT` in `wm-core.module.ts` con `PosthogContextService`
+      (mantenendo `PosthogCapacitorClient` come implementazione interna)
+- [ ] Aggiungere in `GeolocationService` una subscription a `onModeChange$` che cattura i
+      quattro nuovi eventi:
+  - `navigationStarted` — alla transizione verso `'navigation'`
+  - `navigationStopped` — alla transizione da `'navigation'` verso `'stopped'`
+  - `recordingStarted` — alla transizione verso `'recording'`
+  - `recordingStopped` — alla transizione da `'recording'` verso `'stopped'`
+
+## Rischi
+
+- **Snapshot stale:** se la subscription che mantiene il snapshot del contesto è lenta o
+  deferred, un evento catturato subito dopo un cambio di stato potrebbe ricevere proprietà
+  obsolete. Mitigazione: usare `BehaviorSubject` o snapshot sincrono con `Store.select` +
+  `take(1)` + caching locale.
+- **Circolarità di iniezione:** `PosthogContextService` inietterà `PosthogCapacitorClient`
+  direttamente (non via token `POSTHOG_CLIENT`) per evitare dipendenza circolare con il provider
+  che punta al wrapper stesso.
+- **onModeChange$ subscription leak:** la subscription in `GeolocationService` deve essere
+  gestita con `takeUntil` o `ngOnDestroy` per evitare memory leak. Essendo un servizio root,
+  il ciclo di vita è quello dell'app — il rischio è basso ma va gestito con `pairwise()` per
+  distinguere le transizioni.
+- **Dati sensibili (GDPR):** `user_lat/lng` sono dati di geolocalizzazione. Il consenso
+  dell'utente è già gestito a monte dalla configurazione PostHog — questo servizio non introduce
+  nuovi obblighi, ma va documentato nel DPA se non già presente.
+
+## Out of scope
+
+- Modifiche ai siti di chiamata `capture()` esistenti (il wrapper è trasparente)
+- Aggiunta di nuovi eventi oltre ai quattro di navigazione/recording
+- Tracking del pulsante favourite
+- Modifiche al repo principale (nessun file fuori da wm-core è toccato)
+- Modifiche a `wm-types` (i tipi esistenti `WmPosthogProps = Record<string, any>` sono
+  sufficienti)
+
+## Moduli toccati
+
+Tutti i file sono in `core/src/app/shared/wm-core/`:
+
+| File | Tipo | Note |
+|------|------|------|
+| `projects/wm-core/src/services/posthog-context.service.ts` | **NUOVO** | Wrapper `WmPosthogClient` con arricchimento contesto |
+| `projects/wm-core/src/services/geolocation.service.ts` | MODIFICA | Subscription `onModeChange$` per i 4 nuovi eventi |
+| `projects/wm-core/src/wm-core.module.ts` | MODIFICA | `POSTHOG_CLIENT` → `useExisting: PosthogContextService` |

--- a/docs/features/8115-posthog/plan.md
+++ b/docs/features/8115-posthog/plan.md
@@ -1,0 +1,214 @@
+> Ticket: oc:8115
+
+# Piano implementativo — PostHog context enrichment
+
+Tutti i file sono in `wm-core` (`core/src/app/shared/wm-core/`).  
+Commit convention: `feat(oc:8115): ...`
+
+---
+
+## Task 1 — Crea branch feature in wm-core
+
+```bash
+cd core/src/app/shared/wm-core
+git checkout -b feature/oc-8115-posthog
+```
+
+---
+
+## Task 2 — Crea `PosthogContextService`
+
+**File:** `projects/wm-core/src/services/posthog-context.service.ts` (NUOVO)
+
+Il servizio implementa `WmPosthogClient` e funge da wrapper trasparente intorno a
+`PosthogCapacitorClient`. Mantiene un snapshot sincrono del contesto NgRx tramite subscription,
+che viene aggiunto a ogni `capture()`.
+
+**Nota circolarità:** `PosthogContextService` ha bisogno di `GeolocationService.location`,
+ma `GeolocationService` inietta `POSTHOG_CLIENT` (che punta a `PosthogContextService`).
+Per rompere la circolarità, `PosthogContextService` inietta `Injector` e ottiene
+`GeolocationService` in modo lazy al primo utilizzo — pattern Angular standard per
+dipendenze circolari.
+
+**Struttura del servizio:**
+
+```typescript
+@Injectable()
+export class PosthogContextService implements WmPosthogClient {
+  private _contextSnapshot: WmPosthogProps = {};
+  private _geolocationSvc: GeolocationService | null = null;
+
+  constructor(
+    private _client: PosthogCapacitorClient,  // diretto, non via token
+    private _store: Store,
+    private _injector: Injector,
+  ) {
+    // Subscription selettori NgRx → snapshot sincrono
+    combineLatest([
+      this._store.select(currentEcLayer),
+      this._store.select(currentEcPoiId),
+      this._store.select(currentUgcPoiId),
+      this._store.select(currentEcTrack),
+      this._store.select(currentUgcTrackId),
+    ]).subscribe(([layer, ecPoiId, ugcPoiId, ecTrack, ugcTrackId]) => {
+      const snap: WmPosthogProps = {};
+      if (layer?.id != null) snap['layer_id'] = `${layer.id}`;
+      if (ecPoiId != null)   snap['ec_poi_id'] = `${ecPoiId}`;
+      if (ugcPoiId != null)  snap['ugc_poi_id'] = `${ugcPoiId}`;
+      if (ecTrack?.properties?.id != null) snap['ec_track_id'] = `${ecTrack.properties.id}`;
+      if (ugcTrackId != null) snap['ugc_track_id'] = `${ugcTrackId}`;
+      this._contextSnapshot = snap;
+    });
+  }
+
+  private get _geo(): GeolocationService {
+    if (!this._geolocationSvc) {
+      this._geolocationSvc = this._injector.get(GeolocationService);
+    }
+    return this._geolocationSvc;
+  }
+
+  private _buildContext(): WmPosthogProps {
+    const ctx = {...this._contextSnapshot};
+    const loc = this._geo.location;
+    if (loc && Number.isFinite(loc.latitude) && Number.isFinite(loc.longitude)) {
+      ctx['user_lat'] = loc.latitude;
+      ctx['user_lng'] = loc.longitude;
+      if (Number.isFinite(loc.accuracy)) ctx['user_accuracy'] = loc.accuracy;
+    }
+    return ctx;
+  }
+
+  // Le props evento-specifiche sovrascrivono quelle di contesto (caller wins)
+  capture(event: string, props: WmPosthogProps = {}): Promise<void> {
+    return this._client.capture(event, {...this._buildContext(), ...props});
+  }
+
+  identify(distinctId: string, props?: WmPosthogProps): Promise<void> {
+    return this._client.identify(distinctId, props);
+  }
+
+  initAndRegister(props: WmPosthogProps, options?: WmPosthogInitOptions): Promise<void> {
+    return this._client.initAndRegister(props, options);
+  }
+
+  reset(): Promise<void> {
+    return this._client.reset();
+  }
+}
+```
+
+**Selettori da importare:**
+- `currentEcLayer` da `@wm-core/store/user-activity/user-activity.selector`
+- `currentEcPoiId`, `currentEcTrack` da `@wm-core/store/features/ec/ec.selector`
+- `currentUgcPoiId`, `currentUgcTrackId` da `@wm-core/store/features/ugc/ugc.selector`
+
+---
+
+## Task 3 — Aggiorna `wm-core.module.ts`
+
+**File:** `projects/wm-core/src/wm-core.module.ts` (MODIFICA)
+
+Nel metodo `forRoot()`, sostituire il provider `POSTHOG_CLIENT` e aggiungere
+`PosthogContextService`:
+
+```typescript
+// PRIMA:
+PosthogCapacitorClient,
+{provide: POSTHOG_CLIENT, useExisting: PosthogCapacitorClient},
+
+// DOPO:
+PosthogCapacitorClient,
+PosthogContextService,
+{provide: POSTHOG_CLIENT, useExisting: PosthogContextService},
+```
+
+Aggiungere l'import di `PosthogContextService` in testa al file.
+
+---
+
+## Task 4 — Aggiorna `GeolocationService`
+
+**File:** `projects/wm-core/src/services/geolocation.service.ts` (MODIFICA)
+
+**4a — Aggiunge dipendenza opzionale PostHog al costruttore:**
+
+```typescript
+constructor(
+  private _deviceService: DeviceService,
+  private _store: Store,
+  @Optional() @Inject(POSTHOG_CLIENT) private _posthogClient: WmPosthogClient | null,
+) { ... }
+```
+
+Aggiungere gli import necessari: `Optional`, `Inject` da `@angular/core`;
+`POSTHOG_CLIENT` da `@wm-core/store/conf/conf.token`;
+`WmPosthogClient` da `@wm-types/posthog`.
+
+**4b — Subscription `onModeChange` con `pairwise()` nel costruttore:**
+
+Aggiungere dopo il listener `App.addListener`:
+
+```typescript
+this.onModeChange
+  .pipe(pairwise())
+  .subscribe(([prev, curr]) => {
+    if (curr === 'navigation') {
+      this._posthogClient?.capture('navigationStarted');
+    } else if (prev === 'navigation' && curr === 'stopped') {
+      this._posthogClient?.capture('navigationStopped');
+    }
+    if (curr === 'recording') {
+      this._posthogClient?.capture('recordingStarted');
+    } else if (prev === 'recording' && curr === 'stopped') {
+      this._posthogClient?.capture('recordingStopped');
+    }
+  });
+```
+
+Aggiungere import di `pairwise` da `rxjs/operators`.
+
+**Nota:** `onModeChange` è un `BehaviorSubject` con valore iniziale `'stopped'`.
+`pairwise()` aspetta 2 emissioni prima di emettere la prima coppia, quindi la
+transizione iniziale `undefined → 'stopped'` non viene mai catturata — comportamento
+corretto.
+
+---
+
+## Task 5 — Commit in wm-core
+
+```bash
+cd core/src/app/shared/wm-core
+git add projects/wm-core/src/services/posthog-context.service.ts \
+        projects/wm-core/src/services/geolocation.service.ts \
+        projects/wm-core/src/wm-core.module.ts \
+        docs/features/8115-posthog/
+git commit -m "feat(oc:8115): add PosthogContextService wrapper with standard context enrichment"
+```
+
+---
+
+## Task 6 — Aggiorna puntatore submodule nel repo principale
+
+```bash
+cd /Users/peco/Documents/Apps/webmapp-app
+git add core/src/app/shared/wm-core
+git commit -m "feat(oc:8115): bump wm-core to posthog context service"
+```
+
+---
+
+## Task 7 — Apri PR
+
+```bash
+# In wm-core
+cd core/src/app/shared/wm-core
+git push -u origin feature/oc-8115-posthog
+
+# Nel repo principale
+cd /Users/peco/Documents/Apps/webmapp-app
+git checkout -b feature/oc-8115-posthog
+git push -u origin feature/oc-8115-posthog
+gh pr create --base develop --title "feat(oc:8115): PostHog context enrichment" \
+  --body "..."
+```

--- a/projects/wm-core/src/box/layer-box/layer-box.component.ts
+++ b/projects/wm-core/src/box/layer-box/layer-box.component.ts
@@ -38,9 +38,12 @@ export class LayerBoxComponent extends BaseBoxComponent<ILAYERBOX> {
   onClick(): void {
     if (this._posthogClient && this.data?.layer) {
       const layerId = `${this.data.layer.id}`;
-      const layerName = this.data.layer.title ?? this.data.title ?? '';
+      const rawTitle = this.data.layer.title ?? this.data.title ?? '';
+      const layerName =
+        typeof rawTitle === 'string'
+          ? rawTitle
+          : rawTitle.it ?? Object.values(rawTitle).find(v => v) ?? '';
       this._posthogClient.capture('layerOpened', {
-        layer_id: layerId,
         layer_name: layerName,
         layer_label: `${layerId} - ${layerName}`,
       });

--- a/projects/wm-core/src/form/select-nearby-layer/select-nearby-layer.component.spec.ts
+++ b/projects/wm-core/src/form/select-nearby-layer/select-nearby-layer.component.spec.ts
@@ -23,6 +23,7 @@ describe('WmSelectNearbyLayerComponent', () => {
   let store: MockStore;
 
   beforeEach(async () => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       declarations: [WmSelectNearbyLayerComponent],
       imports: [ReactiveFormsModule, IonicModule.forRoot(), CommonModule, WmPipeModule],
@@ -49,7 +50,7 @@ describe('WmSelectNearbyLayerComponent', () => {
     component = fixture.componentInstance;
   });
 
-  afterEach(() => store.resetSelectors());
+  afterEach(() => store?.resetSelectors());
 
   it('pre-seleziona currentEcLayer se presente nello store', () => {
     store.overrideSelector(currentEcLayer, {id: '81'} as any);

--- a/projects/wm-core/src/geobox-map/geobox-map.component.ts
+++ b/projects/wm-core/src/geobox-map/geobox-map.component.ts
@@ -4,7 +4,9 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  Inject,
   OnDestroy,
+  Optional,
   Output,
   ViewChild,
   ViewEncapsulation,
@@ -138,6 +140,8 @@ import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
 import {GeoutilsService} from '@wm-core/services/geoutils.service';
 import {EnvironmentService} from '@wm-core/services/environment.service';
+import {POSTHOG_CLIENT} from '@wm-core/store/conf/conf.token';
+import {WmPosthogClient} from '@wm-types/posthog';
 import {FeatureLike} from 'ol/Feature';
 import {OPTIONS, ZoomFeaturesInViewport} from '@wm-types/config';
 import {Location} from '@wm-types/feature';
@@ -329,6 +333,7 @@ export class WmGeoboxMapComponent implements AfterViewInit, OnDestroy {
     private _geolocationSvc: GeolocationService,
     private _geoutilsSvc: GeoutilsService,
     private _environmentSvc: EnvironmentService,
+    @Optional() @Inject(POSTHOG_CLIENT) private _posthogClient: WmPosthogClient | null,
   ) {
     this._actions$.pipe(ofType(resetMap), takeUntil(this._destroy$)).subscribe(() => {
       this.mapCmp?.resetView();
@@ -490,6 +495,7 @@ export class WmGeoboxMapComponent implements AfterViewInit, OnDestroy {
         focus = !wmMapPositionfocus;
       }
       this._store.dispatch(setFocusPosition({focusPosition: focus}));
+      this._posthogClient?.capture(focus ? 'navigationStarted' : 'navigationStopped');
     });
   }
 

--- a/projects/wm-core/src/pipes/wmtrans.pipe.spec.ts
+++ b/projects/wm-core/src/pipes/wmtrans.pipe.spec.ts
@@ -21,6 +21,10 @@ describe('WmTransPipe', () => {
   });
 
   beforeEach(() => {
+    // Reset static state that may have been left by other spec files using WmPipeModule
+    (WmTransPipe as any)['sub']?.unsubscribe();
+    (WmTransPipe as any)['sub'] = null;
+    ((WmTransPipe as any)['cdrs'] as Set<any>).clear();
     TestBed.resetTestingModule();
     langChange$ = new Subject<void>();
     cdrMock = jasmine.createSpyObj<ChangeDetectorRef>('ChangeDetectorRef', ['markForCheck']);

--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Inject, Injectable, Optional} from '@angular/core';
 import {BehaviorSubject, from, Observable, of, ReplaySubject} from 'rxjs';
 import {
   BackgroundGeolocationPlugin,
@@ -12,10 +12,12 @@ import {WmFeature} from '@wm-types/feature';
 import {DeviceService} from './device.service';
 import {CStopwatch} from '@wm-core/utils/cstopwatch';
 import {getDistance} from 'ol/sphere';
-import {distinctUntilChanged, map, startWith, throttleTime} from 'rxjs/operators';
+import {distinctUntilChanged, map, pairwise, startWith, throttleTime} from 'rxjs/operators';
 import {Store} from '@ngrx/store';
 import {setFocusPosition, setOnRecord} from '@wm-core/store/user-activity/user-activity.action';
 import {onRecord} from '@wm-core/store/user-activity/user-activity.selector';
+import {POSTHOG_CLIENT} from '@wm-core/store/conf/conf.token';
+import {WmPosthogClient} from '@wm-types/posthog';
 import {
   getCurrentUgcTrackLocations,
   saveCurrentUgcTrackLocations,
@@ -45,7 +47,11 @@ export class GeolocationService {
   );
   onRecord$: Observable<boolean> = this._store.select(onRecord);
 
-  constructor(private _deviceService: DeviceService, private _store: Store) {
+  constructor(
+    private _deviceService: DeviceService,
+    private _store: Store,
+    @Optional() @Inject(POSTHOG_CLIENT) private _posthogClient: WmPosthogClient | null,
+  ) {
     if (!this._deviceService.isBrowser) {
       App.addListener('appStateChange', async ({isActive}) => {
         if (isActive) {
@@ -57,6 +63,14 @@ export class GeolocationService {
         }
       });
     }
+
+    this.onModeChange.pipe(pairwise()).subscribe(([prev, curr]) => {
+      if (curr === 'recording') {
+        this._posthogClient?.capture('recordingStarted');
+      } else if (prev === 'recording' && curr === 'stopped') {
+        this._posthogClient?.capture('recordingStopped');
+      }
+    });
   }
 
   get recordTime(): number {

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -1,0 +1,82 @@
+import {DestroyRef, Injectable, Injector} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {Store} from '@ngrx/store';
+import {currentEcPoiId, currentEcTrack} from '@wm-core/store/features/ec/ec.selector';
+import {currentUgcPoiId, currentUgcTrackId} from '@wm-core/store/features/ugc/ugc.selector';
+import {currentEcLayer} from '@wm-core/store/user-activity/user-activity.selector';
+import {WmPosthogClient, WmPosthogInitOptions, WmPosthogProps} from '@wm-types/posthog';
+import {combineLatest} from 'rxjs';
+import {PosthogCapacitorClient} from './posthog-capacitor.client';
+import {GeolocationService} from './geolocation.service';
+
+/**
+ * Wrapper trasparente di PosthogCapacitorClient che arricchisce ogni capture()
+ * con proprietà di contesto standard (posizione GPS, layer/track/POI selezionati).
+ *
+ * Viene fornito come POSTHOG_CLIENT in wm-core.module.ts al posto del client diretto.
+ * GeolocationService è iniettato in modo lazy via Injector per evitare circolarità.
+ * Non usare providedIn: 'root' — richiede PosthogCapacitorClient fornito da WmCoreModule.forRoot().
+ */
+@Injectable()
+export class PosthogContextService implements WmPosthogClient {
+  private _contextSnapshot: WmPosthogProps = {};
+  private _geolocationSvcRef: GeolocationService | null = null;
+
+  constructor(
+    private _client: PosthogCapacitorClient,
+    private _store: Store,
+    private _injector: Injector,
+    private _destroyRef: DestroyRef,
+  ) {
+    combineLatest([
+      this._store.select(currentEcLayer),
+      this._store.select(currentEcPoiId),
+      this._store.select(currentUgcPoiId),
+      this._store.select(currentEcTrack),
+      this._store.select(currentUgcTrackId),
+    ])
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(([layer, ecPoiId, ugcPoiId, ecTrack, ugcTrackId]) => {
+        const snap: WmPosthogProps = {};
+        if (layer?.id != null) snap['layer_id'] = `${layer.id}`;
+        if (ecPoiId != null && ecPoiId !== 0) snap['poi_id'] = `${ecPoiId}`;
+        if (ugcPoiId != null) snap['ugc_poi_id'] = `${ugcPoiId}`;
+        if (ecTrack?.properties?.id != null) snap['track_id'] = `${ecTrack.properties.id}`;
+        if (ugcTrackId != null) snap['ugc_track_id'] = `${ugcTrackId}`;
+        this._contextSnapshot = snap;
+      });
+  }
+
+  private get _geolocationSvc(): GeolocationService {
+    if (!this._geolocationSvcRef) {
+      this._geolocationSvcRef = this._injector.get(GeolocationService);
+    }
+    return this._geolocationSvcRef;
+  }
+
+  private _buildContext(): WmPosthogProps {
+    const ctx = {...this._contextSnapshot};
+    const loc = this._geolocationSvc.location;
+    if (loc && Number.isFinite(loc.latitude) && Number.isFinite(loc.longitude)) {
+      ctx['user_location'] = loc;
+    }
+    return ctx;
+  }
+
+  /** Le props evento-specifiche sovrascrivono quelle di contesto. */
+  capture(event: string, props: WmPosthogProps = {}): Promise<void> {
+    return this._client.capture(event, {...this._buildContext(), ...props});
+  }
+
+  identify(distinctId: string, props?: WmPosthogProps): Promise<void> {
+    return this._client.identify(distinctId, props);
+  }
+
+  initAndRegister(props: WmPosthogProps, options?: WmPosthogInitOptions): Promise<void> {
+    return this._client.initAndRegister(props, options);
+  }
+
+  reset(): Promise<void> {
+    return this._client.reset();
+  }
+}

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -85,6 +85,7 @@ import {IconsEffects} from './store/icons/icons.effects';
 import {register} from 'swiper/element/bundle';
 import {Capacitor} from '@capacitor/core';
 import {PosthogCapacitorClient} from './services/posthog-capacitor.client';
+import {PosthogContextService} from './services/posthog-context.service';
 import {EnvironmentService} from './services/environment.service';
 import {
   APP_TRANSLATION,
@@ -352,7 +353,8 @@ export class WmCoreModule {
         {provide: APP_TRANSLATION, useValue: config.translations || {}},
         {provide: POSTHOG_CONFIG, useValue: config.posthog},
         PosthogCapacitorClient,
-        {provide: POSTHOG_CLIENT, useExisting: PosthogCapacitorClient},
+        PosthogContextService,
+        {provide: POSTHOG_CLIENT, useExisting: PosthogContextService},
       ],
     };
   }


### PR DESCRIPTION
## Summary

- **Nuovo `PosthogContextService`**: wrapper trasparente su `PosthogCapacitorClient` che inietta automaticamente su ogni `capture()`: `user_location` (GPS), `layer_id`, `poi_id`, `track_id`, `ugc_poi_id`, `ugc_ugc_track_id`
- Fornito come `POSTHOG_CLIENT` via `useExisting` in `WmCoreModule.forRoot()` — nessun cambio nei call site
- Circolarità `PosthogContextService → GeolocationService → POSTHOG_CLIENT` risolta con lazy injection via `Injector`
- `implements WmPosthogClient` + `takeUntilDestroyed` per correttezza TypeScript e cleanup subscription
- **`navigationStarted`/`navigationStopped`** catturati in `geobox-map.component.ts` (toggle focus)
- **`recordingStarted`/`recordingStopped`** catturati in `geolocation.service.ts` (transizione `onModeChange`)
- `layer-box`: rimosso `layer_id` ridondante da `layerOpened` (ora auto-iniettato); `layer_name` risolto da `iLocalString` → `string` (preferenza italiana)

## Test plan

- [ ] Aprire un layer → verificare in PostHog che `layerOpened` contenga `layer_id`, `layer_name`, `user_location`
- [ ] Avviare/fermare la navigazione (pulsante centra) → verificare `navigationStarted`/`navigationStopped`
- [ ] Avviare/fermare la registrazione → verificare `recordingStarted`/`recordingStopped`
- [ ] Scaricare un track → verificare `trackDownloaded` con `track_id` auto-iniettato
- [ ] Verificare build TypeScript senza errori

🤖 Generated with [Claude Code](https://claude.com/claude-code)