### PR TITLE
feat(oc:8127): add userOnline heartbeat to PosthogContextService

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,17 +70,16 @@ Solo per smoke test ("il sistema è su e risponde"), non per test di logica UI.
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
-| PostHog heartbeat utente online | oc:8127 | `posthog-context.service.ts` | Ping `userOnline` ogni 60s con campo `mode`; attivo in foreground o in background durante recording |
+| PostHog tracking utente online | oc:8127 | `geolocation.service.ts`, `posthog-context.service.ts` | Evento `userMoved` ad ogni aggiornamento GPS con campo `mode` (GeolocationMode) |
 | Fix regex hostname 5 parti | oc:8031 | `environment.service.ts`, `environment.service.spec.ts` | Regex aggiornata a `(?:\.[^.]+)+` per supportare domini Surge preview a N parti |
 | Ricerca per layer/cammino nella home | oc:7643 | `home-result`, `ec` store (actions/reducer/effects/selectors), `layer-box`, `layer-features-counter-badge`, `user-activity.reducer` | |
 | Selezione cammino nel form UGC segnalazione | oc:7639 | `select-nearby-layer` (nuovo), `form.component`, `geobox-map`, `modal-ugc-uploader`, `geoutils.service`, `user-activity` store (`nearbyLayerId`), `map-core/layer.directive`, `map-core/ol.ts` | Test E2E: `core/cypress/e2e/app_52/ugc-segnalazione-layer-selection.cy.ts` |
 
 ## Decisioni architetturali
 
-### PostHog heartbeat utente online (oc:8127)
-- **Logica aggiunta in `PosthogContextService` invece di un nuovo servizio**: aveva già tutti i deps (GeolocationService lazy, DestroyRef, client). Evita boilerplate inutile.
-- **Flag `_isAppActive` invece di restart timer**: `timer(0, 60_000)` gira sempre, filtrato da `_isAppActive || mode === 'recording'`. Previene burst di eventi al ritorno in foreground.
-- **`_destroyRef.onDestroy()` per cleanup listener Capacitor**: coerente con il pattern DestroyRef già usato nel servizio; non richiede implementare `OnDestroy`.
+### PostHog tracking utente online (oc:8127)
+- **`capture('userMoved')` in `GeolocationService._onLocationUpdate()`**: elimina la dipendenza circolare alla radice. `GeolocationService` ha già `_mode` e `_posthogClient` — non serve nessun workaround lazy. L'evento si attiva ad ogni aggiornamento GPS; il foreground/background è implicito nel watcher.
+- **`GeolocationMode` in wm-types**: tipo condiviso `'navigation' | 'recording' | 'stopped'` estratto in `wm-types/user-activity.ts`. Usato da `GeolocationService` e `WmPosthogProps.mode` per evitare la union literal ripetuta.
 
 ### Fix regex hostname 5 parti (oc:8031)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,11 +70,17 @@ Solo per smoke test ("il sistema è su e risponde"), non per test di logica UI.
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| PostHog heartbeat utente online | oc:8127 | `posthog-context.service.ts` | Ping `userOnline` ogni 60s con campo `mode`; attivo in foreground o in background durante recording |
 | Fix regex hostname 5 parti | oc:8031 | `environment.service.ts`, `environment.service.spec.ts` | Regex aggiornata a `(?:\.[^.]+)+` per supportare domini Surge preview a N parti |
 | Ricerca per layer/cammino nella home | oc:7643 | `home-result`, `ec` store (actions/reducer/effects/selectors), `layer-box`, `layer-features-counter-badge`, `user-activity.reducer` | |
 | Selezione cammino nel form UGC segnalazione | oc:7639 | `select-nearby-layer` (nuovo), `form.component`, `geobox-map`, `modal-ugc-uploader`, `geoutils.service`, `user-activity` store (`nearbyLayerId`), `map-core/layer.directive`, `map-core/ol.ts` | Test E2E: `core/cypress/e2e/app_52/ugc-segnalazione-layer-selection.cy.ts` |
 
 ## Decisioni architetturali
+
+### PostHog heartbeat utente online (oc:8127)
+- **Logica aggiunta in `PosthogContextService` invece di un nuovo servizio**: aveva già tutti i deps (GeolocationService lazy, DestroyRef, client). Evita boilerplate inutile.
+- **Flag `_isAppActive` invece di restart timer**: `timer(0, 60_000)` gira sempre, filtrato da `_isAppActive || mode === 'recording'`. Previene burst di eventi al ritorno in foreground.
+- **`_destroyRef.onDestroy()` per cleanup listener Capacitor**: coerente con il pattern DestroyRef già usato nel servizio; non richiede implementare `OnDestroy`.
 
 ### Fix regex hostname 5 parti (oc:8031)
 

--- a/docs/features/8127-posthog-utente-online/notes.md
+++ b/docs/features/8127-posthog-utente-online/notes.md
@@ -24,5 +24,15 @@ Nessuno.
 
 ## Follow-up
 
-- Verificare volume eventi PostHog dopo il primo deploy: ~60 eventi/ora per utente attivo.
-  Se il piano PostHog viene saturato, aumentare l'intervallo da 60s a 120s o 300s.
+- Verificare volume eventi PostHog dopo il primo deploy: il numero di `locationUpdate` dipende
+  dalla frequenza di aggiornamento GPS (distanceFilter 10m per navigazione/recording, 100m in
+  standby). Su percorsi attivi può essere significativo — monitorare il piano PostHog.
+
+## Revisione post-implementazione
+
+- **Cambio trigger:** dopo revisione, il trigger è stato cambiato da timer fisso (60s) a ogni
+  aggiornamento di posizione (`onLocationChange$`). Più fedele alla semantica "posizione utente"
+  e più semplice: spariscono timer, flag `_isAppActive`, `App.addListener` e tutta la logica
+  foreground/background (il GPS watcher gestisce già questo nativamente).
+- **Cambio nome evento:** da `userOnline` a `locationUpdate` — più preciso rispetto al trigger
+  reale (aggiornamento posizione, non semplice presenza).

--- a/docs/features/8127-posthog-utente-online/notes.md
+++ b/docs/features/8127-posthog-utente-online/notes.md
@@ -1,0 +1,28 @@
+> Ticket: oc:8127
+
+# Notes — [posthog] utente online
+
+## Deviazioni dal piano
+
+- **Nessun nuovo servizio:** il piano iniziale prevedeva `PosthogOnlineService`. Durante il
+  dialogo con il developer si è deciso di aggiungere il timer direttamente in
+  `PosthogContextService`, che aveva già tutti i deps necessari (geolocation lazy, destroyRef,
+  client). Scelta approvata esplicitamente.
+
+## Bug trovati
+
+Nessuno.
+
+## Decisioni
+
+- **Flag `_isAppActive` invece di restart timer:** il timer gira sempre con
+  `filter(() => _isAppActive || mode === 'recording')`. Evita burst di eventi al ritorno in
+  foreground che si sarebbero verificati con `timer(0, ...)` riavviato ad ogni foreground entry.
+- **`_destroyRef.onDestroy()` per cleanup Capacitor listener:** invece di implementare
+  `ngOnDestroy`, si usa il `DestroyRef` già iniettato — coerente con il pattern esistente del
+  servizio.
+
+## Follow-up
+
+- Verificare volume eventi PostHog dopo il primo deploy: ~60 eventi/ora per utente attivo.
+  Se il piano PostHog viene saturato, aumentare l'intervallo da 60s a 120s o 300s.

--- a/docs/features/8127-posthog-utente-online/notes.md
+++ b/docs/features/8127-posthog-utente-online/notes.md
@@ -34,5 +34,16 @@ Nessuno.
   aggiornamento di posizione (`onLocationChange$`). Più fedele alla semantica "posizione utente"
   e più semplice: spariscono timer, flag `_isAppActive`, `App.addListener` e tutta la logica
   foreground/background (il GPS watcher gestisce già questo nativamente).
-- **Cambio nome evento:** da `userOnline` a `locationUpdate` — più preciso rispetto al trigger
-  reale (aggiornamento posizione, non semplice presenza).
+- **Cambio nome evento:** da `userOnline` → `locationUpdate` → `userMoved` (scelta finale).
+
+## Review esterna (peppedeka — 25-06-2026)
+
+- **[C3] `capture('userMoved')` spostato in `GeolocationService._onLocationUpdate()`:**
+  la dipendenza circolare implicita (`PosthogContextService` → `GeolocationService` →
+  `POSTHOG_CLIENT`) viene eliminata alla radice. `GeolocationService` conosce già `_mode` e
+  `_posthogClient` — è il posto naturale per inviare l'evento. `_initLocationTracking()` e il
+  workaround `Promise.resolve().then()` rimossi da `PosthogContextService`.
+- **[C1] `mode?: GeolocationMode` invece di union literal inline:** nuovo tipo
+  `GeolocationMode = 'navigation' | 'recording' | 'stopped'` estratto in
+  `wm-types/user-activity.ts`. Usato in `WmPosthogProps.mode` e in `GeolocationService`
+  al posto del tipo ripetuto tre volte.

--- a/docs/features/8127-posthog-utente-online/overview.md
+++ b/docs/features/8127-posthog-utente-online/overview.md
@@ -21,17 +21,15 @@ online.
 
 ## Requisiti
 
-- [ ] Aggiungere in `PosthogContextService` un timer RxJS `timer(0, 60_000)` che ad ogni tick
-      invia `this.capture('userOnline', { mode: currentMode })`
-- [ ] Il timer usa un flag `_isAppActive` aggiornato da `App.addListener('appStateChange')`:
-      il timer gira sempre, ma ogni tick viene filtrato con
-      `filter(() => _isAppActive || geolocationSvc.currentMode === 'recording')`
-      — nessun restart, nessun burst al ritorno in foreground
-- [ ] Aggiungere il campo `mode?: string` a `WmPosthogProps` in `wm-types`
-- [ ] Il ping viene inviato anche quando `user_location` è `null` (campo semplicemente assente)
-- [ ] Timer gestito con `takeUntilDestroyed(this._destroyRef)` già presente nel servizio
-- [ ] Il listener `App.addListener('appStateChange')` viene salvato come `PluginListenerHandle`
-      e rimosso esplicitamente nell'`ngOnDestroy` del servizio
+- [x] Aggiungere `capture('userMoved', { mode })` in `GeolocationService._onLocationUpdate()`
+      — si attiva ad ogni aggiornamento di posizione GPS
+- [x] Il foreground/background è gestito implicitamente: il GPS watcher si ferma già in
+      background (salvo recording), quindi nessuna logica aggiuntiva è necessaria
+- [x] Aggiungere il tipo `GeolocationMode = 'navigation' | 'recording' | 'stopped'`
+      in `wm-types/user-activity.ts` e il campo `mode?: GeolocationMode` a `WmPosthogProps`
+- [x] L'evento viene inviato anche quando `user_location` è `null` (campo assente se GPS off)
+- [x] `PosthogContextService._buildContext()` aggiunge `user_location` automaticamente
+      a ogni `capture()` se la posizione è disponibile
 
 ## Rischi
 
@@ -60,5 +58,7 @@ online.
 
 | File | Repo | Tipo | Note |
 |------|------|------|------|
-| `projects/wm-core/src/services/posthog-context.service.ts` | `wm-core` | MODIFICA | Aggiunge timer heartbeat + logica foreground/background |
-| `src/posthog.ts` | `wm-types` | MODIFICA | Aggiunge `mode?: string` a `WmPosthogProps` |
+| `projects/wm-core/src/services/geolocation.service.ts` | `wm-core` | MODIFICA | Aggiunge `capture('userMoved')` in `_onLocationUpdate()` |
+| `projects/wm-core/src/services/posthog-context.service.ts` | `wm-core` | MODIFICA | `_buildContext()` arricchisce automaticamente l'evento con GPS e contesto |
+| `src/user-activity.ts` | `wm-types` | MODIFICA | Aggiunge tipo `GeolocationMode` |
+| `src/posthog.ts` | `wm-types` | MODIFICA | Aggiunge `mode?: GeolocationMode` a `WmPosthogProps` |

--- a/docs/features/8127-posthog-utente-online/overview.md
+++ b/docs/features/8127-posthog-utente-online/overview.md
@@ -1,0 +1,64 @@
+> Ticket: oc:8127
+
+# [posthog] utente online
+
+## Cosa cambia
+
+Viene aggiunto un meccanismo di ping periodico (ogni 60 secondi) che invia l'evento `userOnline`
+a PostHog. L'evento trasporta la posizione GPS corrente (se disponibile) e la modalità di
+utilizzo (`navigation` / `recording` / `stopped`), oltre a tutti i campi di contesto standard
+già iniettati automaticamente da `PosthogContextService` (layer, POI, track).
+
+Il ping gira **sempre quando l'app è in foreground** e continua **anche in background durante la
+registrazione traccia**.
+
+## Perché
+
+Il team analytics vuole monitorare quanti utenti sono attivi in real-time. Senza un heartbeat
+periodico, PostHog non può distinguere una sessione attiva da una dimenticata aperta.
+La posizione è richiesta esplicitamente per abilitare la segmentazione geografica degli utenti
+online.
+
+## Requisiti
+
+- [ ] Aggiungere in `PosthogContextService` un timer RxJS `timer(0, 60_000)` che ad ogni tick
+      invia `this.capture('userOnline', { mode: currentMode })`
+- [ ] Il timer usa un flag `_isAppActive` aggiornato da `App.addListener('appStateChange')`:
+      il timer gira sempre, ma ogni tick viene filtrato con
+      `filter(() => _isAppActive || geolocationSvc.currentMode === 'recording')`
+      — nessun restart, nessun burst al ritorno in foreground
+- [ ] Aggiungere il campo `mode?: string` a `WmPosthogProps` in `wm-types`
+- [ ] Il ping viene inviato anche quando `user_location` è `null` (campo semplicemente assente)
+- [ ] Timer gestito con `takeUntilDestroyed(this._destroyRef)` già presente nel servizio
+- [ ] Il listener `App.addListener('appStateChange')` viene salvato come `PluginListenerHandle`
+      e rimosso esplicitamente nell'`ngOnDestroy` del servizio
+
+## Rischi
+
+- **Memory leak:** il timer RxJS deve essere gestito con `takeUntilDestroyed(destroyRef)` o
+  equivalente per evitare che rimanga attivo dopo la distruzione del servizio.
+- **Doppia istanza:** il servizio deve essere fornito una sola volta (non `providedIn: 'root'`)
+  per evitare più timer concorrenti. Va fornito in `WmCoreModule.forRoot()`.
+- **Background su iOS:** anche durante la registrazione, iOS può throttlare i timer JS quando
+  l'app è in background. Il comportamento dipende dal bridge Capacitor e dal sistema operativo —
+  non è garantito che ogni tick arrivi esattamente a 60s. Accettabile per monitoraggio presenza.
+- **PostHog non inizializzato / rollback:** se `posthog.enabled = false` nella config (o chiave
+  mancante), `capture()` è già no-op — il ping si disabilita senza rilascio di codice.
+  Nessuna flag separata necessaria.
+- **Volume eventi:** ogni utente attivo genera ~60 eventi/ora. Su volumi alti (migliaia di
+  utenti concorrenti) il piano PostHog potrebbe essere saturato o generare costi imprevisti.
+  Da verificare con il team analytics prima del deploy in produzione.
+
+## Out of scope
+
+- Modifiche al repo principale `webmapp-app` (nessun file fuori da `wm-core` e `wm-types`)
+- Dashboard o query PostHog
+- Configurabilità dell'intervallo dall'esterno (hardcoded a 60s)
+- Aggiunta di campi extra oltre a `mode` (batteria, rete, ecc.)
+
+## Moduli toccati
+
+| File | Repo | Tipo | Note |
+|------|------|------|------|
+| `projects/wm-core/src/services/posthog-context.service.ts` | `wm-core` | MODIFICA | Aggiunge timer heartbeat + logica foreground/background |
+| `src/posthog.ts` | `wm-types` | MODIFICA | Aggiunge `mode?: string` a `WmPosthogProps` |

--- a/docs/features/8127-posthog-utente-online/plan.md
+++ b/docs/features/8127-posthog-utente-online/plan.md
@@ -1,0 +1,109 @@
+> Ticket: oc:8127
+
+# Piano implementativo — [posthog] utente online
+
+## Repo coinvolti
+
+| Repo | Percorso locale |
+|------|----------------|
+| `wm-types` | `core/src/app/shared/wm-types/` |
+| `wm-core` | `core/src/app/shared/wm-core/` |
+
+---
+
+## Task 1 — `wm-types`: aggiungere `mode` a `WmPosthogProps`
+
+**File:** `src/posthog.ts`
+
+Aggiungere il campo `mode?: string` nella sezione "Event-specific props" di `WmPosthogProps`,
+dopo `layer_label`:
+
+```typescript
+  layer_label?: string;
+  mode?: string;
+```
+
+**Commit:** `feat(oc:8127): add mode field to WmPosthogProps`
+
+---
+
+## Task 2 — `wm-core`: aggiungere heartbeat in `PosthogContextService`
+
+**File:** `projects/wm-core/src/services/posthog-context.service.ts`
+
+### 2a — Import
+
+Aggiungere i nuovi import:
+
+```typescript
+import {App} from '@capacitor/app';
+import {PluginListenerHandle} from '@capacitor/core';
+import {combineLatest, timer} from 'rxjs';
+import {filter, takeUntilDestroyed} from '@angular/core/rxjs-interop'; // già presente
+```
+
+In pratica:
+- Aggiungere `{App}` from `'@capacitor/app'`
+- Aggiungere `{PluginListenerHandle}` from `'@capacitor/core'`
+- Aggiungere `timer` all'import esistente di `rxjs`: `import {combineLatest, timer} from 'rxjs';`
+- Aggiungere `filter` all'import esistente di `rxjs/operators`:
+  `import {distinctUntilChanged, filter, map, ...} from 'rxjs/operators';`
+  *(verificare l'import esistente e aggiungere solo `filter` se mancante)*
+
+### 2b — Proprietà
+
+Aggiungere due proprietà private alla classe, prima delle proprietà esistenti:
+
+```typescript
+private _isAppActive = true;
+private _appStateListener: PluginListenerHandle | null = null;
+```
+
+### 2c — Costruttore: listener appStateChange
+
+Aggiungere alla fine del costruttore (dopo il `combineLatest` esistente):
+
+```typescript
+App.addListener('appStateChange', ({isActive}) => {
+  this._isAppActive = isActive;
+}).then(handle => {
+  this._appStateListener = handle;
+});
+
+this._destroyRef.onDestroy(() => {
+  this._appStateListener?.remove();
+});
+```
+
+### 2d — Costruttore: timer heartbeat
+
+Aggiungere subito dopo il blocco del listener:
+
+```typescript
+timer(0, 60_000)
+  .pipe(
+    takeUntilDestroyed(this._destroyRef),
+    filter(() => this._isAppActive || this._geolocationSvc.currentMode === 'recording'),
+  )
+  .subscribe(() => {
+    this.capture('userOnline', {mode: this._geolocationSvc.currentMode});
+  });
+```
+
+> `_geolocationSvc` è già disponibile come lazy getter nel servizio.
+> `capture()` è no-op se PostHog non è inizializzato — nessun guard necessario.
+
+**Commit:** `feat(oc:8127): add userOnline heartbeat to PosthogContextService`
+
+---
+
+## Verifica
+
+Dopo i due commit, verificare manualmente:
+
+1. Aprire l'app → attendere ~60s → controllare in PostHog (live events) che arrivi `userOnline`
+   con `mode: 'stopped'` e `user_location` se il GPS è attivo
+2. Avviare la navigazione → verificare `mode: 'navigation'` al tick successivo
+3. Mandare l'app in background (senza recording) → nessun evento per 60s
+4. Avviare la registrazione → mandare in background → verificare che il ping continui
+5. Tornare in foreground → verificare che il ping riprenda senza burst duplicati

--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -301,6 +301,7 @@ export class GeolocationService {
         : this._calculateSpeed(this._currentLocation, location);
     this._currentLocation = location;
     this.onLocationChange$.next(location);
+    this._posthogClient?.capture('userMoved', {mode: this._mode});
   }
 
   private _isLocationAlreadyRecorded(location: Location): boolean {

--- a/projects/wm-core/src/services/geolocation.service.ts
+++ b/projects/wm-core/src/services/geolocation.service.ts
@@ -18,6 +18,7 @@ import {setFocusPosition, setOnRecord} from '@wm-core/store/user-activity/user-a
 import {onRecord} from '@wm-core/store/user-activity/user-activity.selector';
 import {POSTHOG_CLIENT} from '@wm-core/store/conf/conf.token';
 import {WmPosthogClient} from '@wm-types/posthog';
+import {GeolocationMode} from '@wm-types/user-activity';
 import {
   getCurrentUgcTrackLocations,
   saveCurrentUgcTrackLocations,
@@ -37,12 +38,12 @@ export class GeolocationService {
   private _watcherId: string | null = null;
   private _webWatcherId: number | null = null;
 
-  private _mode: 'navigation' | 'recording' | 'stopped' = 'stopped';
+  private _mode: GeolocationMode = 'stopped';
   private _isPaused = false;
 
   onLocationChange$: ReplaySubject<Location> = new ReplaySubject<Location>(1);
   onResumeRecording$: ReplaySubject<Location[]> = new ReplaySubject<Location[]>(1);
-  onModeChange: BehaviorSubject<'navigation' | 'recording' | 'stopped'> = new BehaviorSubject(
+  onModeChange: BehaviorSubject<GeolocationMode> = new BehaviorSubject(
     this._mode,
   );
   onRecord$: Observable<boolean> = this._store.select(onRecord);
@@ -93,7 +94,7 @@ export class GeolocationService {
     return this._mode === 'navigation' || this._mode === 'recording';
   }
 
-  get currentMode(): 'navigation' | 'recording' | 'stopped' {
+  get currentMode(): GeolocationMode {
     return this._mode;
   }
 

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -1,11 +1,14 @@
 import {DestroyRef, Injectable, Injector} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {App} from '@capacitor/app';
+import {PluginListenerHandle} from '@capacitor/core';
 import {Store} from '@ngrx/store';
 import {currentEcPoiId, currentEcTrack} from '@wm-core/store/features/ec/ec.selector';
 import {currentUgcPoiId, currentUgcTrackId} from '@wm-core/store/features/ugc/ugc.selector';
 import {currentEcLayer} from '@wm-core/store/user-activity/user-activity.selector';
 import {WmPosthogClient, WmPosthogInitOptions, WmPosthogProps} from '@wm-types/posthog';
-import {combineLatest} from 'rxjs';
+import {combineLatest, timer} from 'rxjs';
+import {filter} from 'rxjs/operators';
 import {PosthogCapacitorClient} from './posthog-capacitor.client';
 import {GeolocationService} from './geolocation.service';
 
@@ -21,6 +24,8 @@ import {GeolocationService} from './geolocation.service';
 export class PosthogContextService implements WmPosthogClient {
   private _contextSnapshot: WmPosthogProps = {};
   private _geolocationSvcRef: GeolocationService | null = null;
+  private _isAppActive = true;
+  private _appStateListener: PluginListenerHandle | null = null;
 
   constructor(
     private _client: PosthogCapacitorClient,
@@ -44,6 +49,25 @@ export class PosthogContextService implements WmPosthogClient {
         if (ecTrack?.properties?.id != null) snap['track_id'] = `${ecTrack.properties.id}`;
         if (ugcTrackId != null) snap['ugc_track_id'] = `${ugcTrackId}`;
         this._contextSnapshot = snap;
+      });
+
+    App.addListener('appStateChange', ({isActive}) => {
+      this._isAppActive = isActive;
+    }).then(handle => {
+      this._appStateListener = handle;
+    });
+
+    this._destroyRef.onDestroy(() => {
+      this._appStateListener?.remove();
+    });
+
+    timer(0, 60_000)
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        filter(() => this._isAppActive || this._geolocationSvc.currentMode === 'recording'),
+      )
+      .subscribe(() => {
+        this.capture('userOnline', {mode: this._geolocationSvc.currentMode});
       });
   }
 

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -1,13 +1,11 @@
 import {DestroyRef, Injectable, Injector} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {App} from '@capacitor/app';
 import {Store} from '@ngrx/store';
 import {currentEcPoiId, currentEcTrack} from '@wm-core/store/features/ec/ec.selector';
 import {currentUgcPoiId, currentUgcTrackId} from '@wm-core/store/features/ugc/ugc.selector';
 import {currentEcLayer} from '@wm-core/store/user-activity/user-activity.selector';
 import {WmPosthogClient, WmPosthogInitOptions, WmPosthogProps} from '@wm-types/posthog';
-import {combineLatest, timer} from 'rxjs';
-import {filter} from 'rxjs/operators';
+import {combineLatest} from 'rxjs';
 import {PosthogCapacitorClient} from './posthog-capacitor.client';
 import {GeolocationService} from './geolocation.service';
 
@@ -21,11 +19,8 @@ import {GeolocationService} from './geolocation.service';
  */
 @Injectable()
 export class PosthogContextService implements WmPosthogClient {
-  private static readonly HEARTBEAT_INTERVAL_MS = 60_000;
-
   private _contextSnapshot: WmPosthogProps = {};
   private _geolocationSvcRef: GeolocationService | null = null;
-  private _isAppActive = true;
 
   constructor(
     private _client: PosthogCapacitorClient,
@@ -51,8 +46,7 @@ export class PosthogContextService implements WmPosthogClient {
         this._contextSnapshot = snap;
       });
 
-    this._initAppStateListener();
-    this._initHeartbeat();
+    this._initLocationTracking();
   }
 
   private get _geolocationSvc(): GeolocationService | null {
@@ -62,23 +56,11 @@ export class PosthogContextService implements WmPosthogClient {
     return this._geolocationSvcRef;
   }
 
-  private _initAppStateListener(): void {
-    (async () => {
-      const handle = await App.addListener('appStateChange', ({isActive}) => {
-        this._isAppActive = isActive;
-      });
-      this._destroyRef.onDestroy(() => handle.remove());
-    })();
-  }
-
-  private _initHeartbeat(): void {
-    timer(0, PosthogContextService.HEARTBEAT_INTERVAL_MS)
-      .pipe(
-        takeUntilDestroyed(this._destroyRef),
-        filter(() => this._isAppActive || this._geolocationSvc?.currentMode === 'recording'),
-      )
+  private _initLocationTracking(): void {
+    this._geolocationSvc?.onLocationChange$
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(() => {
-        this.capture('userOnline', {mode: this._geolocationSvc?.currentMode});
+        this.capture('locationUpdate', {mode: this._geolocationSvc?.currentMode});
       });
   }
 

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -46,7 +46,6 @@ export class PosthogContextService implements WmPosthogClient {
         this._contextSnapshot = snap;
       });
 
-    this._initLocationTracking();
   }
 
   private get _geolocationSvc(): GeolocationService | null {
@@ -54,19 +53,6 @@ export class PosthogContextService implements WmPosthogClient {
       this._geolocationSvcRef = this._injector.get(GeolocationService, null);
     }
     return this._geolocationSvcRef;
-  }
-
-  private _initLocationTracking(): void {
-    // Defer past the constructor to break the circular dependency:
-    // GeolocationService injects POSTHOG_CLIENT (@Optional), so resolving it
-    // synchronously here would trigger NG0200.
-    Promise.resolve().then(() => {
-      this._geolocationSvc?.onLocationChange$
-        .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(() => {
-          this.capture('userMoved', {mode: this._geolocationSvc?.currentMode});
-        });
-    });
   }
 
   private _buildContext(): WmPosthogProps {

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -1,7 +1,6 @@
 import {DestroyRef, Injectable, Injector} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {App} from '@capacitor/app';
-import {PluginListenerHandle} from '@capacitor/core';
 import {Store} from '@ngrx/store';
 import {currentEcPoiId, currentEcTrack} from '@wm-core/store/features/ec/ec.selector';
 import {currentUgcPoiId, currentUgcTrackId} from '@wm-core/store/features/ugc/ugc.selector';
@@ -22,10 +21,11 @@ import {GeolocationService} from './geolocation.service';
  */
 @Injectable()
 export class PosthogContextService implements WmPosthogClient {
+  private static readonly HEARTBEAT_INTERVAL_MS = 60_000;
+
   private _contextSnapshot: WmPosthogProps = {};
   private _geolocationSvcRef: GeolocationService | null = null;
   private _isAppActive = true;
-  private _appStateListener: PluginListenerHandle | null = null;
 
   constructor(
     private _client: PosthogCapacitorClient,
@@ -51,36 +51,40 @@ export class PosthogContextService implements WmPosthogClient {
         this._contextSnapshot = snap;
       });
 
-    App.addListener('appStateChange', ({isActive}) => {
-      this._isAppActive = isActive;
-    }).then(handle => {
-      this._appStateListener = handle;
-    });
-
-    this._destroyRef.onDestroy(() => {
-      this._appStateListener?.remove();
-    });
-
-    timer(0, 60_000)
-      .pipe(
-        takeUntilDestroyed(this._destroyRef),
-        filter(() => this._isAppActive || this._geolocationSvc.currentMode === 'recording'),
-      )
-      .subscribe(() => {
-        this.capture('userOnline', {mode: this._geolocationSvc.currentMode});
-      });
+    this._initAppStateListener();
+    this._initHeartbeat();
   }
 
-  private get _geolocationSvc(): GeolocationService {
+  private get _geolocationSvc(): GeolocationService | null {
     if (!this._geolocationSvcRef) {
-      this._geolocationSvcRef = this._injector.get(GeolocationService);
+      this._geolocationSvcRef = this._injector.get(GeolocationService, null);
     }
     return this._geolocationSvcRef;
   }
 
+  private _initAppStateListener(): void {
+    (async () => {
+      const handle = await App.addListener('appStateChange', ({isActive}) => {
+        this._isAppActive = isActive;
+      });
+      this._destroyRef.onDestroy(() => handle.remove());
+    })();
+  }
+
+  private _initHeartbeat(): void {
+    timer(0, PosthogContextService.HEARTBEAT_INTERVAL_MS)
+      .pipe(
+        takeUntilDestroyed(this._destroyRef),
+        filter(() => this._isAppActive || this._geolocationSvc?.currentMode === 'recording'),
+      )
+      .subscribe(() => {
+        this.capture('userOnline', {mode: this._geolocationSvc?.currentMode});
+      });
+  }
+
   private _buildContext(): WmPosthogProps {
     const ctx = {...this._contextSnapshot};
-    const loc = this._geolocationSvc.location;
+    const loc = this._geolocationSvc?.location;
     if (loc && Number.isFinite(loc.latitude) && Number.isFinite(loc.longitude)) {
       ctx['user_location'] = loc;
     }

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -60,7 +60,7 @@ export class PosthogContextService implements WmPosthogClient {
     this._geolocationSvc?.onLocationChange$
       .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(() => {
-        this.capture('locationUpdate', {mode: this._geolocationSvc?.currentMode});
+        this.capture('userMoved', {mode: this._geolocationSvc?.currentMode});
       });
   }
 

--- a/projects/wm-core/src/services/posthog-context.service.ts
+++ b/projects/wm-core/src/services/posthog-context.service.ts
@@ -57,11 +57,16 @@ export class PosthogContextService implements WmPosthogClient {
   }
 
   private _initLocationTracking(): void {
-    this._geolocationSvc?.onLocationChange$
-      .pipe(takeUntilDestroyed(this._destroyRef))
-      .subscribe(() => {
-        this.capture('userMoved', {mode: this._geolocationSvc?.currentMode});
-      });
+    // Defer past the constructor to break the circular dependency:
+    // GeolocationService injects POSTHOG_CLIENT (@Optional), so resolving it
+    // synchronously here would trigger NG0200.
+    Promise.resolve().then(() => {
+      this._geolocationSvc?.onLocationChange$
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => {
+          this.capture('userMoved', {mode: this._geolocationSvc?.currentMode});
+        });
+    });
   }
 
   private _buildContext(): WmPosthogProps {


### PR DESCRIPTION
## Summary

- Aggiunto heartbeat periodico `userOnline` (ogni 60s) in `PosthogContextService`
- Il ping include il campo `mode` (`navigation`/`recording`/`stopped`) e la posizione GPS se disponibile
- Attivo in foreground; continua in background solo durante la registrazione traccia
- Usa flag `_isAppActive` + `filter()` invece di restart timer — nessun burst al ritorno in foreground
- Listener `App.addListener('appStateChange')` rimosso esplicitamente via `_destroyRef.onDestroy()`

Docs: `docs/features/8127-posthog-utente-online/`

## Test plan

- [ ] Aprire l'app → attendere ~60s → verificare evento `userOnline` in PostHog live events con `mode: 'stopped'`
- [ ] Avviare navigazione → verificare `mode: 'navigation'` al tick successivo
- [ ] Mandare l'app in background (senza recording) → nessun evento per 60s
- [ ] Avviare registrazione → mandare in background → verificare che il ping continui
- [ ] Tornare in foreground → verificare che non ci siano eventi duplicati ravvicinati

🤖 Generated with [Claude Code](https://claude.com/claude-code)