### PR TITLE
feat(oc:5125): unica AddPhotos per ugc-track e ugc-poi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,16 @@ Solo per smoke test ("il sistema è su e risponde"), non per test di logica UI.
 | Fix regex hostname 5 parti | oc:8031 | `environment.service.ts`, `environment.service.spec.ts` | Regex aggiornata a `(?:\.[^.]+)+` per supportare domini Surge preview a N parti |
 | Ricerca per layer/cammino nella home | oc:7643 | `home-result`, `ec` store (actions/reducer/effects/selectors), `layer-box`, `layer-features-counter-badge`, `user-activity.reducer` | |
 | Selezione cammino nel form UGC segnalazione | oc:7639 | `select-nearby-layer` (nuovo), `form.component`, `geobox-map`, `modal-ugc-uploader`, `geoutils.service`, `user-activity` store (`nearbyLayerId`), `map-core/layer.directive`, `map-core/ol.ts` | Test E2E: `core/cypress/e2e/app_52/ugc-segnalazione-layer-selection.cy.ts` |
+| Unica AddPhotos per ugc-track e ugc-poi | oc:5125 | `ugc-properties-base` (nuovo), `ugc-poi-properties.component.ts`, `ugc-track-properties.component.ts` | Estratta `UgcPropertiesBaseComponent` per condividere `_photos`/`photosChanged()` tra editing POI e track già sincronizzati |
 
 ## Decisioni architetturali
+
+### Unica AddPhotos per ugc-track e ugc-poi (oc:5125)
+- **`ModalSaveComponent` (repo principale) era già unificato**: il flusso di registrazione GPS (nuovo track/POI) usa un solo `ModalSaveComponent` con flag `isWaypoint`, non due componenti separati. Il ticket originale referenziava nomi obsoleti (`modal-save.component`/`modal-waypoint-save.component`) — la vera duplicazione residua era nel flusso di *editing* di UGC già sincronizzati, tra `ugc-poi-properties.component.ts` e `ugc-track-properties.component.ts`
+- **`UgcPropertiesBaseComponent` è una classe astratta plain-TS, non un `@Component` Angular**: nessuna injection, nessun decoratore, nessun template — condivide solo `_photos`/`photosChanged()`/getter `photos`. Scelta preferita a un servizio iniettato perché lo stato è intrinsecamente per-istanza (POI vs track), non cross-cutting
+- **`draw-ugc.component.ts` esplicitamente fuori scope**: usa `Photo[]` di Capacitor (foto locali, mai sincronizzate) invece di `Media[]`, un modello dati diverso da quello di editing — unificarlo avrebbe forzato un'astrazione tra tipi semanticamente distinti
+- **`_buildFormData()` in `ugc.service.ts` gestisce già foto locali miste a foto sincronizzate**: filtra `media.filter(p => !p.id)` e le allega come file multipart (`images[]`) nella stessa richiesta di update — non serve nessuna logica aggiuntiva per questo caso nella base class
+- **Debito noto, non affrontato in questo ticket**: `slideOptions`, `isEditing$`, `confOPTIONS$`, `deletePoi()`/`deleteTrack()` restano duplicati identici tra i due componenti — candidati per un refactoring successivo, fuori scope perché il ticket copriva solo AddPhotos
 
 ### PostHog tracking utente online (oc:8127)
 - **`capture('userMoved')` in `GeolocationService._onLocationUpdate()`**: elimina la dipendenza circolare alla radice. `GeolocationService` ha già `_mode` e `_posthogClient` — non serve nessun workaround lazy. L'evento si attiva ad ogni aggiornamento GPS; il foreground/background è implicito nel watcher.

--- a/docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/notes.md
+++ b/docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/notes.md
@@ -1,0 +1,28 @@
+> Ticket: oc:5125
+
+# Notes — Avere una unica AddPhotos per ugc-track e ugc-poi
+
+## Deviazioni dal piano
+
+Nessuna deviazione dai task 1-3 del piano (confermato da review). Aggiunte rispetto al piano originale, emerse dalla review formale (`wm-skills:wm-review-ticket`) prima del commit:
+
+- Aggiunto un getter protetto `photos` in `UgcPropertiesBaseComponent` invece di esporre solo il campo grezzo `_photos` — rispetta alla lettera il requisito originale dell'overview ("getter/metodo protetto per ottenere i photos pronti per il merge"), che l'implementazione iniziale aveva soddisfatto solo in parte.
+- Aggiunta JSDoc minima sulla classe base (coerenza con la convenzione CLAUDE.md e con `BaseSaveComponent`, pattern di riferimento).
+- Import di `UgcPropertiesBaseComponent` cambiato da path relativo (`../ugc-properties-base/...`) ad alias `@wm-core/ugc-properties-base/...`, per coerenza con lo stile di import del resto dei due file.
+- Corretta la motivazione tecnica del rischio "class field shadowing" in `overview.md`: la review ha rilevato che `core/tsconfig.json` ha `useDefineForClassFields: false`, quindi la semantica non è quella ES2022 standard `[[Define]]` come inizialmente scritto — il rischio concreto è più limitato di quanto la formulazione originale suggerisse. La mitigazione (rimozione completa del campo dalle sottoclassi) resta comunque corretta e applicata.
+
+## Bug trovati
+
+Nessuno. La review (5 finder paralleli: correctness, side effect, deviazioni piano, cleanup, design) non ha trovato bug o regressioni introdotte dal refactoring.
+
+## Decisioni
+
+- Scope limitato a `ugc-poi-properties.component.ts` e `ugc-track-properties.component.ts` (edit flow di UGC già sincronizzati) — `draw-ugc.component.ts` (creazione manuale, modello `Photo[]`) e `ModalSaveComponent` (flusso di registrazione GPS nel repo principale, già unificato tramite flag `isWaypoint`) restano fuori scope, come deciso durante la fase di reverse-interaction.
+- Nessun test automatico aggiunto — coerente con lo stato attuale del progetto (spec di componenti wm-core non girano in CI, vedi oc:8023).
+- Verifica manuale: build/serve puliti, home e mappa testate in browser headless senza errori nuovi introdotti dal cambio; il flusso interattivo reale di editing POI/track con foto è stato verificato manualmente dal developer (richiede account autenticato con UGC sincronizzati, non riproducibile in autonomia).
+
+## Follow-up (fuori scope, emersi dalla review)
+
+- Duplicazione residua non consolidata tra `UgcPoiPropertiesComponent` e `UgcTrackPropertiesComponent`: `slideOptions`, `isEditing$`, `confOPTIONS$`, il pattern `deletePoi()`/`deleteTrack()` (stesso alert di conferma) e `removeUgc*FromUrl()`/`triggerDismiss()` sono ancora duplicati identici. Candidato per un ticket successivo — non affrontato qui per restare nello scope dichiarato (solo AddPhotos).
+- `UgcPropertiesBaseComponent` non è esportata da `public-api.ts` del submodule — scelta intenzionale (è un dettaglio implementativo interno, non superficie pubblica), ma da rivalutare se un giorno serve estenderla da fuori wm-core.
+- Il naming `UgcPropertiesBaseComponent` include il suffisso "Component" pur non essendo un `@Component` Angular decorato. Non viola alcuna regola ESLint (`@angular-eslint/component-class-suffix` si applica solo a classi decorate), ma è stato segnalato come potenzialmente fuorviante. Lasciato invariato per non introdurre un secondo giro di rename in questo ticket.

--- a/docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/overview.md
+++ b/docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/overview.md
@@ -1,0 +1,53 @@
+> Ticket: oc:5125
+
+# Avere una unica AddPhotos per ugc-track e ugc-poi
+
+## Cosa cambia
+
+Il ticket originale (creato il 12/03/2025) referenzia `modal-save.component` e `modal-waypoint-save.component`, nomi non più esistenti nella codebase attuale. Un'indagine nel codice ha permesso di individuare l'ambito reale, confermato con l'utente:
+
+- Il flusso di **registrazione** (creazione nuovo track/POI via GPS, `core/src/app/components/shared/modal-save/modal-save.component.ts`) è **già unificato**: un solo `ModalSaveComponent` gestisce sia track che waypoint tramite il flag `isWaypoint`, ed usa già `wm-image-picker` condiviso. Nessuna modifica necessaria qui.
+- Il flusso di **editing di UGC già sincronizzati** (in `wm-core`) ha invece due componenti separati con logica duplicata attorno all'AddPhotos: `ugc-poi-properties.component.ts` e `ugc-track-properties.component.ts`. Entrambi:
+  - hanno lo stesso identico metodo `photosChanged(photos: Media[]): void { this._photos = photos; }`
+  - passano `this._photos ?? []` come `media` nel payload di update (`updatePoi()` / `updateTrack()`)
+  - hanno un metodo `enableEditing()` duplicato e inerte (dead code, non richiamato da nessun template)
+
+Questa feature estrae la logica duplicata in una classe base astratta condivisa, mantenendo separata la logica di dominio (dispatch delle action `updateUgcPoi`/`updateUgcTrack`, che restano specifiche di ciascun componente).
+
+## Perché
+
+Ridurre la duplicazione di codice tra i due componenti di editing UGC, rendendo più facile mantenere in futuro la logica di gestione foto (es. se cambierà il modello `Media` o la validazione).
+
+## Requisiti
+
+- [ ] Creare `UgcPropertiesBaseComponent` (classe astratta) in `projects/wm-core/src/ugc-properties-base/ugc-properties-base.component.ts`, con:
+  - campo protetto `_photos: Media[] = []`
+  - metodo `photosChanged(photos: Media[]): void`
+  - getter/metodo protetto per ottenere i photos pronti per il merge nel payload (nessun fallback `?? []`: il campo è sempre un array valido per costruzione, il fallback attuale nei due componenti è codice morto)
+- [ ] `UgcPoiPropertiesComponent` estende `UgcPropertiesBaseComponent`, rimuove **completamente** il proprio `photosChanged()` e la propria dichiarazione di `_photos` (nessuna ridichiarazione, nemmeno senza inizializzatore — vedi Rischi), usa l'helper ereditato in `updatePoi()`
+- [ ] `UgcTrackPropertiesComponent` estende `UgcPropertiesBaseComponent`, rimuove **completamente** il proprio `photosChanged()` e la propria dichiarazione di `_photos`, usa l'helper ereditato in `updateTrack()`
+- [ ] Rimuovere il metodo `enableEditing()` duplicato e inerte da entrambi i componenti (dead code, nessun template lo richiama)
+- [ ] Comportamento a runtime invariato: editing POI e track con AddPhotos deve funzionare esattamente come prima (nessuna regressione visibile)
+
+## Rischi
+
+- **Class field shadowing**: se una sottoclasse lascia per errore una propria dichiarazione di `_photos` (anche solo `private _photos: Media[];` senza inizializzatore, es. per un merge non pulito), il campo può interferire col valore ereditato. Nota: con `useDefineForClassFields: false` in `core/tsconfig.json` (semantica `[[Set]]`, non ES2022 `[[Define]]`), una dichiarazione senza inizializzatore non genera codice a runtime e quindi non azzererebbe il valore — il rischio concreto in questa codebase è più limitato di quanto una lettura ES2022-standard suggerirebbe. Mitigato comunque da un requisito esplicito di implementazione (rimozione completa, non solo svuotamento) e dalla verifica manuale end-to-end pre-commit.
+- **Nessun test automatico di regressione**: gli spec di componenti wm-core non girano in CI (`tsconfig.spec.json` limita l'include a `src/app/services/**/*.spec.ts`, decisione oc:8023). Il rischio di regressione silenziosa è mitigato da una verifica manuale end-to-end (edit POI + edit track con foto) prima del commit, non da un test automatico.
+- **Scope ridotto rispetto al ticket originale**: `draw-ugc.component.ts` (flusso di creazione manuale, usa `Photo[]` invece di `Media[]`) resta esplicitamente fuori scope — decisione confermata con l'utente per evitare di forzare un'astrazione tra due modelli dati semanticamente diversi (foto locali non sincronizzate vs foto già sincronizzate con id).
+- **`_photos` non resettato su riuso del componente (preesistente, invariato)**: se un'istanza venisse riusata da Ionic per un'entità diversa senza essere distrutta, `_photos` conserverebbe lo stato dell'entità precedente finché l'utente non tocca di nuovo l'image-picker. Comportamento identico oggi in entrambi i componenti — la classe base si limita a spostare il codice esistente, non introduce né corregge questo edge case. Esplicitamente lasciato invariato e fuori scope.
+- **Rollback cross-repo**: `wm-core` è un submodule condiviso da più repo (webmapp-app, osm2cai, camminiditalia). Il rollback tecnico del commit è semplice (nessuna migrazione dati/API), ma se una regressione silenziosa emergesse solo in produzione (assenza di test automatici), un rollback isolato richiederebbe coordinare l'aggiornamento del puntatore submodule in tutti i repo consumer che avessero già bumpato la versione. Rischio accettato, mitigato dalla verifica manuale pre-commit.
+
+**Nota — falso positivo scartato durante la challenge**: è stata inizialmente ipotizzata una fix per "foto locali non sincronizzate inviate in una PUT non valida verso il backend". Verificato che `ugc.service.ts: _buildFormData()` già gestisce correttamente questo caso (filtra `media.filter(p => !p.id)` e li allega come file multipart `images[]` nella stessa richiesta di update) — non è un bug, nessuna modifica necessaria.
+
+## Out of scope
+
+- `draw-ugc.component.ts` (creazione manuale, modello `Photo[]`) — nessuna modifica
+- `ModalSaveComponent` (flusso di registrazione GPS, repo principale `core/`) — già unificato, nessuna modifica
+- Aggiunta di test automatici (nessuno spec esiste oggi per questi componenti; non aggiunti in questo ciclo, coerente con lo stato attuale del progetto)
+- Modifiche a `tsconfig.spec.json` / configurazione CI
+
+## Moduli toccati
+
+- `wm-core/projects/wm-core/src/ugc-properties-base/ugc-properties-base.component.ts` (nuovo)
+- `wm-core/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts` (modificato)
+- `wm-core/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts` (modificato)

--- a/docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/plan.md
+++ b/docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/plan.md
@@ -1,0 +1,59 @@
+> Ticket: oc:5125
+
+# Piano — Avere una unica AddPhotos per ugc-track e ugc-poi
+
+Repo: `wm-core` (submodule). Nessuna modifica al repo principale `webmapp-app` né ad altri submodule.
+
+## Task 1 — Creare `UgcPropertiesBaseComponent`
+
+File: `projects/wm-core/src/ugc-properties-base/ugc-properties-base.component.ts` (nuovo)
+
+- Classe astratta `UgcPropertiesBaseComponent`
+- Campo protetto `_photos: Media[] = []`
+- Metodo pubblico `photosChanged(photos: Media[]): void { this._photos = photos; }`
+- Nessun costruttore, nessuna injection: la classe è puramente un contenitore di stato/logica sincrona, per non forzare le sottoclassi ad allineare le proprie dipendenze DI a quelle della base.
+- Import `Media` da `@wm-types/feature` (stesso import già usato in entrambi i componenti target).
+
+Commit: `feat(oc:5125): add UgcPropertiesBaseComponent to share photo state`
+
+## Task 2 — Refactor `UgcPoiPropertiesComponent`
+
+File: `projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts`
+
+- `export class UgcPoiPropertiesComponent extends UgcPropertiesBaseComponent`
+- Rimuovere la dichiarazione locale `private _photos: Media[] = [];` (nessuna ridichiarazione, nemmeno vuota — vedi rischio class-field-shadowing in overview.md)
+- Rimuovere il metodo locale `photosChanged(photos: Media[]): void { this._photos = photos; }` (ereditato dalla base)
+- Rimuovere il metodo `enableEditing(): void { this.isEditing$; }` (dead code, nessun template lo richiama)
+- In `updatePoi()`, sostituire `media: this._photos ?? [],` con `media: this._photos,` (il fallback non serve più: il campo è sempre un array valido per costruzione nella base class)
+- Nessun altro cambiamento: import, decoratori, altri metodi restano invariati
+
+Commit: `refactor(oc:5125): extend UgcPropertiesBaseComponent in UgcPoiPropertiesComponent`
+
+## Task 3 — Refactor `UgcTrackPropertiesComponent`
+
+File: `projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts`
+
+- `export class UgcTrackPropertiesComponent extends UgcPropertiesBaseComponent`
+- Rimuovere la dichiarazione locale `private _photos: Media[] = [];`
+- Rimuovere il metodo locale `photosChanged(photos: Media[]): void { this._photos = photos; }`
+- Rimuovere il metodo `enableEditing(): void { this.isEditing$; }`
+- In `updateTrack()`, sostituire `media: this._photos ?? [],` con `media: this._photos,`
+- Nessun altro cambiamento
+
+Commit: `refactor(oc:5125): extend UgcPropertiesBaseComponent in UgcTrackPropertiesComponent`
+
+## Task 4 — Verifica manuale end-to-end
+
+Nessun test automatico (vedi overview.md — spec di componenti wm-core non girano in CI). Verificare manualmente in dev server (`npm start`):
+
+1. Aprire un POI UGC già sincronizzato → modalità edit → aggiungere una foto dalla libreria → salvare → verificare che la foto compaia dopo il salvataggio
+2. Aprire un track UGC già sincronizzato → modalità edit → aggiungere una foto → salvare → verificare che la foto compaia
+3. Verificare che il bottone "edit" (che chiama `this.isEditing$.next(true)` inline dal template) funzioni ancora identico su entrambi, a conferma che la rimozione di `enableEditing()` non ha effetti (nessun template lo richiamava)
+4. Controllare in DevTools/console che non ci siano errori TypeScript/runtime legati a `_photos` non definito o `undefined` in nessuno dei due flussi
+
+Nessun commit associato a questo task (è verifica, non codice).
+
+## Note per l'esecuzione
+
+- Nessun commit automatico durante l'implementazione: i commit sopra sono istruzioni testuali, da eseguire solo dopo approvazione esplicita del developer (vedi Fase: execution → review-gate nel workflow wm-plan).
+- Nessuna modifica a `draw-ugc.component.ts`, `ModalSaveComponent` (repo principale), `tsconfig.spec.json` — esplicitamente fuori scope (vedi overview.md).

--- a/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
+++ b/projects/wm-core/src/ugc-poi-properties/ugc-poi-properties.component.ts
@@ -12,12 +12,13 @@ import {Store} from '@ngrx/store';
 import {BehaviorSubject, from, Observable, of} from 'rxjs';
 import {switchMap, take} from 'rxjs/operators';
 import {Point} from 'geojson';
-import {Media, WmFeature} from '@wm-types/feature';
+import {WmFeature} from '@wm-types/feature';
 import {LangService} from '@wm-core/localization/lang.service';
 import {deleteUgcPoi, updateUgcPoi} from '@wm-core/store/features/ugc/ugc.actions';
 import {UntypedFormGroup} from '@angular/forms';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {currentUgcPoi, currentUgcPoiProperties} from '@wm-core/store/features/ugc/ugc.selector';
+import {UgcPropertiesBaseComponent} from '@wm-core/ugc-properties-base/ugc-properties-base.component';
 
 @Component({
   standalone: false,
@@ -27,7 +28,7 @@ import {currentUgcPoi, currentUgcPoiProperties} from '@wm-core/store/features/ug
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class UgcPoiPropertiesComponent {
+export class UgcPoiPropertiesComponent extends UgcPropertiesBaseComponent {
   @Output('dismiss') dismiss: EventEmitter<any> = new EventEmitter<any>();
   @Output('poi-click') poiClick: EventEmitter<number> = new EventEmitter<number>();
   @ViewChild('content') content: IonContent;
@@ -39,8 +40,6 @@ export class UgcPoiPropertiesComponent {
   currentUgcPoiProperties$ = this._store.select(currentUgcPoiProperties);
   fg: UntypedFormGroup;
   isEditing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-
-  private _photos: Media[] = [];
 
   slideOptions = {
     allowTouchMove: false,
@@ -58,7 +57,9 @@ export class UgcPoiPropertiesComponent {
     private _alertCtlr: AlertController,
     private _langSvc: LangService,
     private _urlHandlerSvc: UrlHandlerService,
-  ) {}
+  ) {
+    super();
+  }
 
   deletePoi(): void {
     this.currentUgcPoi$
@@ -84,10 +85,6 @@ export class UgcPoiPropertiesComponent {
       .subscribe(alert => alert.present());
   }
 
-  enableEditing(): void {
-    this.isEditing$;
-  }
-
   removeUgcPoiFromUrl(): void {
     this._urlHandlerSvc.updateURL({ugc_poi: undefined});
   }
@@ -108,7 +105,7 @@ export class UgcPoiPropertiesComponent {
             form: this.fg.value,
             ...(this.fg.value?.layer_id != null && {layer_id: this.fg.value.layer_id}),
             updatedAt: new Date(),
-            media: this._photos ?? [],
+            media: this.photos,
           },
         };
 
@@ -116,9 +113,5 @@ export class UgcPoiPropertiesComponent {
         this.isEditing$.next(false);
       }
     });
-  }
-
-  photosChanged(photos: Media[]): void {
-    this._photos = photos;
   }
 }

--- a/projects/wm-core/src/ugc-properties-base/ugc-properties-base.component.ts
+++ b/projects/wm-core/src/ugc-properties-base/ugc-properties-base.component.ts
@@ -1,0 +1,23 @@
+import {Media} from '@wm-types/feature';
+
+/**
+ * Base class shared by UgcPoiPropertiesComponent and UgcTrackPropertiesComponent
+ * to hold the photo list edited via wm-image-picker.
+ */
+export abstract class UgcPropertiesBaseComponent {
+  protected _photos: Media[] = [];
+
+  /**
+   * Photos ready to be merged into the update payload.
+   */
+  protected get photos(): Media[] {
+    return this._photos;
+  }
+
+  /**
+   * Handler for wm-image-picker's (photosChanged) output.
+   */
+  photosChanged(photos: Media[]): void {
+    this._photos = photos;
+  }
+}

--- a/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
+++ b/projects/wm-core/src/ugc-track-properties/ugc-track-properties.component.ts
@@ -16,13 +16,14 @@ import {Store} from '@ngrx/store';
 import {BehaviorSubject, from, Observable} from 'rxjs';
 import {take, tap} from 'rxjs/operators';
 import {LineString} from 'geojson';
-import {Media, WmFeature} from '@wm-types/feature';
+import {WmFeature} from '@wm-types/feature';
 import {LangService} from '@wm-core/localization/lang.service';
 import {deleteUgcTrack, updateUgcTrack} from '@wm-core/store/features/ugc/ugc.actions';
 import {UntypedFormGroup} from '@angular/forms';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
 import {trackElevationChartHoverElemenents} from '@wm-core/store/user-activity/user-activity.action';
+import {UgcPropertiesBaseComponent} from '@wm-core/ugc-properties-base/ugc-properties-base.component';
 
 @Component({
   standalone: false,
@@ -32,7 +33,7 @@ import {trackElevationChartHoverElemenents} from '@wm-core/store/user-activity/u
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class UgcTrackPropertiesComponent {
+export class UgcTrackPropertiesComponent extends UgcPropertiesBaseComponent {
   @Input('track') set setTrack(track: WmFeature<LineString>) {
     if (track != null) {
       this.track = track;
@@ -64,14 +65,14 @@ export class UgcTrackPropertiesComponent {
   };
   track: WmFeature<LineString>;
 
-  private _photos: Media[] = [];
-
   constructor(
     private _store: Store,
     private _alertCtlr: AlertController,
     private _langSvc: LangService,
     private _urlHandlerSvc: UrlHandlerService,
-  ) {}
+  ) {
+    super();
+  }
 
   @HostListener('document:keydown.Escape', ['$event'])
   public close(): void {
@@ -118,16 +119,8 @@ export class UgcTrackPropertiesComponent {
     ).subscribe(alert => alert.present());
   }
 
-  enableEditing(): void {
-    this.isEditing$;
-  }
-
   onLocationHover(event: WmSlopeChartHoverElements): void {
     this._store.dispatch(trackElevationChartHoverElemenents({elements: event}));
-  }
-
-  photosChanged(photos: Media[]): void {
-    this._photos = photos;
   }
 
   removeUgcTrackFromUrl(): void {
@@ -147,7 +140,7 @@ export class UgcTrackPropertiesComponent {
           ...this.track?.properties,
           name: this.fg.value.title,
           form: this.fg.value,
-          media: this._photos ?? [],
+          media: this.photos,
           updatedAt: new Date(),
         },
       };


### PR DESCRIPTION
## Summary
- Estratta `UgcPropertiesBaseComponent` (classe base astratta) per condividere la logica di `_photos`/`photosChanged()` tra `UgcPoiPropertiesComponent` e `UgcTrackPropertiesComponent` (flusso di editing di UGC POI/track già sincronizzati)
- Rimosso `enableEditing()` (dead code duplicato in entrambi i componenti, non richiamato da nessun template)
- Rimosso il fallback ridondante `?? []` nel merge del payload di update (il campo `_photos` è sempre un array valido per costruzione)

Il flusso di registrazione GPS (`ModalSaveComponent`, repo principale) era già unificato tramite un flag `isWaypoint` — non toccato da questa PR. `draw-ugc.component.ts` (creazione manuale, modello dati `Photo[]` diverso da `Media[]`) resta esplicitamente fuori scope.

Dettagli completi in `docs/features/5125-avere-una-unica-addphotos-per-ugc-track-e-ugc-poi/` (overview, plan, notes).

## Test plan
- [x] Build/lint puliti (`tsc --noEmit` sul progetto principale, nessun errore sui file toccati)
- [x] Review formale (5 finder paralleli: correctness, side effect, deviazioni piano, cleanup, design) — nessun bloccante
- [x] Verifica manuale: home/mappa caricate senza errori nuovi in browser headless
- [x] Verifica manuale end-to-end (editing POI e track con aggiunta foto) confermata dal developer
- [ ] Nessun test automatico aggiunto (spec di componenti wm-core non girano in CI, vedi oc:8023)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>