### PR TITLE
feat(oc:8174): add foreground version check on app resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Solo per smoke test ("il sistema è su e risponde"), non per test di logica UI.
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Controllo aggiornamenti app al resume | oc:8174 | `update.service.ts`, `conf.effects.ts` | `startForegroundWatcher` registra `App.addListener('appStateChange')` in `UpdateService`; `checkAppVersion$` chiama watcher + update flow in `concat` |
 | PostHog tracking utente online | oc:8127 | `geolocation.service.ts`, `posthog-context.service.ts` | Evento `userMoved` ad ogni aggiornamento GPS con campo `mode` (GeolocationMode) |
 | Fix regex hostname 5 parti | oc:8031 | `environment.service.ts`, `environment.service.spec.ts` | Regex aggiornata a `(?:\.[^.]+)+` per supportare domini Surge preview a N parti |
 | Ricerca per layer/cammino nella home | oc:7643 | `home-result`, `ec` store (actions/reducer/effects/selectors), `layer-box`, `layer-features-counter-badge`, `user-activity.reducer` | |
@@ -92,6 +93,12 @@ Solo per smoke test ("il sistema è su e risponde"), non per test di logica UI.
 - **`draw-ugc.component.ts` esplicitamente fuori scope**: usa `Photo[]` di Capacitor (foto locali, mai sincronizzate) invece di `Media[]`, un modello dati diverso da quello di editing — unificarlo avrebbe forzato un'astrazione tra tipi semanticamente distinti
 - **`_buildFormData()` in `ugc.service.ts` gestisce già foto locali miste a foto sincronizzate**: filtra `media.filter(p => !p.id)` e le allega come file multipart (`images[]`) nella stessa richiesta di update — non serve nessuna logica aggiuntiva per questo caso nella base class
 - **Debito noto, non affrontato in questo ticket**: `slideOptions`, `isEditing$`, `confOPTIONS$`, `deletePoi()`/`deleteTrack()` restano duplicati identici tra i due componenti — candidati per un refactoring successivo, fuori scope perché il ticket copriva solo AddPhotos
+
+### Controllo aggiornamenti app al resume (oc:8174)
+- **`startForegroundWatcher` in `UpdateService`**: il listener Capacitor `appStateChange` vive nel service (non in un effect NgRx), così il service rimane testabile in isolamento e il ciclo di vita del listener è disaccoppiato dallo store. `checkAppVersion$` lo avvia come side-effect la prima volta che l'azione viene dispatchata.
+- **`concat` invece di `Promise.all`**: le due operazioni (`startForegroundWatcher` + `handleAppUpdateFlow`) sono sequenziali e con `catchError(() => EMPTY)` indipendente — se il watcher non si registra, il controllo versione parte comunque.
+- **`await remove()` prima di re-registrare**: `PluginListenerHandle.remove()` è asincrono; senza `await` c'è una finestra in cui due listener sono attivi contemporaneamente e `handleAppUpdateFlow` viene chiamato due volte sullo stesso resume.
+- **Guard `isAppMobile` nel service, non nell'effect**: l'effect non sa nulla della piattaforma — il service incapsula la guardia, restituisce `Promise<void>` silenziosamente su browser.
 
 ### PostHog tracking utente online (oc:8127)
 - **`capture('userMoved')` in `GeolocationService._onLocationUpdate()`**: elimina la dipendenza circolare alla radice. `GeolocationService` ha già `_mode` e `_posthogClient` — non serve nessun workaround lazy. L'evento si attiva ad ogni aggiornamento GPS; il foreground/background è implicito nel watcher.

--- a/docs/features/8174-controllo-aggiornamenti-app-al-resume/notes.md
+++ b/docs/features/8174-controllo-aggiornamenti-app-al-resume/notes.md
@@ -1,0 +1,22 @@
+> Ticket: oc:8174
+
+# Notes — Controllo aggiornamenti app al resume
+
+## Deviazioni dal piano
+
+- **`startForegroundVersionWatcher$` eliminato**: il piano prevedeva un effect separato su `loadConfSuccess`. Durante la review è stato deciso di integrare `startForegroundWatcher` direttamente in `checkAppVersion$` via `concat`, che condivide già `confApp` e rappresenta lo stesso momento semantico di inizializzazione.
+- **`Promise.all` scartato**: proposto inizialmente per la chiamata parallela, sostituito con `concat` RxJS puro — più coerente con il resto del codebase NgRx.
+
+## Decisioni
+
+- `concat` con `catchError(() => EMPTY)` indipendente per ogni step: se `startForegroundWatcher` fallisce (es. Capacitor non ancora pronto), `handleAppUpdateFlow` viene comunque eseguito.
+- `await remove()` sul handle precedente prima di re-registrare: elimina la finestra in cui due listener sono attivi contemporaneamente su `appStateChange`.
+- Guard `isAppMobile` in `startForegroundWatcher`: su browser il metodo esce immediatamente senza registrare listener (l'evento Cordova/Capacitor `appStateChange` non arriva mai su web).
+
+## Bug trovati
+
+- **Doppia invocazione concorrente di `handleAppUpdateFlow`**: due eventi `isActive: true` ravvicinati (es. unlock rapido) potevano creare due chiamate concorrenti che superavano entrambe il check `isThrottled` prima che `markShown` fosse scritto → due toast/modal sovrapposti. Risolto con flag `_isUpdateInProgress` e `.catch(() => {}).finally(...)` nel callback del listener.
+
+## Follow-up
+
+- Nessun test E2E aggiunto: il comportamento dipende dal ciclo di vita nativo Capacitor, non testabile via Cypress in CI.

--- a/docs/features/8174-controllo-aggiornamenti-app-al-resume/overview.md
+++ b/docs/features/8174-controllo-aggiornamenti-app-al-resume/overview.md
@@ -1,0 +1,44 @@
+> Ticket: oc:8174
+
+# Controllo aggiornamenti app al resume
+
+## Cosa cambia
+
+Ogni volta che l'app torna in foreground (evento Capacitor `appStateChange.isActive: true`) mentre il processo è ancora vivo, viene eseguito un controllo della versione disponibile sullo store. Attualmente il controllo avviene solo all'avvio a freddo (`checkAppVersion` dispatchata una sola volta da `app.component.ts` dopo `loadConfSuccess`). Con questa feature il controllo viene ripetuto ad ogni resume di sessione viva, con throttling già gestito da `UpdateService` (patch: 6h, minor: 2h, major: sempre).
+
+**Scope:** copre resume brevi/medi (minuti–ore) in cui il processo è ancora in memoria su entrambe le piattaforme. I cold start (iOS termina il processo dopo background prolungato) sono già coperti dal meccanismo esistente in `app.component.ts`.
+
+## Perché
+
+Un utente che alterna background/foreground frequentemente — o che lascia l'app in background su Android dove i processi vivono più a lungo — non riceve notifiche di aggiornamento tra un cold start e l'altro. Il trigger sul foreground colma questo gap senza impatto sulle prestazioni grazie al throttling esistente.
+
+## Requisiti
+
+- [ ] `UpdateService` espone un metodo `startForegroundWatcher(appConfig: APP): Promise<void>` che registra `App.addListener('appStateChange', ...)` e chiama `handleAppUpdateFlow(appConfig)` quando `isActive: true`
+- [ ] Ogni chiamata a `startForegroundWatcher` esegue `await this._foregroundHandle?.remove()` prima di registrare il nuovo listener — elimina la finestra in cui entrambi i listener sono attivi (`remove()` è asincrono)
+- [ ] Il `PluginListenerHandle` restituito da `App.addListener` viene salvato in `_foregroundListenerHandle` per il remove futuro
+- [ ] Guard `isAppMobile` in `startForegroundWatcher`: se non siamo su native, il metodo ritorna senza registrare nulla
+- [ ] Un nuovo effect NgRx `startForegroundVersionWatcher$` in `conf.effects.ts` ascolta `loadConfSuccess` e chiama il watcher via `switchMap(() => from(this._updateService.startForegroundWatcher(action.conf.APP)).pipe(catchError(() => EMPTY)))` con `dispatch: false` — la Promise è tracciata e gli errori non inghiottiti silenziosamente
+- [ ] Il throttling non viene modificato — rimane delegato a `UpdateService.handleAppUpdateFlow` (patch 6h, minor 2h, major sempre)
+
+## Rischi
+
+- **`loadConfSuccess` ri-dispatchata con conf aggiornata:** il remove-before-register garantisce che il listener usi sempre il `confApp` più recente. Comportamento corretto e intenzionale.
+- **`App.addListener` non disponibile su browser:** mitigato dal guard `isAppMobile` — su browser il metodo ritorna senza registrare nulla.
+- **Rollback:** la modifica tocca wm-core (submodule) — un hotfix richiede revert in wm-core + bump del puntatore submodulo in webmapp-app + deploy. Nessun feature flag previsto: il throttling esistente limita i danni nel caso peggiore.
+- **iOS background prolungato:** il processo viene terminato dall'OS → cold start → già coperto dall'`app.component.ts` esistente. Questo caso non è in scope di questa feature.
+
+## Out of scope
+
+- Modifiche al meccanismo di throttling esistente in `UpdateService`
+- Modifiche a `DeviceService.onForeground` (ReplaySubject Cordova legacy)
+- Trigger del check su eventi diversi dal foreground (timer, connettività)
+- Feature flag runtime per disabilitare il watcher
+- Test E2E (dipende dal ciclo di vita nativo Capacitor, non testabile via Cypress)
+
+## Moduli toccati
+
+| File | Repo | Modifica |
+|---|---|---|
+| `projects/wm-core/src/services/update.service.ts` | wm-core | Aggiunge `startForegroundWatcher(appConfig)` + `_foregroundListenerHandle` |
+| `projects/wm-core/src/store/conf/conf.effects.ts` | wm-core | Aggiunge `startForegroundVersionWatcher$` su `loadConfSuccess` |

--- a/docs/features/8174-controllo-aggiornamenti-app-al-resume/plan.md
+++ b/docs/features/8174-controllo-aggiornamenti-app-al-resume/plan.md
@@ -1,0 +1,130 @@
+> Ticket: oc:8174
+
+# Plan — Controllo aggiornamenti app al resume
+
+## Task 1 — Crea branch in wm-core
+
+```bash
+cd core/src/app/shared/wm-core
+git checkout develop
+git pull origin develop
+git checkout -b feature/oc-8174-controllo-aggiornamenti-app-al-resume
+```
+
+---
+
+## Task 2 — `update.service.ts`: aggiungi `startForegroundWatcher`
+
+File: `projects/wm-core/src/services/update.service.ts`
+
+### 2a — Aggiungi import `PluginListenerHandle`
+
+```ts
+import {PluginListenerHandle} from '@capacitor/core';
+```
+
+### 2b — Aggiungi campo privato dopo il costruttore
+
+```ts
+private _foregroundListenerHandle: PluginListenerHandle | null = null;
+```
+
+### 2c — Aggiungi metodo `startForegroundWatcher`
+
+```ts
+async startForegroundWatcher(appConfig: APP): Promise<void> {
+  if (!this._deviceService.isAppMobile) {
+    return;
+  }
+  if (this._foregroundListenerHandle) {
+    await this._foregroundListenerHandle.remove();
+    this._foregroundListenerHandle = null;
+  }
+  this._foregroundListenerHandle = await App.addListener(
+    'appStateChange',
+    ({isActive}) => {
+      if (isActive) {
+        this.handleAppUpdateFlow(appConfig);
+      }
+    },
+  );
+}
+```
+
+---
+
+## Task 3 — `conf.effects.ts`: aggiungi `startForegroundVersionWatcher$`
+
+File: `projects/wm-core/src/store/conf/conf.effects.ts`
+
+### 3a — Aggiungi import `loadConfSuccess`
+
+`loadConfSuccess` è già importato da `conf.actions` — nessuna modifica necessaria.
+
+Aggiungi import RxJS mancanti se necessario: `from`, `EMPTY`.
+
+```ts
+import {of, from, EMPTY} from 'rxjs';
+import {catchError, filter, map, switchMap, withLatestFrom, take} from 'rxjs/operators';
+```
+
+### 3b — Aggiungi effect dopo `checkAppVersion$`
+
+```ts
+startForegroundVersionWatcher$ = createEffect(
+  () =>
+    this._actions$.pipe(
+      ofType(loadConfSuccess),
+      switchMap(action =>
+        from(this._updateService.startForegroundWatcher(action.conf.APP)).pipe(
+          catchError(() => EMPTY),
+        ),
+      ),
+    ),
+  {dispatch: false},
+);
+```
+
+---
+
+## Task 4 — Verifica manuale
+
+- Apri l'app su un device/emulatore nativo (Android o iOS)
+- Verifica che al cold start il check avvenga normalmente (comportamento invariato)
+- Porta l'app in background, attendi qualche secondo, riporta in foreground
+- Verifica che `handleAppUpdateFlow` venga chiamato (se disponibile aggiornamento: toasts/modal; altrimenti nessun popup — normale)
+- Verifica che su browser (Chrome DevTools mobile) nessun listener venga registrato
+
+---
+
+## Task 5 — Commit in wm-core
+
+```bash
+git add projects/wm-core/src/services/update.service.ts
+git add projects/wm-core/src/store/conf/conf.effects.ts
+git commit -m "feat(oc:8174): add foreground version check on app resume"
+```
+
+---
+
+## Task 6 — Bump submodulo in webmapp-app
+
+```bash
+cd ../../../../  # torna in core/
+git add src/app/shared/wm-core
+git commit -m "feat(oc:8174): bump wm-core — foreground version check on resume"
+```
+
+---
+
+## Task 7 — Apri PR in wm-core verso `develop`
+
+```bash
+cd src/app/shared/wm-core
+git push -u origin feature/oc-8174-controllo-aggiornamenti-app-al-resume
+gh pr create \
+  --repo webmappsrl/wm-core \
+  --base develop \
+  --title "feat(oc:8174): add foreground version check on app resume" \
+  --body "Closes oc:8174 — registra App.addListener appStateChange in UpdateService e chiama handleAppUpdateFlow ad ogni resume. Effect startForegroundVersionWatcher\$ in conf.effects.ts avvia il watcher dopo loadConfSuccess."
+```

--- a/projects/wm-core/src/services/update.service.ts
+++ b/projects/wm-core/src/services/update.service.ts
@@ -1,6 +1,7 @@
 import {Inject, Injectable} from '@angular/core';
 import {AlertController, ModalController, ToastController} from '@ionic/angular';
 import {App} from '@capacitor/app';
+import {PluginListenerHandle} from '@capacitor/core';
 import {AppUpdate} from '@capawesome/capacitor-app-update';
 import {HttpClient} from '@angular/common/http';
 
@@ -21,6 +22,9 @@ import {DeviceService} from './device.service';
 
 @Injectable({providedIn: 'root'})
 export class UpdateService {
+  private _foregroundListenerHandle: PluginListenerHandle | null = null;
+  private _isUpdateInProgress = false;
+
   constructor(
     private _modalController: ModalController,
     private _toastController: ToastController,
@@ -262,6 +266,30 @@ export class UpdateService {
   }
 
   // ── Flow principale ─────────────────────────────────────────────────────────
+
+  /**
+   * Registra un listener Capacitor che esegue il controllo versione ad ogni resume.
+   * Sostituisce il listener precedente se già registrato.
+   */
+  async startForegroundWatcher(appConfig: APP): Promise<void> {
+    if (!this._deviceService.isAppMobile) {
+      return;
+    }
+    if (this._foregroundListenerHandle) {
+      await this._foregroundListenerHandle.remove();
+      this._foregroundListenerHandle = null;
+    }
+    this._foregroundListenerHandle = await App.addListener('appStateChange', ({isActive}) => {
+      if (isActive && !this._isUpdateInProgress) {
+        this._isUpdateInProgress = true;
+        this.handleAppUpdateFlow(appConfig)
+          .catch(() => {})
+          .finally(() => {
+            this._isUpdateInProgress = false;
+          });
+      }
+    });
+  }
 
   async handleAppUpdateFlow(appConfig: APP): Promise<void> {
     const evaluation = await this.evaluateUpdate(appConfig);

--- a/projects/wm-core/src/store/conf/conf.effects.ts
+++ b/projects/wm-core/src/store/conf/conf.effects.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
-import {of} from 'rxjs';
+import {of, from, EMPTY, concat} from 'rxjs';
 import {catchError, filter, map, switchMap, withLatestFrom, take} from 'rxjs/operators';
 import {
   loadConf,
@@ -84,7 +84,10 @@ export class ConfEffects {
           ),
         ),
         switchMap(([_, confApp]) =>
-          this._updateService.handleAppUpdateFlow(confApp),
+          concat(
+            from(this._updateService.startForegroundWatcher(confApp)).pipe(catchError(() => EMPTY)),
+            from(this._updateService.handleAppUpdateFlow(confApp)).pipe(catchError(() => EMPTY)),
+          ),
         ),
       ),
     {dispatch: false},


### PR DESCRIPTION
## Summary

- Aggiunge `startForegroundWatcher(appConfig: APP)` in `UpdateService`: registra `App.addListener('appStateChange', ...)` e chiama `handleAppUpdateFlow` ad ogni resume nativo
- `checkAppVersion$` in `conf.effects.ts` avvia watcher + update flow in `concat` al primo dispatch
- Flag `_isUpdateInProgress` previene doppia invocazione concorrente su eventi `isActive: true` ravvicinati

## Test plan

- [ ] Verifica cold start: il check versione avviene normalmente all'avvio (comportamento invariato)
- [ ] Verifica resume nativo: porta l'app in background, attendi qualche secondo, riporta in foreground — se disponibile un aggiornamento, appare toast/modal
- [ ] Verifica throttling: dopo che il popup è apparso, un secondo resume entro 6h (patch) / 2h (minor) non mostra nulla
- [ ] Verifica browser: nessun listener registrato (guard `isAppMobile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)