### PR TITLE
feat(oc:8284): distanza rimanente durante la registrazione traccia UGC

### DIFF
--- a/docs/features/8284-distanza-rimanente-registrazione-ugc/overview.md
+++ b/docs/features/8284-distanza-rimanente-registrazione-ugc/overview.md
@@ -6,7 +6,9 @@
 
 Nessuna nuova logica di calcolo in wm-core. Verificato che `UserActivityEffects.trackRemainingDistance$` (oc:8177, `store/user-activity/user-activity.effects.ts`) calcola già `trackDistanceCovered`/`trackRemainingDistance`/`trackPositionStale` combinando `GeolocationService.onLocationChange$` con il selettore `ec.currentEcTrack` — **senza alcun gating su `onRecord`/modalità**: il calcolo è già attivo, live, ogni volta che una traccia è selezionata, indipendentemente dal fatto che l'utente stia registrando, navigando o nient'altro. Il box di registrazione (repo principale) legge quindi direttamente questi selettori già pubblici (`user-activity.selector.ts`), senza alcuna modifica a wm-core per il calcolo delle distanze.
 
-Unica modifica: innalzamento della costante `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-remaining-distance.ts`) da 3 a 8 m/s, per rendere plausibili anche spostamenti in bici durante la registrazione UGC (il repo contiene già un GPX di test per un percorso in bici a 18km/h) — decisione presa in Fase: challenge con lo sviluppatore, non trattata nella call con il CTO ma comunque valida. È una modifica cross-cutting: si applica anche al calcolo esistente in visualizzazione (oc:8177).
+Innalzamento della costante `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-remaining-distance.ts`) da 3 a 8 m/s, per rendere plausibili anche spostamenti in bici durante la registrazione UGC (il repo contiene già un GPX di test per un percorso in bici a 18km/h) — decisione presa in Fase: challenge con lo sviluppatore, non trattata nella call con il CTO ma comunque valida. È una modifica cross-cutting: si applica anche al calcolo esistente in visualizzazione (oc:8177).
+
+**Aggiunta a posteriori (dopo verifica su device reale del box di registrazione, vedi overview lato `core`)**: nuovo `@Input() showSuffix: boolean = true` su `WmTrackLiveDistanceBadgeComponent` (`track-live-distance-badge/`). A `false`, il badge mostra solo la distanza formattata, senza il suffisso `" da te"` che il componente aggiunge di default. Default `true` per non alterare l'unico uso esistente (`tab-detail.component.html`, oc:8177) — nessuna modifica richiesta lì. Il box di registrazione (repo principale) passa `[showSuffix]="false"`, perché l'etichetta "PARTENZA"/"ARRIVO" già dà il contesto e "da te" risultava ridondante.
 
 ## Perché
 
@@ -15,6 +17,7 @@ Riuso deliberato dell'architettura esistente invece di introdurne una nuova. Rev
 ## Requisiti
 
 - [ ] `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-remaining-distance.ts`) alzata da 3 a 8 m/s
+- [ ] `WmTrackLiveDistanceBadgeComponent`: nuovo `@Input() showSuffix = true` — a `false` omette il suffisso `" da te"` dal testo del badge, mostrando solo la distanza formattata. Nessun impatto sull'uso esistente in `tab-detail.component.html` (default `true`, nessuna modifica al chiamante)
 
 ## Rischi
 
@@ -35,5 +38,4 @@ Riuso deliberato dell'architettura esistente invece di introdurne una nuova. Rev
 
 **wm-core (submodule):**
 - `projects/wm-core/src/constants/track-remaining-distance.ts` — `REMAINING_DISTANCE_MAX_SPEED_MS` da 3 a 8 m/s
-
-Nessun'altra modifica a wm-core.
+- `projects/wm-core/src/track-live-distance-badge/track-live-distance-badge.component.ts` / `.html` — nuovo `@Input() showSuffix` (aggiunta a posteriori, vedi "Cosa cambia")

--- a/docs/features/8284-distanza-rimanente-registrazione-ugc/overview.md
+++ b/docs/features/8284-distanza-rimanente-registrazione-ugc/overview.md
@@ -10,6 +10,8 @@ Innalzamento della costante `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-
 
 **Aggiunta a posteriori (dopo verifica su device reale del box di registrazione, vedi overview lato `core`)**: nuovo `@Input() showSuffix: boolean = true` su `WmTrackLiveDistanceBadgeComponent` (`track-live-distance-badge/`). A `false`, il badge mostra solo la distanza formattata, senza il suffisso `" da te"` che il componente aggiunge di default. Default `true` per non alterare l'unico uso esistente (`tab-detail.component.html`, oc:8177) — nessuna modifica richiesta lì. Il box di registrazione (repo principale) passa `[showSuffix]="false"`, perché l'etichetta "PARTENZA"/"ARRIVO" già dà il contesto e "da te" risultava ridondante.
 
+**Fix applicato dopo la review formale (`wm-skills:wm-review-ticket`)**: la logica di combinazione `trackDistanceCovered`/`trackRemainingDistance`/`trackPositionStale`/`confOPTIONSShowTrackRemainingDistance` (con lo stesso gate) era duplicata identica tra `tab-detail.component.ts` (oc:8177) e `track-recorder.component.ts` (oc:8284, repo principale). Estratta in un nuovo selettore condiviso `trackLiveDistanceVm` (con interfaccia `TrackLiveDistanceVm`) in `user-activity.selector.ts` — questo **aggiunge un nuovo selettore a wm-core**, contraddicendo la precedente formulazione di questa sezione ("nessuna nuova logica di calcolo in wm-core"): non è un nuovo *calcolo*, ma una composizione di selettori già esistenti, resa esplicita e condivisa invece di lasciata duplicata in due consumer.
+
 ## Perché
 
 Riuso deliberato dell'architettura esistente invece di introdurne una nuova. Revisione con il CTO (call del 22/07/2026, trascrizione condivisa) ha corretto un'impostazione iniziale eccessivamente elaborata — uno stato dedicato `recordingEcTrackId` con pin/sostituzione-in-corsa/persistenza su localForage/retry automatico — perché il dato necessario è già disponibile e calcolato: l'unico lavoro reale è di visualizzazione (vedi overview lato `core`).
@@ -18,6 +20,8 @@ Riuso deliberato dell'architettura esistente invece di introdurne una nuova. Rev
 
 - [ ] `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-remaining-distance.ts`) alzata da 3 a 8 m/s
 - [ ] `WmTrackLiveDistanceBadgeComponent`: nuovo `@Input() showSuffix = true` — a `false` omette il suffisso `" da te"` dal testo del badge, mostrando solo la distanza formattata. Nessun impatto sull'uso esistente in `tab-detail.component.html` (default `true`, nessuna modifica al chiamante)
+- [ ] `user-activity.selector.ts`: nuovo selettore `trackLiveDistanceVm` (+ interfaccia `TrackLiveDistanceVm`) che compone `trackDistanceCovered`/`trackRemainingDistance`/`trackPositionStale`/`confOPTIONSShowTrackRemainingDistance` con lo stesso gate già usato nei due consumer — sostituisce la logica duplicata inline in `tab-detail.component.ts` e `track-recorder.component.ts`
+- [ ] `tab-detail.component.ts`: aggiornato per usare `this._store.select(trackLiveDistanceVm)` al posto del `combineLatest` inline; rimossi gli import ora inutilizzati (`combineLatest`, `map`, i singoli selettori)
 
 ## Rischi
 
@@ -32,10 +36,12 @@ Riuso deliberato dell'architettura esistente invece di introdurne una nuova. Rev
 - Marker di posizione sul profilo altimetrico durante la registrazione
 - Modifica della soglia di 100m (`REMAINING_DISTANCE_OFF_TRACK_THRESHOLD_M`, riusata identica a oc:8177)
 - Feature flag/kill-switch runtime
-- Qualunque modifica a `GeolocationService`, `store/user-activity/` (oltre a nessuna azione/reducer/selector/effect nuovo), `utils/localForage.ts`, `store/features/ec/ec.effects.ts`
+- Qualunque modifica a `GeolocationService`, `utils/localForage.ts`, `store/features/ec/ec.effects.ts` — su `store/user-activity/` resta esclusa qualunque nuova *action/reducer/effect* (il nuovo `trackLiveDistanceVm` è un selettore che compone selettori già esistenti, non un nuovo stato)
 
 ## Moduli toccati
 
 **wm-core (submodule):**
 - `projects/wm-core/src/constants/track-remaining-distance.ts` — `REMAINING_DISTANCE_MAX_SPEED_MS` da 3 a 8 m/s
 - `projects/wm-core/src/track-live-distance-badge/track-live-distance-badge.component.ts` / `.html` — nuovo `@Input() showSuffix` (aggiunta a posteriori, vedi "Cosa cambia")
+- `projects/wm-core/src/store/user-activity/user-activity.selector.ts` — nuovo selettore condiviso `trackLiveDistanceVm` (fix post-review)
+- `projects/wm-core/src/tab-detail/tab-detail.component.ts` — aggiornato per riusare `trackLiveDistanceVm` (fix post-review, nessuna modifica al template `tab-detail.component.html`)

--- a/docs/features/8284-distanza-rimanente-registrazione-ugc/overview.md
+++ b/docs/features/8284-distanza-rimanente-registrazione-ugc/overview.md
@@ -1,0 +1,39 @@
+> Ticket: oc:8284
+
+# Distanza rimanente durante la registrazione traccia UGC
+
+## Cosa cambia
+
+Nessuna nuova logica di calcolo in wm-core. Verificato che `UserActivityEffects.trackRemainingDistance$` (oc:8177, `store/user-activity/user-activity.effects.ts`) calcola già `trackDistanceCovered`/`trackRemainingDistance`/`trackPositionStale` combinando `GeolocationService.onLocationChange$` con il selettore `ec.currentEcTrack` — **senza alcun gating su `onRecord`/modalità**: il calcolo è già attivo, live, ogni volta che una traccia è selezionata, indipendentemente dal fatto che l'utente stia registrando, navigando o nient'altro. Il box di registrazione (repo principale) legge quindi direttamente questi selettori già pubblici (`user-activity.selector.ts`), senza alcuna modifica a wm-core per il calcolo delle distanze.
+
+Unica modifica: innalzamento della costante `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-remaining-distance.ts`) da 3 a 8 m/s, per rendere plausibili anche spostamenti in bici durante la registrazione UGC (il repo contiene già un GPX di test per un percorso in bici a 18km/h) — decisione presa in Fase: challenge con lo sviluppatore, non trattata nella call con il CTO ma comunque valida. È una modifica cross-cutting: si applica anche al calcolo esistente in visualizzazione (oc:8177).
+
+## Perché
+
+Riuso deliberato dell'architettura esistente invece di introdurne una nuova. Revisione con il CTO (call del 22/07/2026, trascrizione condivisa) ha corretto un'impostazione iniziale eccessivamente elaborata — uno stato dedicato `recordingEcTrackId` con pin/sostituzione-in-corsa/persistenza su localForage/retry automatico — perché il dato necessario è già disponibile e calcolato: l'unico lavoro reale è di visualizzazione (vedi overview lato `core`).
+
+## Requisiti
+
+- [ ] `REMAINING_DISTANCE_MAX_SPEED_MS` (`constants/track-remaining-distance.ts`) alzata da 3 a 8 m/s
+
+## Rischi
+
+- **Modifica di `REMAINING_DISTANCE_MAX_SPEED_MS` è cross-cutting** — alzarla per il caso bici della registrazione modifica anche il comportamento esistente in visualizzazione (oc:8177); rischio ritenuto basso (la soglia più alta rende la ricerca locale plausibile più spesso, non introduce falsi negativi), ma da verificare in test manuale su una traccia in visualizzazione dopo il merge, non solo sulla registrazione
+
+## Out of scope
+
+- **Qualsiasi stato dedicato alla registrazione** (pin, sostituzione in corsa, persistenza su localForage, retry automatico, fetch/cache dedicati) — esplicitamente respinto dal CTO in review: "il dato ce l'abbiamo già presente nel dettaglio, non lo dobbiamo calcolare, vogliamo solo visualizzarlo lì". Introdurre questo stato "crea una forte dipendenza da gestire in tutti i casi, altrimenti c'è il bug" (citazione dalla call)
+- **Gestione esplicita del cambio/deselezione traccia durante la registrazione** (switch da una tappa all'altra, deselezione manuale, ecc.) — comportamento naturale della cascata di condizioni già esistente sul selettore `currentEcTrack`, nessuna logica ad-hoc. Se l'utente chiude il pannello traccia, i due valori smettono di essere disponibili anche nel box di registrazione — stesso comportamento di oggi in `tab-detail.component.html`, **confermato esplicitamente dallo sviluppatore dopo la call**: nessuna eccezione/persistenza per lo stato di registrazione
+- Auto-detezione/suggerimento di tracce nelle vicinanze quando nessuna traccia è selezionata
+- Nuova UI di selezione traccia dedicata al flusso di registrazione
+- Marker di posizione sul profilo altimetrico durante la registrazione
+- Modifica della soglia di 100m (`REMAINING_DISTANCE_OFF_TRACK_THRESHOLD_M`, riusata identica a oc:8177)
+- Feature flag/kill-switch runtime
+- Qualunque modifica a `GeolocationService`, `store/user-activity/` (oltre a nessuna azione/reducer/selector/effect nuovo), `utils/localForage.ts`, `store/features/ec/ec.effects.ts`
+
+## Moduli toccati
+
+**wm-core (submodule):**
+- `projects/wm-core/src/constants/track-remaining-distance.ts` — `REMAINING_DISTANCE_MAX_SPEED_MS` da 3 a 8 m/s
+
+Nessun'altra modifica a wm-core.

--- a/docs/features/8284-distanza-rimanente-registrazione-ugc/plan.md
+++ b/docs/features/8284-distanza-rimanente-registrazione-ugc/plan.md
@@ -1,0 +1,84 @@
+> Ticket: oc:8284
+
+# Distanza rimanente durante la registrazione traccia UGC (wm-core) Implementation Plan
+
+**Goal:** Alzare la soglia di velocità plausibile usata da `GeoutilsService.getRemainingDistance()` da 3 a 8 m/s, per non forzare una ricerca globale (più costosa) ad ogni fix GPS durante registrazioni UGC in bici/e-bike.
+
+**Architecture:** Modifica di una singola costante condivisa. Nessun nuovo stato, azione, effect o selector — la logica di calcolo (`getRemainingDistance`, `prepareRemainingDistanceContext`) resta invariata, così come tutto il resto di `GeolocationService`/store `user-activity`/`localForage.ts` (esplicitamente esclusi in Fase: challenge e nella review con il CTO, vedi `overview.md`).
+
+**Tech Stack:** Angular 20 (submodule wm-core), Karma + Jasmine.
+
+## Global Constraints
+
+- Nessuna modifica a `GeolocationService`, `store/user-activity/`, `utils/localForage.ts`, `store/features/ec/ec.effects.ts` — solo la costante.
+- La modifica è cross-cutting: si applica anche al calcolo esistente in visualizzazione (oc:8177), non solo alla registrazione. Verificare che la suite esistente resti verde.
+- Commit convention: `fix(oc:8284): ...` (è un aggiustamento di soglia, non una nuova feature in questo repo).
+
+---
+
+### Task 1: Alzare `REMAINING_DISTANCE_MAX_SPEED_MS` da 3 a 8 m/s
+
+**Files:**
+- Modify: `core/src/app/shared/wm-core/projects/wm-core/src/constants/track-remaining-distance.ts:25`
+- Test: `core/src/app/shared/wm-core/projects/wm-core/src/services/geoutils.service.spec.ts` (esistente, nessuna modifica — verifica di non-regressione)
+
+**Interfaces:**
+- Consumes: nessuna nuova dipendenza — `REMAINING_DISTANCE_MAX_SPEED_MS` è già importata e usata in `geoutils.service.ts` (`getRemainingDistance`, calcolo `maxPlausibleJump`)
+- Produces: nessuna nuova interfaccia — il valore esportato resta un `number`, solo il valore numerico cambia
+
+- [ ] **Step 1: Verifica il valore attuale e il contesto d'uso**
+
+```bash
+cd /Users/peco/Documents/Apps/webmapp-app
+grep -n "REMAINING_DISTANCE_MAX_SPEED_MS" core/src/app/shared/wm-core/projects/wm-core/src/constants/track-remaining-distance.ts core/src/app/shared/wm-core/projects/wm-core/src/services/geoutils.service.ts
+```
+
+Output atteso: la riga `export const REMAINING_DISTANCE_MAX_SPEED_MS = 3;` nel file constants, e un uso in `geoutils.service.ts` dentro `getRemainingDistance()` per calcolare `maxPlausibleJump`.
+
+- [ ] **Step 2: Esegui la suite esistente PRIMA della modifica (baseline)**
+
+```bash
+cd /Users/peco/Documents/Apps/webmapp-app/core/src/app/shared/wm-core
+npx ng test wm-core --configuration=ci
+```
+
+Expected: tutti i test verdi (nessun fallimento), incluso `geoutils.service.spec.ts` → describe `getRemainingDistance`. Annota il conteggio totale (es. "163/163") per confrontarlo dopo la modifica.
+
+- [ ] **Step 3: Modifica la costante**
+
+In `core/src/app/shared/wm-core/projects/wm-core/src/constants/track-remaining-distance.ts`, riga 25:
+
+```typescript
+// Prima:
+export const REMAINING_DISTANCE_MAX_SPEED_MS = 3;
+
+// Dopo:
+export const REMAINING_DISTANCE_MAX_SPEED_MS = 8;
+```
+
+Aggiorna anche il commento sopra la costante (se presente) per riflettere che la soglia ora copre anche andature in bici/e-bike durante la registrazione UGC (oc:8284), non solo il camminare (oc:8177).
+
+- [ ] **Step 4: Esegui di nuovo la suite e confronta con la baseline**
+
+```bash
+cd /Users/peco/Documents/Apps/webmapp-app/core/src/app/shared/wm-core
+npx ng test wm-core --configuration=ci
+```
+
+Expected: stesso numero di test verdi dello Step 2, nessun nuovo fallimento. In particolare il test `'con lastKnownProgress vincola la ricerca a una finestra locale...'` (righe 152-186 di `geoutils.service.spec.ts`) deve restare verde — usa `elapsedSeconds: 10`, ma l'`impliedJump` in quel caso è vicino a 0 (il punto trovato dalla ricerca locale coincide quasi esattamente col progress noto), quindi non è sensibile al valore di `REMAINING_DISTANCE_MAX_SPEED_MS`.
+
+Se un test fallisce, NON procedere: fermarsi e analizzare se il fallimento è dovuto alla modifica (in tal caso, la modifica ha un effetto collaterale non previsto nell'overview — documentarlo in `notes.md` prima di continuare) o a un problema preesistente scollegato.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/peco/Documents/Apps/webmapp-app/core/src/app/shared/wm-core
+git add projects/wm-core/src/constants/track-remaining-distance.ts
+git commit -m "fix(oc:8284): alza soglia velocità plausibile a 8 m/s per registrazione in bici"
+```
+
+---
+
+## Note per l'esecutore
+
+Questo file copre **solo** il submodule wm-core. Il lavoro principale (UI del box di registrazione) è nel repo principale — vedi `docs/features/8284-distanza-rimanente-registrazione-ugc/plan.md` in `/Users/peco/Documents/Apps/webmapp-app`. I due piani sono indipendenti: questo può essere eseguito e commesso senza attendere l'altro (e viceversa), ma la PR di wm-core va aperta prima o insieme a quella del repo principale, perché quest'ultimo dipende dai selettori già esistenti in wm-core (nessuna dipendenza inversa da questo task).

--- a/projects/wm-core/src/constants/track-remaining-distance.ts
+++ b/projects/wm-core/src/constants/track-remaining-distance.ts
@@ -19,10 +19,11 @@ export const HOVER_DISMISS_DELAY_MS = 2500;
 // Soglia oltre la quale la posizione GPS mostrata viene considerata "non aggiornata".
 export const TRACK_POSITION_STALE_THRESHOLD_MS = 60_000;
 
-// Velocità massima plausibile di un camminatore/corridore leggero, usata come soglia per
-// il fallback a ricerca globale in GeoutilsService.getRemainingDistance quando lo spostamento
-// implicito rispetto all'ultimo trackProgress noto supera questo limite.
-export const REMAINING_DISTANCE_MAX_SPEED_MS = 3;
+// Velocità massima plausibile di un utente in movimento (camminata, corsa leggera o bici/e-bike
+// durante la registrazione UGC, oc:8284), usata come soglia per il fallback a ricerca globale in
+// GeoutilsService.getRemainingDistance quando lo spostamento implicito rispetto all'ultimo
+// trackProgress noto supera questo limite.
+export const REMAINING_DISTANCE_MAX_SPEED_MS = 8;
 export const REMAINING_DISTANCE_MIN_PLAUSIBLE_JUMP_M = 150;
 export const REMAINING_DISTANCE_LOCAL_WINDOW_RATIO = 0.15;
 export const REMAINING_DISTANCE_LOCAL_WINDOW_MIN_M = 300;

--- a/projects/wm-core/src/store/user-activity/user-activity.selector.ts
+++ b/projects/wm-core/src/store/user-activity/user-activity.selector.ts
@@ -1,7 +1,12 @@
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {currentCustomTrack, currentUgcPoi, currentUgcPoiDrawn} from '../features/ugc/ugc.selector';
 import {UserActivityState} from './user-activity.reducer';
-import {confFlowLineQuote, confPOIFORMS, confTRACKFORMS} from '../conf/conf.selector';
+import {
+  confFlowLineQuote,
+  confOPTIONSShowTrackRemainingDistance,
+  confPOIFORMS,
+  confTRACKFORMS,
+} from '../conf/conf.selector';
 import {WmSlopeChartFlowLineQuote} from '@wm-types/slope-chart';
 
 export const userActivity = createFeatureSelector<UserActivityState>('user-activity');
@@ -244,3 +249,26 @@ export const trackDistanceCovered = createSelector(
 );
 export const trackProgress = createSelector(userActivity, state => state.trackProgress);
 export const trackPositionStale = createSelector(userActivity, state => state.trackPositionStale);
+
+export interface TrackLiveDistanceVm {
+  distanceCovered: number | null;
+  remainingDistance: number | null;
+  stale: boolean;
+}
+
+// Selettore condiviso tra tab-detail.component.ts (oc:8177, visualizzazione traccia) e
+// track-recorder.component.ts (oc:8284, box di registrazione) — evita di duplicare in ogni
+// consumer lo stesso gate su OPTIONS.showTrackRemainingDistance. Quando disabilitato, le
+// distanze restano null a prescindere dal dato reale (il gate è su `enabled`, non sul valore
+// numerico, perché distanceCovered/remainingDistance possono valere legittimamente 0).
+export const trackLiveDistanceVm = createSelector(
+  trackDistanceCovered,
+  trackRemainingDistance,
+  trackPositionStale,
+  confOPTIONSShowTrackRemainingDistance,
+  (distanceCovered, remainingDistance, stale, enabled): TrackLiveDistanceVm => ({
+    distanceCovered: enabled !== false ? distanceCovered : null,
+    remainingDistance: enabled !== false ? remainingDistance : null,
+    stale,
+  }),
+);

--- a/projects/wm-core/src/tab-detail/tab-detail.component.ts
+++ b/projects/wm-core/src/tab-detail/tab-detail.component.ts
@@ -10,20 +10,12 @@ import {GeoJsonProperties} from 'geojson';
 import {IGeojsonFeature, IGeojsonProperties} from '../types/model';
 import {ISlopeChartHoverElements} from '../types/slope-chart';
 import {Store} from '@ngrx/store';
-import {combineLatest, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {confOPTIONS, confOPTIONSShowTrackRemainingDistance} from '@wm-core/store/conf/conf.selector';
+import {Observable} from 'rxjs';
+import {confOPTIONS} from '@wm-core/store/conf/conf.selector';
 import {
-  trackDistanceCovered,
-  trackPositionStale,
-  trackRemainingDistance,
+  trackLiveDistanceVm,
+  TrackLiveDistanceVm,
 } from '@wm-core/store/user-activity/user-activity.selector';
-
-export interface TrackLiveDistanceVm {
-  distanceCovered: number | null;
-  remainingDistance: number | null;
-  stale: boolean;
-}
 
 @Component({
   standalone: false,
@@ -43,23 +35,10 @@ export class WmTabDetailComponent {
   confOptions$: Observable<any> = this._store.select(confOPTIONS);
   public route: IGeojsonFeature;
 
-  // Gate su OPTIONS.showTrackRemainingDistance: quando disabilitato le distanze live restano
-  // null e le righe Partenza/Arrivo si comportano come prima di oc:8177 (visibili solo se
-  // properties.from/to sono presenti). Quando abilitato, distanceCovered/remainingDistance
-  // possono valere 0 (traguardo raggiunto/appena partiti): per questo il gate è su `enabled`,
-  // non sul valore numerico, altrimenti *ngIf nasconderebbe il badge esattamente a 0.
-  trackLiveDistanceVm$: Observable<TrackLiveDistanceVm> = combineLatest([
-    this._store.select(trackDistanceCovered),
-    this._store.select(trackRemainingDistance),
-    this._store.select(trackPositionStale),
-    this._store.select(confOPTIONSShowTrackRemainingDistance),
-  ]).pipe(
-    map(([distanceCovered, remainingDistance, stale, enabled]) => ({
-      distanceCovered: enabled !== false ? distanceCovered : null,
-      remainingDistance: enabled !== false ? remainingDistance : null,
-      stale,
-    })),
-  );
+  // Selettore condiviso con track-recorder.component.ts (oc:8284) — vedi commento su
+  // trackLiveDistanceVm in user-activity.selector.ts per il gate su
+  // OPTIONS.showTrackRemainingDistance.
+  trackLiveDistanceVm$: Observable<TrackLiveDistanceVm> = this._store.select(trackLiveDistanceVm);
 
   constructor(private _store: Store<any>) {}
 

--- a/projects/wm-core/src/track-live-distance-badge/track-live-distance-badge.component.html
+++ b/projects/wm-core/src/track-live-distance-badge/track-live-distance-badge.component.html
@@ -7,5 +7,5 @@
     <circle cx="12" cy="12" r="8" />
     <circle cx="12" cy="12" r="3" fill="white" />
   </svg>
-  {{ distanceMeters | distance: 'auto':1 }} {{ 'da te' | wmtrans }}
+  {{ distanceMeters | distance: 'auto':1 }}<ng-container *ngIf="showSuffix"> {{ 'da te' | wmtrans }}</ng-container>
 </span>

--- a/projects/wm-core/src/track-live-distance-badge/track-live-distance-badge.component.ts
+++ b/projects/wm-core/src/track-live-distance-badge/track-live-distance-badge.component.ts
@@ -11,4 +11,8 @@ import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@ang
 export class WmTrackLiveDistanceBadgeComponent {
   @Input() distanceMeters: number | null = null;
   @Input() stale = false;
+  // Di default il badge mostra "<distanza> da te" (comportamento esistente in tab-detail,
+  // oc:8177). A `false` mostra solo la distanza — usato nel box di registrazione (oc:8284),
+  // dove il contesto ("PARTENZA"/"ARRIVO" già in etichetta) rende "da te" ridondante.
+  @Input() showSuffix = true;
 }


### PR DESCRIPTION
## Summary
- Innalzata `REMAINING_DISTANCE_MAX_SPEED_MS` da 3 a 8 m/s (`constants/track-remaining-distance.ts`) per rendere plausibili anche spostamenti in bici/e-bike durante la registrazione UGC — modifica cross-cutting, si applica anche al calcolo esistente in visualizzazione (oc:8177).
- Nuovo `@Input() showSuffix` su `WmTrackLiveDistanceBadgeComponent` (default `true`, nessun impatto sull'uso esistente in `tab-detail.component.html`) per omettere il suffisso "da te" nel box di registrazione del repo principale.
- Fix da review formale: estratta in un selettore condiviso `trackLiveDistanceVm` (`user-activity.selector.ts`) la logica duplicata tra `tab-detail.component.ts` e il box di registrazione (repo principale), eliminando la duplicazione.

PR gemella nel repo principale (`webmapp-app`) consuma questi cambiamenti.

## Test plan
- [x] Suite Karma (181/181) verde prima/dopo ogni modifica
- [ ] Verifica finale su develop dopo merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)