### PR TITLE
fix(oc:4783): add wmMapPadding to ugc uploader preview map

### DIFF
--- a/docs/features/4783-controllare-il-padding-della-mappa/notes.md
+++ b/docs/features/4783-controllare-il-padding-della-mappa/notes.md
@@ -1,0 +1,17 @@
+> Ticket: oc:4783
+
+# Notes — Controllare il padding della mappa
+
+## Deviazioni dal piano
+
+- Il coinvolgimento di questo repo non era previsto nell'overview iniziale (lo scope originale era limitato a `map-core`). È emerso a posteriori: il developer aveva già aggiunto `[wmMapPadding]="[20, 20, 20, 20]"` a `modal-ugc-uploader.component.html` per la verifica manuale del fix (Step 4 del piano in `map-core`), e ha poi deciso di renderlo permanente. `overview.md` di questo repo è stato creato dopo l'implementazione per documentare questa estensione di scope, non prima come da ordine di fase standard del workflow.
+- Branch `feature/oc-4783-controllare-il-padding-della-mappa` creato dopo che la modifica al file era già presente in working tree (non da branch pulito) — la modifica è stata comunque portata correttamente sul nuovo branch, nessuna perdita.
+
+## Bug trovati
+Nessuno.
+
+## Decisioni
+- Il binding resta permanente (vedi `map-core/docs/features/4783-controllare-il-padding-della-mappa/notes.md` per il contesto completo della decisione).
+
+## Follow-up
+Nessuno specifico a questo repo — vedi i follow-up in `map-core/docs/features/4783-controllare-il-padding-della-mappa/notes.md`.

--- a/docs/features/4783-controllare-il-padding-della-mappa/overview.md
+++ b/docs/features/4783-controllare-il-padding-della-mappa/overview.md
@@ -1,0 +1,21 @@
+> Ticket: oc:4783
+
+# Controllare il padding della mappa
+
+## Cosa cambia
+`modal-ugc-uploader.component.html:25-29` mantiene il binding `[wmMapPadding]="[20, 20, 20, 20]"` su `<wm-map>` (posizionato prima di `[wmMapGeojson]`, come da convenzione di ordine attributi documentata in `map-core/CLAUDE.md`). Il fix vero e proprio (perché il padding produca un effetto visibile) è nel submodule `map-core` — vedi `map-core/docs/features/4783-controllare-il-padding-della-mappa/overview.md`.
+
+## Perché
+Il bug originale (padding senza effetto) era stato riprodotto proprio con questo binding. Durante la verifica del fix in `map-core`, si è deciso di rendere il binding permanente invece di rimuoverlo dopo il test: ora che il padding funziona, migliora la leggibilità della traccia caricata nel flusso di upload UGC rispetto ai bordi della mappa di anteprima.
+
+## Requisiti
+- [x] `[wmMapPadding]="[20, 20, 20, 20]"` presente e permanente su `<wm-map>` in `modal-ugc-uploader.component.html`
+
+## Rischi
+- Nessun rischio aggiuntivo oltre a quelli già documentati in `map-core/docs/features/4783-controllare-il-padding-della-mappa/overview.md` (il comportamento dipende interamente dal fix in `map-core`).
+
+## Out of scope
+- Binding di `wmMapPadding` su `modal-success` (repo principale `webmapp-app`) — non richiesto
+
+## Moduli toccati
+- `core/src/app/shared/wm-core/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.html`

--- a/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.html
+++ b/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.html
@@ -25,6 +25,7 @@
       <wm-map
         [wmMapConf]="confMap$|async"
         [wmMapOnly]="true"
+        [wmMapPadding]="[20, 20, 20, 20]"
         [wmMapGeojson]="ugcFeature$|async"
       ></wm-map>
       <wm-form


### PR DESCRIPTION
## Summary
- Aggiunto `[wmMapPadding]="[20, 20, 20, 20]"` alla mappa di anteprima traccia in `modal-ugc-uploader.component.html`
- Il binding era già usato nel repro del ticket ma non aveva effetto per un bug in `map-core` (vedi PR collegata webmappsrl/map-core#60): ora che il fix è applicato, il padding migliora la leggibilità della traccia caricata rispetto ai bordi della mappa
- Dipende da webmappsrl/map-core#60 (submodule pin da aggiornare dopo il merge di quella PR)
- Documentazione in `docs/features/4783-controllare-il-padding-della-mappa/`

## Test plan
- [x] Verificato manualmente: caricamento di un file .geojson/.gpx in "Carica File" mostra ora un margine di 20px tra la traccia e i bordi della mappa di anteprima

Ticket: oc:4783

🤖 Generated with [Claude Code](https://claude.com/claude-code)