### PR TITLE
feat(oc:8163): profilo utente - nome, cognome e avatar

### DIFF
--- a/docs/features/8163-profilo-utente-nome-cognome-avatar/notes.md
+++ b/docs/features/8163-profilo-utente-nome-cognome-avatar/notes.md
@@ -1,0 +1,73 @@
+> Ticket: oc:8163
+
+# Notes — Profilo utente: nome, cognome e avatar (wm-core)
+
+## Deviazioni dal piano
+
+### `ModalHeaderComponent` spostato da `wm-core.module.ts` a `shared.module.ts`
+Non previsto da nessun task del piano. Necessario perché `ProfileEditComponent` (Task 5, dichiarato in
+`profile.module.ts`) usa `<wm-modal-header>` nel proprio template, ma `profile.module.ts` importa
+`WmSharedModule`, non `WmCoreModule` (dove `ModalHeaderComponent` era dichiarato direttamente). Spostato
+in `WmSharedModule` (già importato sia da `profile.module.ts` sia da `wm-core.module.ts`), verificando che
+`LoginComponent`/`RegisterComponent` (altri consumer) continuino a funzionare — nessuna doppia
+dichiarazione, nessuna regressione (suite completa 223/223 verde).
+
+### Gestione SUCCESS/ERROR incapsulata in `ProfileEditComponent`, non in `profile-user.component` come da piano
+Il piano (Task 5, nota dopo lo Step 3) prevedeva che l'osservazione dell'esito di `updateUserProfile`
+(chiusura modale al successo, alert all'errore) avvenisse in `profile-user.component` (Task 6).
+Nell'implementazione reale, `ProfileEditComponent.save()` si iscrive direttamente allo stream `Actions`
+(`ofType(loadAuthsSuccess, updateUserProfileFailure)`) e gestisce da sé dismiss/alert — `profile-user.component`
+si limita ad aprire il modale. Scelta più incapsulata (il componente non dipende dal chiamante per il
+proprio ciclo di vita), non documentata esplicitamente durante l'esecuzione.
+
+### `CameraService.getPhotos()` — limite qualità/dimensione applicato di default al posto di essere parametrizzato
+Il piano (Task 4) modificava direttamente il default condiviso di `getPhotos()` (usato anche dai flussi
+UGC esistenti: segnalazioni POI/traccia) invece di seguire l'alternativa che lo stesso piano suggeriva
+("estrarre un `getPhotos(options?: Partial<GalleryImageOptions>)` parametrizzato"). **Corretto durante la
+review formale** (3 finder indipendenti su 5 hanno segnalato lo stesso problema): `getPhotos()` ora accetta
+un secondo parametro opzionale `options?: Partial<GalleryImageOptions>`; il default torna a
+`quality: 100` (nessun limite, comportamento pre-ticket per i flussi UGC), e solo `addProfilePhoto()`
+passa esplicitamente `{quality: 80, width: 1600}`. Nessuna foto UGC (documentazione sentieri/POI) viene più
+compressa come effetto collaterale dell'avatar. Verificato: suite completa 223/223 verde dopo il fix.
+
+## Rischio noto, non risolto in questo ciclo
+
+### Riuso di `loadAuthsSuccess` per il successo di `updateUserProfile` — nessun ID di correlazione
+`updateUserProfile$` (auth.effects.ts) dispatcha `loadAuthsSuccess({user})` come azione di successo,
+stesso pattern già usato da `updatePrivacyAgree$` — ma senza alcun ID di correlazione tra il dispatch di
+`ProfileEditComponent.save()` e l'azione che chiude il modale. Rischio teorico: se un'altra azione
+`loadAuthsSuccess`/`updateUserProfileFailure` non correlata si verificasse mentre il modale è in stato
+`SAVING` (es. refresh silenzioso di sessione), il modale potrebbe chiudersi interpretando quell'esito come
+il proprio.
+
+**Verificato esplicitamente** (durante la review formale) che questo riuso NON corrompe il token di
+autenticazione reale: `setAccessToken(user)` (`auth.reducer.ts`) scrive `localStorage.access_token` solo
+se `user.access_token` è presente (mai lo rimuove se assente), e `AuthInterceptor` legge il token da
+`localStorage` direttamente, non dallo stato NgRx `user.access_token` — quindi anche se la risposta di
+`update()` (che non include `access_token`, a differenza di login/signup) sovrascrive
+`state.user.access_token` a `undefined`, l'autenticazione reale delle richieste successive non ne risente.
+
+Non corretto in questo ciclo: introdurre una `updateUserProfileSuccess` dedicata (invece di riusare
+`loadAuthsSuccess`) risolverebbe sia la correlazione sia l'effetto collaterale di `syncUgcAfterAuthSuccess$`
+(un sync UGC completo ad ogni modifica profilo, già segnalato come accettato nel piano) — ma è un cambio
+più ampio dello store auth, da valutare in un ciclo successivo con il developer, non applicato
+unilateralmente durante questa review.
+
+### `FetchGravatarAvatarJob` non cattura eccezioni da `addMedia()->toMediaCollection()`
+Il docblock del job promette "nessun retry, fallimento sempre loggato distintamente" — ma questo copre solo
+la chiamata HTTP (timeout/connessione) e lo status code. Se Gravatar risponde 200 con un body non
+processabile da Spatie Media Library/GD (corrotto, troncato), l'eccezione non viene catturata e sfugge da
+`handle()` senza il logging distinto promesso. Rilevante soprattutto in scala (backfill su migliaia di
+utenti). Non corretto in questo ciclo — richiede una decisione su come loggare/gestire questo caso
+specifico, segnalato per un ciclo successivo.
+
+## Follow-up per cicli successivi (da findings di cleanup, non bloccanti)
+- Colore `#4285f4` hardcoded ripetuto in più punti (profile-user, profile-edit) — da centralizzare in una
+  variabile SCSS condivisa.
+- `addProfilePhoto()`/`addPhotos()` in `CameraService` duplicano lo stesso action sheet con solo il tipo di
+  ritorno diverso — candidato per un helper condiviso parametrizzato.
+- Pattern "avatar o iniziali" duplicato tra `profile-user.component` e `profile-edit.component` — candidato
+  per un componente condiviso `wm-user-avatar`.
+- Nessuna guardia sincrona esplicita contro il doppio tap su "Salva" in `ProfileEditComponent.save()` (solo
+  `[disabled]` sul bottone) — pattern "guardia a due livelli" usato altrove nel repo (es. condivisione
+  social) non replicato qui; rischio basso, mitigato comunque da `switchMap` nell'effect.

--- a/docs/features/8163-profilo-utente-nome-cognome-avatar/overview.md
+++ b/docs/features/8163-profilo-utente-nome-cognome-avatar/overview.md
@@ -1,0 +1,48 @@
+> Ticket: oc:8163
+
+# Profilo utente: nome, cognome e avatar (wm-core)
+
+## Cosa cambia
+
+L'utente può visualizzare e modificare il proprio profilo (nome, cognome, avatar) tramite un **nuovo componente modale dedicato** (`profile-edit`), separato dall'header read-only esistente `wm-profile-user` (riusato in più punti dell'app, incluso un popup, e che resta invariato salvo il collegamento al modale). L'avatar mostrato è quello restituito dal backend (`avatar_url`, pre-popolato da Gravatar o caricato dall'utente); se assente, viene mostrato un fallback grafico con la sola iniziale del nome (il cognome è opzionale, quindi non è garantito). L'upload della foto riusa l'action sheet già esistente in `CameraService.addPhotos()` (Scatta una foto / Dalla libreria / Annulla).
+
+## Perché
+
+Il cliente vuole che gli utenti abbiano un'identità riconoscibile nell'app, come base per le feature social future (esperienze, passaporto, badge).
+
+## Requisiti
+
+- [ ] `IUser` (auth.model.ts): aggiunta `surname?: string` e `avatar_url?: string`
+- [ ] Store auth: nuova action/effect NgRx dedicata (l'unica esistente, `updateUserPrivacy$`/`updatePrivacyAgree()`, è a scopo singolo per `privacy` e invia JSON) che costruisca una richiesta `FormData`/multipart verso l'endpoint già esistente `POST /api/auth/user` (`AppAuthController::update`, verificato in `wm-package/routes/api.php:31`) — il contratto di partial update (`sometimes`) è già collaudato in produzione per `privacy`, ma la costruzione multipart per nome/cognome/foto va scritta da zero, non è un semplice riuso
+- [ ] Nuovo componente modale `ProfileEditComponent` (`projects/wm-core/src/profile/profile-edit/`) con form nome, cognome, upload avatar
+  - [ ] [UX] Touch target minimo 44×44px, spaziatura ≥8px tra elementi interattivi
+  - [ ] [UX] Upload avatar tramite un nuovo metodo dedicato in `CameraService` (es. `addProfilePhoto(): Promise<Photo>`) che riusa lo stesso action sheet di `addPhotos()` (Scatta una foto / Dalla libreria / Annulla) ma restituisce una singola foto — `addPhotos()` esistente (firma `Promise<Photo[]>`) resta invariato per non impattare i flussi UGC che lo consumano già
+  - [ ] Limite dimensione/compressione lato client sulla foto selezionata prima dell'upload (oggi `CameraService.getPhotos()` non ha `limit`/resize impostato) — evita timeout upload su connessioni mobili scadenti con foto di grandi dimensioni dalla libreria
+  - [ ] [UX] Stato esplicito loading → success/error sia sul submit del form sia sull'upload della foto (nessun invio silenzioso)
+  - [ ] [UX] Label sempre visibili sui campi (mai solo placeholder); errori mostrati dopo il touch del campo (pattern Angular reactive forms già in uso nel resto dell'app)
+  - [ ] [UX] Dismiss del modale gestito esplicitamente sul back-button Android (comportamento standard Ionic modal, non delegato al default)
+- [ ] Fallback iniziali: mostra solo l'iniziale del nome (mai un placeholder generico) quando `avatar_url` è assente; stesso sizing di `ion-avatar` esistente per evitare layout shift quando l'immagine reale carica in un secondo momento
+  - [ ] [UX] Iniziali su sfondo colorato coerente con la palette esistente dell'app
+- [ ] `profile-user.component`: aggiornamento per mostrare avatar reale o fallback iniziali (oggi mostra sempre l'icona generica `wm-icon-user-outline`) e per aprire il nuovo modale di edit
+- [ ] Traduzioni: tutte le nuove chiavi UI in tutte le lingue esistenti (`it, en, de, es, fr, pr, sq`), testo base in italiano (pattern consolidato nel repo)
+
+## Rischi
+
+- **[UX] Nome/cognome molto lunghi** possono rompere il layout dell'header o il calcolo delle iniziali — va previsto un troncamento esplicito (CSS `text-overflow` o limite caratteri lato form).
+- **[UX] Upload fallito o assenza di connessione** — l'utente deve restare con il fallback iniziali senza stati inconsistenti (es. spinner bloccato a tempo indeterminato); serve un timeout/retry esplicito sull'upload.
+- **`avatar_url`/`surname` dipendono dal backend** — se lo shard non ha ancora pubblicato la migration/deploy di wm-package, questi campi restano sempre `undefined`: il fallback a iniziali gestisce già questo caso senza errori, ma va verificato in test manuale prima del rollout.
+- **Test Cypress esistente `login-offline.cy.ts` referenzia `wm-profile-user`** — un cambio di markup nel componente (aggiunta avatar/iniziali) può rompere selettori DOM impliciti nel test; da verificare in Fase: execution/test, non blocca la pianificazione.
+- **Duplicazione visiva nome+cognome per utenti esistenti** — confermato via query diretta sul DB di produzione `camminiditalia` che molti utenti esistenti hanno già `name` con nome e cognome concatenati (es. "Gianlorenzo Spaggiari", "massimo gardini"). Se un utente esistente compila ora il nuovo campo `surname` senza modificare `name`, l'header o altri punti dell'app che concatenano `name` + `surname` per la visualizzazione rischiano di mostrare un cognome duplicato (es. "Massimo Gardini Gardini"). Mitigazione: **non concatenare mai `name` e `surname` per la visualizzazione** — mostrare `name` così com'è (può già contenere il cognome) e `surname` solo come campo separato nel form di edit, mai fuso in un'unica stringa visualizzata. Nessuna migrazione/parsing automatico del `name` esistente è previsto in questo ciclo.
+
+## Out of scope
+
+- Editing avatar per altri utenti o contesto admin
+- Crop/editing dell'immagine caricata (upload diretto, nessun editor immagine)
+
+## Moduli toccati
+
+- `projects/wm-core/src/store/auth/auth.model.ts`
+- `projects/wm-core/src/store/auth/` (selectors, effects, actions se necessario)
+- `projects/wm-core/src/profile/profile-edit/` (nuovo componente)
+- `projects/wm-core/src/profile/profile-user/profile-user.component.*`
+- `projects/wm-core/src/localization/i18n/*.ts` (nuove chiavi)

--- a/docs/features/8163-profilo-utente-nome-cognome-avatar/plan.md
+++ b/docs/features/8163-profilo-utente-nome-cognome-avatar/plan.md
@@ -1,0 +1,931 @@
+> Ticket: oc:8163
+
+# Profilo utente: nome, cognome e avatar (wm-core) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Estendere `IUser` con `surname`/`avatar_url`, aggiungere un nuovo modale `ProfileEditComponent` per modificare nome, cognome e foto profilo, e mostrare l'avatar reale o un fallback a iniziali in `profile-user.component`.
+
+**Architecture:** Nuova action/effect NgRx (`updateUserProfile`) che invia `FormData`/multipart a `POST /api/auth/user` (endpoint già esistente, verificato in `wm-package/routes/api.php:31`), riusando `loadAuthsSuccess` come azione di successo (stesso pattern di `updatePrivacyAgree$`). Nuovo metodo `CameraService.addProfilePhoto()` che riusa l'action sheet di `addPhotos()` senza modificarlo. Nuova pipe pura `WmUserInitialsPipe` per il fallback iniziali.
+
+**Tech Stack:** Angular 20 (NgModule, non standalone), Ionic 8, NgRx 20, `@capacitor/camera`, Karma/Jasmine.
+
+## Global Constraints
+
+- Nessun commit/branch automatico: i comandi `git commit` nei task sono istruzioni testuali per lo sviluppatore.
+- Commit convention: `feat(oc:8163): ...` / `fix(oc:8163): ...`.
+- Questo piano dipende dal contratto API già collaudato in wm-package (piano `wm-package`, Task 3/4) — ma il fallback a iniziali permette di sviluppare e testare la UI anche prima che il backend sia disponibile su uno shard specifico.
+- Mai concatenare `user.name` e `user.surname` in un'unica stringa visualizzata (rischio duplicazione per utenti esistenti con `name` già completo, es. "Gianlorenzo Spaggiari" → confermato su DB produzione camminiditalia).
+- Traduzioni: testo base in italiano, chiavi aggiunte in tutti e 7 i file (`it, en, de, es, fr, pr, sq`).
+- `addPhotos()` esistente in `CameraService` (usato dai flussi UGC, firma `Promise<Photo[]>`) non va modificato — nuovo metodo dedicato `addProfilePhoto()`.
+- JSDoc richiesto su funzioni/metodi pubblici (enforced da ESLint sul repo principale).
+
+---
+
+### Task 1: `IUser` — aggiungi `surname` e `avatar_url`
+
+**Files:**
+- Modify: `projects/wm-core/src/store/auth/auth.model.ts`
+
+**Interfaces:**
+- Produces: `IUser.surname?: string`, `IUser.avatar_url?: string` — consumati da Task 2 (pipe iniziali), Task 5 (form edit), Task 6 (`profile-user.component`).
+
+- [ ] **Step 1: Modifica l'interfaccia**
+
+In `auth.model.ts`:
+
+```typescript
+export interface IUser {
+  id: number;
+  email?: string;
+  name?: string;
+  surname?: string;
+  avatar_url?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  role?: string;
+  access_token: string;
+  properties?: {
+    privacy?: Privacy[];
+  };
+}
+```
+
+- [ ] **Step 2: Verifica la compilazione TypeScript**
+
+Run: `cd core && npx tsc --noEmit -p src/app/shared/wm-core/projects/wm-core/tsconfig.lib.json`
+Expected: nessun nuovo errore (i due campi sono opzionali, nessun consumer esistente si rompe).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add projects/wm-core/src/store/auth/auth.model.ts
+git commit -m "feat(oc:8163): add surname and avatar_url to IUser"
+```
+
+---
+
+### Task 2: Pipe pura `WmUserInitialsPipe` — fallback iniziali
+
+**Files:**
+- Create: `projects/wm-core/src/pipes/wm-user-initials.pipe.ts`
+- Test: `projects/wm-core/src/pipes/wm-user-initials.pipe.spec.ts`
+- Modify: `projects/wm-core/src/pipes/pipe.module.ts`
+
+**Interfaces:**
+- Produces: pipe `userInitials` — `transform(name: string | null | undefined): string`. Consumata da Task 6 (`profile-user.component.html`).
+
+- [ ] **Step 1: Scrivi il test fallente**
+
+```typescript
+import {WmUserInitialsPipe} from './wm-user-initials.pipe';
+
+describe('WmUserInitialsPipe', () => {
+  let pipe: WmUserInitialsPipe;
+
+  beforeEach(() => {
+    pipe = new WmUserInitialsPipe();
+  });
+
+  it('returns the uppercase first letter of the name', () => {
+    expect(pipe.transform('mario')).toBe('M');
+  });
+
+  it('returns only the first letter even if the name contains a space (full name in a single field)', () => {
+    expect(pipe.transform('Gianlorenzo Spaggiari')).toBe('G');
+  });
+
+  it('trims leading whitespace before taking the first letter', () => {
+    expect(pipe.transform('  Paolo')).toBe('P');
+  });
+
+  it('returns an empty string for null, undefined or empty name', () => {
+    expect(pipe.transform(null)).toBe('');
+    expect(pipe.transform(undefined)).toBe('');
+    expect(pipe.transform('')).toBe('');
+    expect(pipe.transform('   ')).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test per verificare che fallisca**
+
+Run: `cd core && npx ng test wm-core --include='**/wm-user-initials.pipe.spec.ts' --watch=false`
+Expected: FAIL — `WmUserInitialsPipe` non esiste.
+
+- [ ] **Step 3: Scrivi la pipe**
+
+```typescript
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  standalone: false,
+  name: 'userInitials',
+  pure: true,
+})
+export class WmUserInitialsPipe implements PipeTransform {
+  /**
+   * Restituisce la sola iniziale (maiuscola) del nome fornito, o stringa vuota
+   * se il nome è assente/vuoto — mai un placeholder generico (es. "?").
+   */
+  transform(name: string | null | undefined): string {
+    const trimmed = (name ?? '').trim();
+    if (trimmed.length === 0) {
+      return '';
+    }
+    return trimmed.charAt(0).toUpperCase();
+  }
+}
+```
+
+- [ ] **Step 4: Registra la pipe in `pipe.module.ts`**
+
+Aggiungi l'import e la voce nell'array `pipes`:
+
+```typescript
+import {WmUserInitialsPipe} from './wm-user-initials.pipe';
+```
+
+```typescript
+const pipes = [
+  // ...esistenti
+  WmHasLogoPipe,
+  WmUserInitialsPipe,
+];
+```
+
+- [ ] **Step 5: Esegui il test per verificare che passi**
+
+Run: `cd core && npx ng test wm-core --include='**/wm-user-initials.pipe.spec.ts' --watch=false`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add projects/wm-core/src/pipes/wm-user-initials.pipe.ts projects/wm-core/src/pipes/wm-user-initials.pipe.spec.ts projects/wm-core/src/pipes/pipe.module.ts
+git commit -m "feat(oc:8163): add WmUserInitialsPipe for avatar fallback"
+```
+
+---
+
+### Task 3: Store auth — action/effect `updateUserProfile`
+
+**Files:**
+- Modify: `projects/wm-core/src/store/auth/auth.actions.ts`
+- Modify: `projects/wm-core/src/store/auth/auth.service.ts`
+- Modify: `projects/wm-core/src/store/auth/auth.effects.ts`
+
+**Interfaces:**
+- Consumes: `IUser` (Task 1).
+- Produces: `updateUserProfile({name?: string; surname?: string; avatarPhoto?: Photo})` action; `AuthService.updateProfile(data): Observable<IUser>`. Consumato da Task 5 (`ProfileEditComponent`).
+
+- [ ] **Step 1: Aggiungi le nuove action in `auth.actions.ts`**
+
+```typescript
+import {Photo} from '@capacitor/camera';
+```
+
+```typescript
+export const updateUserProfile = createAction(
+  '[Auth] update user profile',
+  props<{name?: string; surname?: string; avatarPhoto?: Photo}>(),
+);
+export const updateUserProfileFailure = createAction(
+  '[Auth] update user profile failure',
+  props<{error: HttpErrorResponse}>(),
+);
+```
+
+- [ ] **Step 2: Aggiungi `AuthService.updateProfile()` in `auth.service.ts`**
+
+Aggiungi l'import in testa al file:
+
+```typescript
+import {Photo} from '@capacitor/camera';
+import {CameraService} from '@wm-core/services/camera.service';
+```
+
+Aggiungi `CameraService` al costruttore:
+
+```typescript
+constructor(
+  private _http: HttpClient,
+  private _environmentSvc: EnvironmentService,
+  private _store: Store,
+  private _langSvc: LangService,
+  private _alertCtrl: AlertController,
+  private _modalCtrl: ModalController,
+  private _cameraSvc: CameraService,
+) {}
+```
+
+Aggiungi il metodo (dopo `updatePrivacyAgree`):
+
+```typescript
+/**
+ * Update name, surname and/or avatar photo. Builds multipart FormData only
+ * when an avatarPhoto is provided; otherwise sends plain JSON (same endpoint
+ * already used by updatePrivacyAgree, POST /api/auth/user).
+ */
+updateProfile(data: {name?: string; surname?: string; avatarPhoto?: Photo}): Observable<IUser> {
+  if (!data.avatarPhoto) {
+    const body: {name?: string; surname?: string} = {};
+    if (data.name != null) body.name = data.name;
+    if (data.surname != null) body.surname = data.surname;
+    return this._http.post(`${this._environmentSvc.origin}/api/auth/user`, body) as Observable<IUser>;
+  }
+
+  return from(this._cameraSvc.getPhotoFile({
+    id: data.avatarPhoto.path ?? data.avatarPhoto.webPath,
+    photoURL: data.avatarPhoto.webPath,
+    datasrc: data.avatarPhoto.webPath,
+    position: null,
+  } as any)).pipe(
+    switchMap(blob => {
+      const formData = new FormData();
+      if (data.name != null) formData.append('name', data.name);
+      if (data.surname != null) formData.append('surname', data.surname);
+      formData.append('avatar', blob, 'avatar.jpg');
+      return this._http.post(`${this._environmentSvc.origin}/api/auth/user`, formData) as Observable<IUser>;
+    }),
+  );
+}
+```
+
+Nota: `CameraService.getPhotoFile()` esiste già (usato dai flussi UGC) e sa già estrarre un `Blob` da un `Photo`/`IPhotoItem` — qui lo riusiamo passandogli solo i campi che effettivamente legge (`photoURL`), senza duplicare la logica di conversione file→blob.
+
+- [ ] **Step 3: Aggiungi l'effect in `auth.effects.ts`**
+
+```typescript
+updateUserProfile$ = createEffect(() => {
+  return this._actions$.pipe(
+    ofType(AuthActions.updateUserProfile),
+    switchMap(action =>
+      this._authSvc.updateProfile(action).pipe(
+        map(user => {
+          saveAuth(user);
+          return AuthActions.loadAuthsSuccess({user});
+        }),
+        catchError(error => {
+          return of(AuthActions.updateUserProfileFailure({error}));
+        }),
+      ),
+    ),
+  );
+});
+```
+
+Nota (da documentare in `notes.md`): questo effect riusa `loadAuthsSuccess` come azione di successo, stesso pattern di `updatePrivacyAgree$` — questo fa scattare anche `syncUgcAfterAuthSuccess$` (dispatcha `syncUgc()` se l'utente ha già accettato la privacy). È un effetto collaterale accettato, non un bug: `updatePrivacyAgree$` esistente ha già lo stesso comportamento, quindi non introduce un pattern nuovo, solo un `syncUgc()` ridondante ad ogni modifica profilo per utenti già loggati con privacy accettata.
+
+- [ ] **Step 4: Verifica la compilazione**
+
+Run: `cd core && npx tsc --noEmit -p src/app/shared/wm-core/projects/wm-core/tsconfig.lib.json`
+Expected: nessun errore.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add projects/wm-core/src/store/auth/auth.actions.ts projects/wm-core/src/store/auth/auth.service.ts projects/wm-core/src/store/auth/auth.effects.ts
+git commit -m "feat(oc:8163): add updateUserProfile action/effect with multipart avatar upload"
+```
+
+---
+
+### Task 4: `CameraService.addProfilePhoto()` — nuovo metodo dedicato
+
+**Files:**
+- Modify: `projects/wm-core/src/services/camera.service.ts`
+
+**Interfaces:**
+- Produces: `CameraService.addProfilePhoto(): Promise<Photo>` — consumato da Task 5 (`ProfileEditComponent`). `addPhotos()` esistente resta invariato (firma `Promise<Photo[]>`, usato dai flussi UGC).
+
+- [ ] **Step 1: Aggiungi il metodo**
+
+In `camera.service.ts`, dopo `addPhotos()`:
+
+```typescript
+/**
+ * Same action sheet as addPhotos() (Scatta una foto / Dalla libreria / Annulla)
+ * but returns a single Photo — used for profile avatar upload. Does not touch
+ * addPhotos(), which is shared by the UGC flows and returns Photo[].
+ */
+async addProfilePhoto(): Promise<Photo> {
+  return new Promise<Photo>((resolve, reject) => {
+    this._actionSheetCtrl
+      .create({
+        header: this._lanSvc.instant("Origine dell'immagine"),
+        buttons: [
+          {
+            text: this._lanSvc.instant('Scatta una foto'),
+            handler: () => {
+              this.shotPhoto().then(photo => resolve(photo));
+            },
+          },
+          {
+            text: this._lanSvc.instant('Dalla libreria'),
+            handler: () => {
+              this.getPhotos(null).then(photos => {
+                if (photos.length === 0) {
+                  reject();
+                  return;
+                }
+                resolve(photos[0]);
+              });
+            },
+          },
+          {
+            text: this._lanSvc.instant('Annulla'),
+            role: 'cancel',
+            handler: () => {
+              reject();
+            },
+          },
+        ],
+      })
+      .then(actionSheet => {
+        actionSheet.present();
+      });
+  });
+}
+```
+
+- [ ] **Step 2: Aggiungi il limite dimensione lato client**
+
+Nel metodo `getPhotos()` esistente (già usato sia da `addPhotos()` che dal nuovo `addProfilePhoto()`), imposta esplicitamente `width`/`quality` nell'oggetto `GalleryImageOptions` per contenere la dimensione delle foto selezionate dalla libreria:
+
+```typescript
+const options: GalleryImageOptions = {
+  quality: 80,
+  width: 1600,
+};
+```
+
+Nota: questo abbassa leggermente la qualità/dimensione anche per il flusso UGC esistente (che condivide `getPhotos()`) — verificato in Fase: challenge come rischio noto ("nessun limite dimensione oggi"); 1600px/qualità 80 è già ampiamente sufficiente per un avatar e non degrada visibilmente le foto UGC (usate in gallerie a schermo intero, non stampe). Se in code review si preferisce isolare questo limite al solo avatar, estrarre un `getPhotos(options?: Partial<GalleryImageOptions>)` parametrizzato invece di modificare il default condiviso.
+
+- [ ] **Step 3: Verifica la compilazione**
+
+Run: `cd core && npx tsc --noEmit -p src/app/shared/wm-core/projects/wm-core/tsconfig.lib.json`
+Expected: nessun errore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add projects/wm-core/src/services/camera.service.ts
+git commit -m "feat(oc:8163): add addProfilePhoto() and client-side size limit to CameraService"
+```
+
+---
+
+### Task 5: `ProfileEditComponent` — nuovo modale
+
+**Files:**
+- Create: `projects/wm-core/src/profile/profile-edit/profile-edit.component.ts`
+- Create: `projects/wm-core/src/profile/profile-edit/profile-edit.component.html`
+- Create: `projects/wm-core/src/profile/profile-edit/profile-edit.component.scss`
+- Test: `projects/wm-core/src/profile/profile-edit/profile-edit.component.spec.ts`
+- Modify: `projects/wm-core/src/profile/profile.module.ts`
+
+**Interfaces:**
+- Consumes: `IUser` (Task 1), `updateUserProfile` action (Task 3), `CameraService.addProfilePhoto()` (Task 4), `WmUserInitialsPipe` (Task 2).
+- Produces: componente `ProfileEditComponent` (`wm-profile-edit`), apribile via `ModalController` — consumato da Task 6 (`profile-user.component`).
+
+- [ ] **Step 1: Scrivi lo spec (istanza TS pura, senza `TestBed`)**
+
+Pattern già in uso nel repo per evitare il crash `NG0201` su `APP_TRANSLATION` mancante in DI (vedi `ugc-track-properties.component.spec.ts`, oc:8183):
+
+```typescript
+import {ProfileEditComponent} from './profile-edit.component';
+
+describe('ProfileEditComponent', () => {
+  let component: ProfileEditComponent;
+  let modalCtrlSpy: any;
+  let storeSpy: any;
+  let cameraSvcSpy: any;
+  let formBuilder: any;
+
+  beforeEach(() => {
+    modalCtrlSpy = {dismiss: jasmine.createSpy('dismiss')};
+    storeSpy = {
+      dispatch: jasmine.createSpy('dispatch'),
+      pipe: () => ({subscribe: () => {}}),
+      select: () => ({pipe: () => ({subscribe: () => {}})}),
+    };
+    cameraSvcSpy = {addProfilePhoto: jasmine.createSpy('addProfilePhoto')};
+    formBuilder = new (require('@angular/forms').UntypedFormBuilder)();
+
+    component = new ProfileEditComponent(formBuilder, modalCtrlSpy, storeSpy, cameraSvcSpy);
+  });
+
+  it('builds a form with name and surname controls', () => {
+    expect(component.profileForm.contains('name')).toBeTrue();
+    expect(component.profileForm.contains('surname')).toBeTrue();
+  });
+
+  it('marks the form invalid when name is empty', () => {
+    component.profileForm.patchValue({name: ''});
+    expect(component.profileForm.invalid).toBeTrue();
+  });
+
+  it('marks the form valid when name is present and surname is empty (surname optional)', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: ''});
+    expect(component.profileForm.valid).toBeTrue();
+  });
+
+  it('dismisses the modal via ModalController', () => {
+    component.dismiss();
+    expect(modalCtrlSpy.dismiss).toHaveBeenCalled();
+  });
+
+  it('dispatches updateUserProfile with form values on save', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: 'Rossi'});
+    component.save();
+    expect(storeSpy.dispatch).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Esegui lo spec per verificare che fallisca**
+
+Run: `cd core && npx ng test wm-core --include='**/profile-edit.component.spec.ts' --watch=false`
+Expected: FAIL — `ProfileEditComponent` non esiste.
+
+- [ ] **Step 3: Scrivi il componente**
+
+```typescript
+import {ChangeDetectionStrategy, Component, Input, OnInit, ViewEncapsulation} from '@angular/core';
+import {UntypedFormBuilder, UntypedFormGroup, Validators} from '@angular/forms';
+import {ModalController} from '@ionic/angular';
+import {Store} from '@ngrx/store';
+import {Photo} from '@capacitor/camera';
+import {BehaviorSubject} from 'rxjs';
+import {CameraService} from '@wm-core/services/camera.service';
+import {updateUserProfile} from '@wm-core/store/auth/auth.actions';
+
+export enum EProfileEditState {
+  IDLE = 'IDLE',
+  UPLOADING_PHOTO = 'UPLOADING_PHOTO',
+  SAVING = 'SAVING',
+  SUCCESS = 'SUCCESS',
+  ERROR = 'ERROR',
+}
+
+@Component({
+  standalone: false,
+  selector: 'wm-profile-edit',
+  templateUrl: './profile-edit.component.html',
+  styleUrls: ['./profile-edit.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ProfileEditComponent implements OnInit {
+  @Input() currentName: string;
+  @Input() currentSurname: string;
+  @Input() currentAvatarUrl: string;
+
+  profileForm: UntypedFormGroup;
+  selectedPhoto: Photo | null = null;
+  state$: BehaviorSubject<EProfileEditState> = new BehaviorSubject<EProfileEditState>(
+    EProfileEditState.IDLE,
+  );
+  submitted$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  readonly EProfileEditState = EProfileEditState;
+
+  constructor(
+    private _formBuilder: UntypedFormBuilder,
+    private _modalCtrl: ModalController,
+    private _store: Store,
+    private _cameraSvc: CameraService,
+  ) {
+    this.profileForm = this._formBuilder.group({
+      name: ['', [Validators.required, Validators.maxLength(255)]],
+      surname: ['', [Validators.maxLength(255)]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.profileForm.patchValue({
+      name: this.currentName ?? '',
+      surname: this.currentSurname ?? '',
+    });
+  }
+
+  dismiss(): void {
+    this._modalCtrl.dismiss();
+  }
+
+  async pickPhoto(): Promise<void> {
+    this.state$.next(EProfileEditState.UPLOADING_PHOTO);
+    try {
+      this.selectedPhoto = await this._cameraSvc.addProfilePhoto();
+      this.state$.next(EProfileEditState.IDLE);
+    } catch (e) {
+      // Annullamento esplicito dell'utente o permesso negato: torna a IDLE senza
+      // mostrare un errore (non è un fallimento, è una scelta dell'utente).
+      this.state$.next(EProfileEditState.IDLE);
+    }
+  }
+
+  save(): void {
+    this.submitted$.next(true);
+    if (this.profileForm.invalid) {
+      return;
+    }
+
+    this.state$.next(EProfileEditState.SAVING);
+    this._store.dispatch(
+      updateUserProfile({
+        name: this.profileForm.value.name,
+        surname: this.profileForm.value.surname || undefined,
+        avatarPhoto: this.selectedPhoto ?? undefined,
+      }),
+    );
+    // Nota: lo stato SUCCESS/ERROR effettivo va agganciato in Task 6 quando
+    // profile-user.component osserva l'esito dell'azione (loadAuthsSuccess /
+    // updateUserProfileFailure) e chiude il modale o mostra l'errore.
+  }
+}
+```
+
+- [ ] **Step 4: Scrivi il template**
+
+```html
+<wm-modal-header class="wm-profile-edit-header" [title]="'Modifica profilo' | wmtrans" (dismiss)="dismiss()">
+</wm-modal-header>
+<ion-content>
+  <form class="wm-profile-edit-form" (ngSubmit)="save()" [formGroup]="profileForm">
+    <div class="wm-profile-edit-avatar-container">
+      <ion-avatar
+        class="wm-profile-edit-avatar"
+        (click)="pickPhoto()"
+      >
+        <img *ngIf="selectedPhoto?.webPath; else currentOrInitials" [src]="selectedPhoto.webPath" />
+        <ng-template #currentOrInitials>
+          <img *ngIf="currentAvatarUrl" [src]="currentAvatarUrl" />
+          <div class="wm-profile-edit-avatar-initials" *ngIf="!currentAvatarUrl">
+            {{ currentName | userInitials }}
+          </div>
+        </ng-template>
+        <ion-spinner
+          *ngIf="(state$|async) === EProfileEditState.UPLOADING_PHOTO"
+          class="wm-profile-edit-avatar-spinner"
+        ></ion-spinner>
+      </ion-avatar>
+      <button type="button" class="wm-profile-edit-avatar-change-button" (click)="pickPhoto()">
+        {{ "Cambia foto" | wmtrans }}
+      </button>
+    </div>
+
+    <div class="wm-profile-edit-field-container">
+      <ion-label class="wm-profile-edit-label">{{ "Nome" | wmtrans }}</ion-label>
+      <ion-item
+        class="wm-profile-edit-field"
+        [ngClass]="{
+          'wm-profile-edit-field-has-error':
+          (submitted$|async) && profileForm.controls.name.invalid
+        }"
+      >
+        <ion-input type="text" formControlName="name" class="wm-profile-edit-input"></ion-input>
+      </ion-item>
+      <span
+        class="wm-profile-edit-field-error"
+        *ngIf="(submitted$|async) && profileForm.controls.name.errors?.required"
+      >
+        {{ "Il nome è obbligatorio" | wmtrans }}
+      </span>
+    </div>
+
+    <div class="wm-profile-edit-field-container">
+      <ion-label class="wm-profile-edit-label">{{ "Cognome" | wmtrans }}</ion-label>
+      <ion-item class="wm-profile-edit-field">
+        <ion-input type="text" formControlName="surname" class="wm-profile-edit-input"></ion-input>
+      </ion-item>
+    </div>
+
+    <button
+      type="submit"
+      class="wm-profile-edit-save-button"
+      [disabled]="(state$|async) === EProfileEditState.SAVING"
+    >
+      <ion-spinner *ngIf="(state$|async) === EProfileEditState.SAVING"></ion-spinner>
+      <ng-container *ngIf="(state$|async) !== EProfileEditState.SAVING">
+        {{ "Salva" | wmtrans }}
+      </ng-container>
+    </button>
+  </form>
+</ion-content>
+```
+
+- [ ] **Step 5: Scrivi lo scss minimale (touch target e spaziatura da requisito UX)**
+
+```scss
+.wm-profile-edit-avatar-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+}
+
+.wm-profile-edit-avatar {
+  width: 96px;
+  height: 96px;
+  position: relative;
+}
+
+.wm-profile-edit-avatar-initials {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--wm-color-primary, #4285f4);
+  color: #fff;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.wm-profile-edit-avatar-spinner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.wm-profile-edit-avatar-change-button,
+.wm-profile-edit-save-button {
+  min-height: 44px;
+  min-width: 44px;
+}
+
+.wm-profile-edit-field-container {
+  margin-bottom: 8px;
+}
+
+.wm-profile-edit-field-has-error {
+  --border-color: var(--wm-color-danger, #eb445a);
+}
+
+.wm-profile-edit-field-error {
+  color: var(--wm-color-danger, #eb445a);
+  font-size: 0.8rem;
+}
+```
+
+- [ ] **Step 6: Registra il componente in `profile.module.ts`**
+
+```typescript
+import {ProfileEditComponent} from './profile-edit/profile-edit.component';
+import {ReactiveFormsModule} from '@angular/forms';
+import {WmPipeModule} from '../pipes/pipe.module';
+```
+
+```typescript
+const components = [
+  ProfileAuthComponent,
+  ProfileUserComponent,
+  ProfileDataComponent,
+  WmProfilePopupComponent,
+  ProfileEditComponent,
+];
+```
+
+```typescript
+@NgModule({
+  declarations: components,
+  imports: [CommonModule, IonicModule, WmPipeModule, WmSharedModule, ReactiveFormsModule],
+  exports: components,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class WmProfileModule {}
+```
+
+(`WmPipeModule` era già importato per `hasLogo`/altre pipe esistenti — verifica che sia già presente prima di aggiungerlo due volte; se assente, aggiungilo.)
+
+- [ ] **Step 7: Esegui lo spec per verificare che passi**
+
+Run: `cd core && npx ng test wm-core --include='**/profile-edit.component.spec.ts' --watch=false`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add projects/wm-core/src/profile/profile-edit/ projects/wm-core/src/profile/profile.module.ts
+git commit -m "feat(oc:8163): add ProfileEditComponent modal for profile editing"
+```
+
+---
+
+### Task 6: `profile-user.component` — avatar reale/iniziali + apertura modale
+
+**Files:**
+- Modify: `projects/wm-core/src/profile/profile-user/profile-user.component.ts`
+- Modify: `projects/wm-core/src/profile/profile-user/profile-user.component.html`
+- Modify: `projects/wm-core/src/profile/profile-user/profile-user.component.scss`
+
+**Interfaces:**
+- Consumes: `IUser.avatar_url`/`surname` (Task 1), `WmUserInitialsPipe` (Task 2), `ProfileEditComponent` (Task 5).
+
+- [ ] **Step 1: Modifica il componente**
+
+```typescript
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+import {select, Store} from '@ngrx/store';
+import {from, Observable} from 'rxjs';
+import {switchMap, take} from 'rxjs/operators';
+import {IUser} from '@wm-core/store/auth/auth.model';
+import {isLogged, user} from '@wm-core/store/auth/auth.selectors';
+import {confAUTHEnable} from '@wm-core/store/conf/conf.selector';
+import {ModalController} from '@ionic/angular';
+import {ProfileEditComponent} from '@wm-core/profile/profile-edit/profile-edit.component';
+
+@Component({
+  standalone: false,
+  selector: 'wm-profile-user',
+  templateUrl: './profile-user.component.html',
+  styleUrls: ['./profile-user.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ProfileUserComponent {
+  authEnable$: Observable<boolean> = this._store.select(confAUTHEnable);
+  isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));
+  user$: Observable<IUser> = this._store.pipe(select(user));
+
+  constructor(
+    private _store: Store,
+    private _modalCtrl: ModalController,
+  ) {}
+
+  openEditProfile(currentUser: IUser): void {
+    this.user$
+      .pipe(
+        take(1),
+        switchMap(() =>
+          from(
+            this._modalCtrl.create({
+              component: ProfileEditComponent,
+              componentProps: {
+                currentName: currentUser?.name,
+                currentSurname: currentUser?.surname,
+                currentAvatarUrl: currentUser?.avatar_url,
+              },
+              canDismiss: true,
+              mode: 'ios',
+              id: 'wm-profile-edit-modal',
+            }),
+          ),
+        ),
+      )
+      .subscribe(modal => modal.present());
+  }
+}
+```
+
+Nota: `canDismiss: true` (non impostato a `false` o a una funzione bloccante) — Ionic gestisce già il dismiss su hardware back-button Android per i modali con questa configurazione, come verificato negli altri modali esistenti (`LoginComponent`, `ProfileAuthComponent`). Nessun codice aggiuntivo necessario per questo comportamento; verificare comunque su device/emulatore Android in fase di test manuale (Fase: execution).
+
+- [ ] **Step 2: Modifica il template**
+
+```html
+<ng-container *ngIf="(isLogged$|async)">
+  <div class="wm-profile-user-container" *ngIf="user$|async as currentUser" (click)="openEditProfile(currentUser)">
+    <ion-avatar class="wm-profile-user-avatar">
+      <img *ngIf="currentUser?.avatar_url" [src]="currentUser.avatar_url" />
+      <div class="wm-profile-user-avatar-initials" *ngIf="!currentUser?.avatar_url">
+        {{ currentUser?.name | userInitials }}
+      </div>
+    </ion-avatar>
+    <div class="wm-profile-user-header-container">
+      <h4 class="wm-profile-user-name">{{currentUser?.name}}</h4>
+      <div class="wm-profile-user-email">{{currentUser?.email}}</div>
+    </div>
+  </div>
+</ng-container>
+```
+
+Nota: `currentUser.name` viene mostrato così com'è, mai concatenato con `currentUser.surname` — vedi vincolo globale del piano.
+
+- [ ] **Step 3: Aggiorna lo scss (sostituisci la vecchia regola `-avatar-icon`)**
+
+Rimuovi (se presente) la regola scss legata a `.wm-profile-user-avatar-icon` (icona generica, non più usata) e aggiungi:
+
+```scss
+.wm-profile-user-container {
+  cursor: pointer;
+}
+
+.wm-profile-user-avatar-initials {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--wm-color-primary, #4285f4);
+  color: #fff;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+```
+
+- [ ] **Step 4: Verifica manuale (non automatizzabile in questo task)**
+
+Avvia l'app (`npm start` da `core/`), accedi con un utente di test, apri la pagina profilo:
+- Verifica che l'header mostri le iniziali colorate se l'utente non ha avatar.
+- Clicca sull'header e verifica che si apra il modale `ProfileEditComponent`.
+- Compila nome/cognome, salva, verifica che l'header si aggiorni con i nuovi valori dopo la chiusura del modale (o mentre resta aperto, secondo l'implementazione dello stato SUCCESS — se non ancora agganciato, annotalo in `notes.md` come follow-up).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add projects/wm-core/src/profile/profile-user/
+git commit -m "feat(oc:8163): show real avatar or initials fallback in profile-user, open edit modal"
+```
+
+---
+
+### Task 7: Traduzioni
+
+**Files:**
+- Modify: `projects/wm-core/src/localization/i18n/it.ts`
+- Modify: `projects/wm-core/src/localization/i18n/en.ts`
+- Modify: `projects/wm-core/src/localization/i18n/de.ts`
+- Modify: `projects/wm-core/src/localization/i18n/es.ts`
+- Modify: `projects/wm-core/src/localization/i18n/fr.ts`
+- Modify: `projects/wm-core/src/localization/i18n/pr.ts`
+- Modify: `projects/wm-core/src/localization/i18n/sq.ts`
+
+**Interfaces:**
+- Consumes: chiavi usate nel template di Task 5/6 (`'Modifica profilo'`, `'Cambia foto'`, `'Nome'`, `'Cognome'`, `'Il nome è obbligatorio'`, `'Salva'`, `"Origine dell'immagine"`, `'Scatta una foto'`, `'Dalla libreria'`, `'Annulla'` — questi ultimi 4 già esistenti in `it.ts` per `CameraService.addPhotos()`, verificare prima di duplicarli).
+
+- [ ] **Step 1: Verifica quali chiavi esistono già**
+
+```bash
+grep -E "'Modifica profilo'|'Cambia foto'|'Nome'|'Cognome'|'Il nome è obbligatorio'|'Salva'" projects/wm-core/src/localization/i18n/it.ts
+```
+
+Aggiungi solo le chiavi mancanti nei passi successivi (`'Scatta una foto'`, `'Dalla libreria'`, `'Annulla'`, `"Origine dell'immagine"` risultano già presenti da `CameraService`, non duplicarle).
+
+- [ ] **Step 2: Aggiungi le chiavi mancanti in `it.ts`**
+
+```typescript
+'Modifica profilo': 'Modifica profilo',
+'Cambia foto': 'Cambia foto',
+'Nome': 'Nome',
+'Cognome': 'Cognome',
+"Il nome è obbligatorio": "Il nome è obbligatorio",
+'Salva': 'Salva',
+```
+
+(Se `'Nome'`/`'Salva'` risultano già presenti per altre feature, riusa la chiave esistente — non crearne una duplicata con lo stesso testo.)
+
+- [ ] **Step 3: Aggiungi le traduzioni corrispondenti in `en.ts`, `de.ts`, `es.ts`, `fr.ts`, `pr.ts`, `sq.ts`**
+
+Esempio per `en.ts`:
+
+```typescript
+'Modifica profilo': 'Edit profile',
+'Cambia foto': 'Change photo',
+'Nome': 'Name',
+'Cognome': 'Surname',
+"Il nome è obbligatorio": 'Name is required',
+'Salva': 'Save',
+```
+
+Ripeti con traduzione appropriata per `de` (Tedesco), `es` (Spagnolo), `fr` (Francese), `pr` (Portoghese), `sq` (Albanese) — usa un traduttore o madrelingua per la revisione finale, i valori sopra sono un punto di partenza.
+
+- [ ] **Step 4: Verifica che non manchino chiavi in nessun file**
+
+```bash
+for f in it en de es fr pr sq; do
+  echo "=== $f ==="
+  grep -c "'Modifica profilo'" projects/wm-core/src/localization/i18n/$f.ts
+done
+```
+
+Expected: `1` per ognuno dei 7 file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add projects/wm-core/src/localization/i18n/*.ts
+git commit -m "feat(oc:8163): add profile edit translations for all 7 languages"
+```
+
+---
+
+## Self-Review Checklist (compilata dall'autore del piano)
+
+- **Spec coverage:** `IUser` esteso (Task 1), fallback iniziali (Task 2), store/multipart (Task 3), upload foto dedicato + limite dimensione (Task 4), modale edit con tutti i requisiti UX (Task 5), integrazione in `profile-user` (Task 6), traduzioni (Task 7) — tutti i requisiti di `overview.md` sono coperti. Il rischio "test Cypress `login-offline.cy.ts`" resta una verifica manuale in Fase: execution, non un task di questo piano (repo `webmapp-app`, fuori da questo piano wm-core).
+- **Placeholder scan:** nessun TODO; Task 6 Step 4 è una verifica manuale dichiarata esplicitamente come tale, non un placeholder di codice.
+- **Type consistency:** `EProfileEditState` (Task 5) usato coerentemente in `.ts` e `.html`; `updateUserProfile({name?, surname?, avatarPhoto?})` (Task 3) ha la stessa forma in `auth.actions.ts`, `auth.service.ts` e nella chiamata `save()` di `ProfileEditComponent` (Task 5); `WmUserInitialsPipe`/`userInitials` (Task 2) nome pipe coerente tra dichiarazione e uso nei template (Task 5, Task 6).
+
+## Execution Handoff
+
+Piano salvato in `docs/features/8163-profilo-utente-nome-cognome-avatar/plan.md`. Due opzioni di esecuzione:
+
+**1. Subagent-Driven (consigliato)** — un subagente fresco per task, review tra un task e l'altro, iterazione rapida.
+
+**2. Inline Execution** — esecuzione in questa sessione con `executing-plans`, batch execution con checkpoint.
+
+Quale preferisci?

--- a/projects/wm-core/src/localization/i18n/de.ts
+++ b/projects/wm-core/src/localization/i18n/de.ts
@@ -284,4 +284,11 @@ export const wmDE = {
   'Preferito': 'Favorit',
   'Non preferito': 'Kein Favorit',
   'Impossibile aggiornare i preferiti, riprova': 'Favoriten konnten nicht aktualisiert werden, versuche es erneut',
+  'Modifica profilo': 'Profil bearbeiten',
+  'Cambia foto': 'Foto ändern',
+  'Il nome è obbligatorio': 'Der Name ist erforderlich',
+  'Il nome non può superare i 255 caratteri': 'Der Name darf 255 Zeichen nicht überschreiten',
+  'Cognome': 'Nachname',
+  'Il cognome non può superare i 255 caratteri': 'Der Nachname darf 255 Zeichen nicht überschreiten',
+  'Salva': 'Speichern',
 };

--- a/projects/wm-core/src/localization/i18n/en.ts
+++ b/projects/wm-core/src/localization/i18n/en.ts
@@ -289,4 +289,11 @@ export const wmEN = {
   'Preferito': 'Favorite',
   'Non preferito': 'Not favorite',
   'Impossibile aggiornare i preferiti, riprova': 'Could not update favorites, try again',
+  'Modifica profilo': 'Edit profile',
+  'Cambia foto': 'Change photo',
+  'Il nome è obbligatorio': 'Name is required',
+  'Il nome non può superare i 255 caratteri': 'Name cannot exceed 255 characters',
+  'Cognome': 'Surname',
+  'Il cognome non può superare i 255 caratteri': 'Surname cannot exceed 255 characters',
+  'Salva': 'Save',
 };

--- a/projects/wm-core/src/localization/i18n/es.ts
+++ b/projects/wm-core/src/localization/i18n/es.ts
@@ -280,4 +280,11 @@ export const wmES = {
   'Preferito': 'Favorito',
   'Non preferito': 'No favorito',
   'Impossibile aggiornare i preferiti, riprova': 'No se han podido actualizar los favoritos, inténtalo de nuevo',
+  'Modifica profilo': 'Editar perfil',
+  'Cambia foto': 'Cambiar foto',
+  'Il nome è obbligatorio': 'El nombre es obligatorio',
+  'Il nome non può superare i 255 caratteri': 'El nombre no puede superar los 255 caracteres',
+  'Cognome': 'Apellido',
+  'Il cognome non può superare i 255 caratteri': 'El apellido no puede superar los 255 caracteres',
+  'Salva': 'Guardar',
 };

--- a/projects/wm-core/src/localization/i18n/fr.ts
+++ b/projects/wm-core/src/localization/i18n/fr.ts
@@ -283,4 +283,11 @@ export const wmFR = {
   'Preferito': 'Favori',
   'Non preferito': 'Non favori',
   'Impossibile aggiornare i preferiti, riprova': 'Impossible de mettre à jour les favoris, réessayez',
+  'Modifica profilo': 'Modifier le profil',
+  'Cambia foto': 'Changer de photo',
+  'Il nome è obbligatorio': 'Le prénom est obligatoire',
+  'Il nome non può superare i 255 caratteri': 'Le prénom ne peut pas dépasser 255 caractères',
+  'Cognome': 'Nom de famille',
+  'Il cognome non può superare i 255 caratteri': 'Le nom de famille ne peut pas dépasser 255 caractères',
+  'Salva': 'Enregistrer',
 };

--- a/projects/wm-core/src/localization/i18n/it.ts
+++ b/projects/wm-core/src/localization/i18n/it.ts
@@ -288,4 +288,11 @@ export const wmIT = {
   'Preferito': 'Preferito',
   'Non preferito': 'Non preferito',
   'Impossibile aggiornare i preferiti, riprova': 'Impossibile aggiornare i preferiti, riprova',
+  'Modifica profilo': 'Modifica profilo',
+  'Cambia foto': 'Cambia foto',
+  'Il nome è obbligatorio': 'Il nome è obbligatorio',
+  'Il nome non può superare i 255 caratteri': 'Il nome non può superare i 255 caratteri',
+  'Cognome': 'Cognome',
+  'Il cognome non può superare i 255 caratteri': 'Il cognome non può superare i 255 caratteri',
+  'Salva': 'Salva',
 };

--- a/projects/wm-core/src/localization/i18n/pr.ts
+++ b/projects/wm-core/src/localization/i18n/pr.ts
@@ -280,4 +280,11 @@ export const wmPR = {
   'Preferito': 'Favorito',
   'Non preferito': 'Não favorito',
   'Impossibile aggiornare i preferiti, riprova': 'Não foi possível atualizar os favoritos, tente novamente',
+  'Modifica profilo': 'Editar perfil',
+  'Cambia foto': 'Alterar foto',
+  'Il nome è obbligatorio': 'O nome é obrigatório',
+  'Il nome non può superare i 255 caratteri': 'O nome não pode exceder 255 caracteres',
+  'Cognome': 'Sobrenome',
+  'Il cognome non può superare i 255 caratteri': 'O sobrenome não pode exceder 255 caracteres',
+  'Salva': 'Salvar',
 };

--- a/projects/wm-core/src/localization/i18n/sq.ts
+++ b/projects/wm-core/src/localization/i18n/sq.ts
@@ -288,4 +288,11 @@ export const wmSQ = {
   'Preferito': 'Të preferuar',
   'Non preferito': 'Jo i preferuar',
   'Impossibile aggiornare i preferiti, riprova': 'Nuk u arrit të përditësohen të preferuarat, provo përsëri',
+  'Modifica profilo': 'Modifiko profilin',
+  'Cambia foto': 'Ndrysho foton',
+  'Il nome è obbligatorio': 'Emri është i detyrueshëm',
+  'Il nome non può superare i 255 caratteri': 'Emri nuk mund të kalojë 255 karaktere',
+  'Cognome': 'Mbiemri',
+  'Il cognome non può superare i 255 caratteri': 'Mbiemri nuk mund të kalojë 255 karaktere',
+  'Salva': 'Ruaj',
 };

--- a/projects/wm-core/src/pipes/pipe.module.ts
+++ b/projects/wm-core/src/pipes/pipe.module.ts
@@ -20,6 +20,7 @@ import {WmTimeFormatterPipe} from './wm-time-formatter.pipe';
 import {WmSortPipe} from './wm-sort.pipe';
 import {WmFilterFeaturesPipe} from './wm-filter-features';
 import {WmHasLogoPipe} from './wm-has-logo.pipe';
+import {WmUserInitialsPipe} from './wm-user-initials.pipe';
 
 const pipes = [
   WmTransPipe,
@@ -42,6 +43,7 @@ const pipes = [
   WmSortPipe,
   WmFilterFeaturesPipe,
   WmHasLogoPipe,
+  WmUserInitialsPipe,
 ];
 @NgModule({
   imports: [CommonModule],

--- a/projects/wm-core/src/pipes/wm-user-initials.pipe.spec.ts
+++ b/projects/wm-core/src/pipes/wm-user-initials.pipe.spec.ts
@@ -1,0 +1,28 @@
+import {WmUserInitialsPipe} from './wm-user-initials.pipe';
+
+describe('WmUserInitialsPipe', () => {
+  let pipe: WmUserInitialsPipe;
+
+  beforeEach(() => {
+    pipe = new WmUserInitialsPipe();
+  });
+
+  it('returns the uppercase first letter of the name', () => {
+    expect(pipe.transform('mario')).toBe('M');
+  });
+
+  it('returns only the first letter even if the name contains a space (full name in a single field)', () => {
+    expect(pipe.transform('Gianlorenzo Spaggiari')).toBe('G');
+  });
+
+  it('trims leading whitespace before taking the first letter', () => {
+    expect(pipe.transform('  Paolo')).toBe('P');
+  });
+
+  it('returns an empty string for null, undefined or empty name', () => {
+    expect(pipe.transform(null)).toBe('');
+    expect(pipe.transform(undefined)).toBe('');
+    expect(pipe.transform('')).toBe('');
+    expect(pipe.transform('   ')).toBe('');
+  });
+});

--- a/projects/wm-core/src/pipes/wm-user-initials.pipe.ts
+++ b/projects/wm-core/src/pipes/wm-user-initials.pipe.ts
@@ -1,0 +1,20 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  standalone: false,
+  name: 'userInitials',
+  pure: true,
+})
+export class WmUserInitialsPipe implements PipeTransform {
+  /**
+   * Restituisce la sola iniziale (maiuscola) del nome fornito, o stringa vuota
+   * se il nome è assente/vuoto — mai un placeholder generico (es. "?").
+   */
+  transform(name: string | null | undefined): string {
+    const trimmed = (name ?? '').trim();
+    if (trimmed.length === 0) {
+      return '';
+    }
+    return trimmed.charAt(0).toUpperCase();
+  }
+}

--- a/projects/wm-core/src/profile/profile-edit/profile-edit.component.html
+++ b/projects/wm-core/src/profile/profile-edit/profile-edit.component.html
@@ -1,0 +1,100 @@
+<wm-modal-header
+  class="wm-profile-edit-header"
+  [title]="'Modifica profilo' | wmtrans"
+  (dismiss)="dismiss()"
+></wm-modal-header>
+<ion-content>
+  <form class="wm-profile-edit-form" (ngSubmit)="save()" [formGroup]="profileForm">
+    <div class="wm-profile-edit-avatar-container">
+      <button
+        type="button"
+        class="wm-profile-edit-avatar"
+        (click)="pickPhoto()"
+        [attr.aria-label]="'Cambia foto' | wmtrans"
+      >
+        <ion-avatar class="wm-profile-edit-avatar-circle">
+          <img *ngIf="selectedPhoto?.webPath; else currentOrInitials" [src]="selectedPhoto.webPath" />
+          <ng-template #currentOrInitials>
+            <img *ngIf="currentAvatarUrl" [src]="currentAvatarUrl" />
+            <div class="wm-profile-edit-avatar-initials" *ngIf="!currentAvatarUrl">
+              {{ currentName | userInitials }}
+            </div>
+          </ng-template>
+          <div
+            class="wm-profile-edit-avatar-scrim"
+            *ngIf="(state$ | async) === EProfileEditState.UPLOADING_PHOTO"
+          >
+            <ion-spinner class="wm-profile-edit-avatar-spinner" color="light"></ion-spinner>
+          </div>
+        </ion-avatar>
+        <span
+          class="wm-profile-edit-avatar-badge"
+          *ngIf="(state$ | async) !== EProfileEditState.UPLOADING_PHOTO"
+        >
+          <i class="icon-fill-camera"></i>
+        </span>
+      </button>
+    </div>
+
+    <ion-card class="wm-profile-edit-fields-card">
+      <div class="wm-profile-edit-field-container">
+        <ion-label class="wm-profile-edit-label">{{ 'Nome' | wmtrans }}</ion-label>
+        <ion-item
+          class="wm-profile-edit-field"
+          lines="none"
+          [ngClass]="{
+            'wm-profile-edit-field-has-error':
+              (submitted$ | async) && profileForm.controls.name.invalid
+          }"
+        >
+          <ion-input type="text" formControlName="name" class="wm-profile-edit-input"></ion-input>
+        </ion-item>
+        <span
+          class="wm-profile-edit-field-error"
+          *ngIf="(submitted$ | async) && profileForm.controls.name.errors?.required"
+        >
+          {{ 'Il nome è obbligatorio' | wmtrans }}
+        </span>
+        <span
+          class="wm-profile-edit-field-error"
+          *ngIf="(submitted$ | async) && profileForm.controls.name.errors?.maxlength"
+        >
+          {{ 'Il nome non può superare i 255 caratteri' | wmtrans }}
+        </span>
+      </div>
+
+      <div class="wm-profile-edit-field-divider"></div>
+
+      <div class="wm-profile-edit-field-container">
+        <ion-label class="wm-profile-edit-label">{{ 'Cognome' | wmtrans }}</ion-label>
+        <ion-item
+          class="wm-profile-edit-field"
+          lines="none"
+          [ngClass]="{
+            'wm-profile-edit-field-has-error':
+              (submitted$ | async) && profileForm.controls.surname.invalid
+          }"
+        >
+          <ion-input type="text" formControlName="surname" class="wm-profile-edit-input"></ion-input>
+        </ion-item>
+        <span
+          class="wm-profile-edit-field-error"
+          *ngIf="(submitted$ | async) && profileForm.controls.surname.errors?.maxlength"
+        >
+          {{ 'Il cognome non può superare i 255 caratteri' | wmtrans }}
+        </span>
+      </div>
+    </ion-card>
+
+    <button
+      type="submit"
+      class="wm-profile-edit-save-button"
+      [disabled]="(state$ | async) === EProfileEditState.SAVING"
+    >
+      <ion-spinner *ngIf="(state$ | async) === EProfileEditState.SAVING"></ion-spinner>
+      <ng-container *ngIf="(state$ | async) !== EProfileEditState.SAVING">
+        {{ 'Salva' | wmtrans }}
+      </ng-container>
+    </button>
+  </form>
+</ion-content>

--- a/projects/wm-core/src/profile/profile-edit/profile-edit.component.scss
+++ b/projects/wm-core/src/profile/profile-edit/profile-edit.component.scss
@@ -1,0 +1,161 @@
+wm-profile-edit {
+  .wm-profile-edit-form {
+    display: block;
+    padding: 16px;
+  }
+
+  .wm-profile-edit-avatar-container {
+    display: flex;
+    justify-content: center;
+    padding: 24px 16px 20px;
+  }
+
+  // Il bottone dell'avatar è ora l'intero elemento cliccabile (non più un link
+  // testuale separato "Cambia foto" sotto la foto) — il badge fotocamera
+  // sovrapposto (pattern riconoscibile: WhatsApp/Instagram/LinkedIn) comunica
+  // già da solo l'azione; l'aria-label copre l'accessibilità.
+  .wm-profile-edit-avatar {
+    position: relative;
+    width: 104px;
+    height: 104px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    border-radius: 50%;
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid var(--wm-color-primary, #4285f4);
+      outline-offset: 3px;
+    }
+  }
+
+  .wm-profile-edit-avatar-circle {
+    width: 100%;
+    height: 100%;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  .wm-profile-edit-avatar-initials {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--wm-color-primary, #4285f4);
+    color: #fff;
+    font-size: 2.1rem;
+    font-weight: 600;
+  }
+
+  // Overlay di caricamento: scurisce la foto invece di nasconderla, cerchio
+  // pieno (non un rettangolo che sborda dall'avatar), spinner chiaro centrato.
+  .wm-profile-edit-avatar-scrim {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: rgba(15, 17, 23, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .wm-profile-edit-avatar-spinner {
+    width: 30px;
+    height: 30px;
+  }
+
+  // Badge fotocamera sovrapposto al bordo dell'avatar — nascosto durante il
+  // caricamento (lo scrim+spinner sopra bastano, evita due indicatori insieme).
+  .wm-profile-edit-avatar-badge {
+    position: absolute;
+    bottom: -1px;
+    right: -1px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--wm-color-primary, #4285f4);
+    border: 3px solid var(--wm-color-white, #fff);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 14px;
+  }
+
+  // Touch target minimo 44x44 (linee guida iOS/Android) sugli elementi
+  // interattivi del modale — l'avatar (104px) lo supera già ampiamente.
+  .wm-profile-edit-save-button {
+    min-height: 44px;
+    min-width: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: none;
+    background: var(--wm-color-primary, #4285f4);
+    color: #fff;
+    border-radius: 8px;
+    font-size: var(--wm-font-md, 1rem);
+    width: 100%;
+    margin-top: 16px;
+
+    &[disabled] {
+      opacity: 0.6;
+    }
+  }
+
+  // Opzione B (design review oc:8163): i campi vivono dentro un'unica ion-card
+  // contenuta invece che fluttuare direttamente sullo sfondo del modale — resta
+  // un modulo a scopo unico, non un menu; nuovi campi si aggiungono come nuovi
+  // .wm-profile-edit-field-container dentro la stessa card. `--wm-color-light`
+  // è bianco puro in questo tema (invisibile su sfondo bianco): si usa invece
+  // `--wm-color-greybackground`, il token dedicato a sfondi "incassati".
+  ion-card.wm-profile-edit-fields-card {
+    margin: 0 0 16px;
+    box-shadow: none;
+    background: var(--wm-color-greybackground, #f2f2f2);
+    border: 1px solid var(--wm-color-grey, #d2d2d2);
+    border-radius: 14px;
+    padding: 4px 14px;
+  }
+
+  .wm-profile-edit-field-container {
+    padding: 10px 0;
+
+    ion-item {
+      --background: transparent;
+      --padding-start: 0;
+      --inner-padding-end: 0;
+    }
+  }
+
+  .wm-profile-edit-field-divider {
+    height: 1px;
+    background: var(--wm-color-grey, #d2d2d2);
+    margin: 0 -14px;
+  }
+
+  .wm-profile-edit-label {
+    display: block;
+    margin-bottom: 4px;
+    font-size: var(--wm-font-sm, 0.85rem);
+  }
+
+  .wm-profile-edit-field-has-error {
+    --border-color: var(--wm-color-danger, #eb445a);
+    --highlight-color-focused: var(--wm-color-danger, #eb445a);
+  }
+
+  .wm-profile-edit-field-error {
+    display: block;
+    margin-top: 4px;
+    color: var(--wm-color-danger, #eb445a);
+    font-size: 0.8rem;
+  }
+}

--- a/projects/wm-core/src/profile/profile-edit/profile-edit.component.spec.ts
+++ b/projects/wm-core/src/profile/profile-edit/profile-edit.component.spec.ts
@@ -1,0 +1,121 @@
+import {UntypedFormBuilder} from '@angular/forms';
+import {Actions} from '@ngrx/effects';
+import {Subject} from 'rxjs';
+import {Action} from '@ngrx/store';
+
+import * as AuthActions from '@wm-core/store/auth/auth.actions';
+import {EProfileEditState, ProfileEditComponent} from './profile-edit.component';
+
+/**
+ * `ProfileEditComponent` is exercised as a plain TS class (no `TestBed`, no template
+ * compilation): its template uses `wmtrans`/Ionic components whose DI chain
+ * (`APP_TRANSLATION`) is not wired up outside the full app module and has previously
+ * caused `NG0201` crashes in boilerplate specs (see wm-core CLAUDE.md, oc:8023, and the
+ * same pattern in `ugc-track-properties.component.spec.ts`, oc:8183). Instantiating the
+ * class directly with mocked constructor dependencies avoids Angular's compiler/DI
+ * entirely while still covering the form validation and save/dismiss logic, none of which
+ * depends on the rendered template.
+ *
+ * `Actions` (from `@ngrx/effects`) is a real `Observable` subclass whose constructor
+ * accepts a source `Observable<Action>` (see `node_modules/@ngrx/effects/.../ngrx-effects.mjs`)
+ * — a `Subject<Action>` fed manually in each test stands in for the real actions stream
+ * without needing `TestBed`/`EffectsModule`.
+ */
+describe('ProfileEditComponent', () => {
+  let component: ProfileEditComponent;
+  let modalCtrlSpy: any;
+  let storeSpy: any;
+  let cameraSvcSpy: any;
+  let alertCtrlSpy: any;
+  let langSvcSpy: any;
+  let formBuilder: any;
+  let actionsSubject: Subject<Action>;
+  let actions$: Actions;
+
+  beforeEach(() => {
+    modalCtrlSpy = {dismiss: jasmine.createSpy('dismiss')};
+    storeSpy = {
+      dispatch: jasmine.createSpy('dispatch'),
+      pipe: () => ({subscribe: () => {}}),
+      select: () => ({pipe: () => ({subscribe: () => {}})}),
+    };
+    cameraSvcSpy = {addProfilePhoto: jasmine.createSpy('addProfilePhoto')};
+    alertCtrlSpy = {
+      create: jasmine.createSpy('create').and.returnValue(
+        Promise.resolve({present: jasmine.createSpy('present')}),
+      ),
+    };
+    langSvcSpy = {instant: jasmine.createSpy('instant').and.callFake((s: string) => s)};
+    formBuilder = new UntypedFormBuilder();
+    actionsSubject = new Subject<Action>();
+    actions$ = new Actions(actionsSubject);
+
+    component = new ProfileEditComponent(
+      formBuilder,
+      modalCtrlSpy,
+      storeSpy,
+      cameraSvcSpy,
+      actions$,
+      alertCtrlSpy,
+      langSvcSpy,
+    );
+  });
+
+  it('builds a form with name and surname controls', () => {
+    expect(component.profileForm.contains('name')).toBeTrue();
+    expect(component.profileForm.contains('surname')).toBeTrue();
+  });
+
+  it('marks the form invalid when name is empty', () => {
+    component.profileForm.patchValue({name: ''});
+    expect(component.profileForm.invalid).toBeTrue();
+  });
+
+  it('marks the form valid when name is present and surname is empty (surname optional)', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: ''});
+    expect(component.profileForm.valid).toBeTrue();
+  });
+
+  it('dismisses the modal via ModalController', () => {
+    component.dismiss();
+    expect(modalCtrlSpy.dismiss).toHaveBeenCalled();
+  });
+
+  it('dispatches updateUserProfile with form values on save', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: 'Rossi'});
+    component.save();
+    expect(storeSpy.dispatch).toHaveBeenCalled();
+  });
+
+  it('sends surname: "" (not undefined) when an existing surname is cleared and saved', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: 'Rossi'});
+    component.profileForm.patchValue({surname: ''});
+    component.save();
+    expect(storeSpy.dispatch).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        surname: '',
+      }),
+    );
+  });
+
+  it('transitions to SUCCESS and dismisses the modal when loadAuthsSuccess fires after save', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: 'Rossi'});
+    component.save();
+    expect(component.state$.value).toBe(EProfileEditState.SAVING);
+
+    actionsSubject.next(AuthActions.loadAuthsSuccess({user: {} as any}));
+
+    expect(component.state$.value).toBe(EProfileEditState.SUCCESS);
+    expect(modalCtrlSpy.dismiss).toHaveBeenCalled();
+  });
+
+  it('transitions to ERROR and shows an alert when updateUserProfileFailure fires after save', () => {
+    component.profileForm.patchValue({name: 'Mario', surname: 'Rossi'});
+    component.save();
+
+    actionsSubject.next(AuthActions.updateUserProfileFailure({error: {} as any}));
+
+    expect(component.state$.value).toBe(EProfileEditState.ERROR);
+    expect(alertCtrlSpy.create).toHaveBeenCalled();
+  });
+});

--- a/projects/wm-core/src/profile/profile-edit/profile-edit.component.ts
+++ b/projects/wm-core/src/profile/profile-edit/profile-edit.component.ts
@@ -1,0 +1,175 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation,
+} from '@angular/core';
+import {UntypedFormBuilder, UntypedFormGroup, Validators} from '@angular/forms';
+import {AlertController, ModalController} from '@ionic/angular';
+import {Store} from '@ngrx/store';
+import {Actions, ofType} from '@ngrx/effects';
+import {Photo} from '@capacitor/camera';
+import {BehaviorSubject, from, Subject} from 'rxjs';
+import {take, takeUntil} from 'rxjs/operators';
+import {CameraService} from '@wm-core/services/camera.service';
+import {LangService} from '@wm-core/localization/lang.service';
+import * as AuthActions from '@wm-core/store/auth/auth.actions';
+
+export enum EProfileEditState {
+  IDLE = 'IDLE',
+  UPLOADING_PHOTO = 'UPLOADING_PHOTO',
+  SAVING = 'SAVING',
+  SUCCESS = 'SUCCESS',
+  ERROR = 'ERROR',
+}
+
+/**
+ * Modale di modifica del profilo utente (nome, cognome, avatar). Apribile via
+ * `ModalController` da `ProfileUserComponent` (Task 6). Osserva direttamente l'esito
+ * dell'azione `updateUserProfile` filtrando lo stream `Actions` su `loadAuthsSuccess`/
+ * `updateUserProfileFailure` (stesso pattern generico già usato da `updatePrivacyAgree$`
+ * in `auth.effects.ts` — nessun ID di correlazione dedicato esiste per nessuno di questi
+ * flussi): al successo chiude il modale, all'errore mostra un alert nativo.
+ */
+@Component({
+  standalone: false,
+  selector: 'wm-profile-edit',
+  templateUrl: './profile-edit.component.html',
+  styleUrls: ['./profile-edit.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ProfileEditComponent implements OnInit, OnDestroy {
+  @Input() currentName: string;
+  @Input() currentSurname: string;
+  @Input() currentAvatarUrl: string;
+
+  profileForm: UntypedFormGroup;
+  selectedPhoto: Photo | null = null;
+  state$: BehaviorSubject<EProfileEditState> = new BehaviorSubject<EProfileEditState>(
+    EProfileEditState.IDLE,
+  );
+  submitted$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  readonly EProfileEditState = EProfileEditState;
+
+  private _destroy$ = new Subject<void>();
+
+  constructor(
+    private _formBuilder: UntypedFormBuilder,
+    private _modalCtrl: ModalController,
+    private _store: Store,
+    private _cameraSvc: CameraService,
+    private _actions$: Actions,
+    private _alertCtrl: AlertController,
+    private _langSvc: LangService,
+  ) {
+    this.profileForm = this._formBuilder.group({
+      name: ['', [Validators.required, Validators.maxLength(255)]],
+      surname: ['', [Validators.maxLength(255)]],
+    });
+  }
+
+  /**
+   * Precompila il form con i valori correnti del profilo, passati dal chiamante via
+   * `@Input`.
+   */
+  ngOnInit(): void {
+    this.profileForm.patchValue({
+      name: this.currentName ?? '',
+      surname: this.currentSurname ?? '',
+    });
+  }
+
+  /**
+   * Chiude il modale senza salvare.
+   */
+  dismiss(): void {
+    this._modalCtrl.dismiss();
+  }
+
+  /**
+   * Chiude la subscription su `Actions` avviata in `save()` — stesso pattern
+   * `takeUntil(this._destroy$)` già usato in `geobox-map.component.ts` per un
+   * componente (non un effect) che inietta `Actions` direttamente. Senza questo, se il
+   * modale viene chiuso prima che il salvataggio risolva, una `loadAuthsSuccess`/
+   * `updateUserProfileFailure` successiva e non correlata chiamerebbe comunque
+   * `this._modalCtrl.dismiss()`, potenzialmente chiudendo un modale diverso aperto nel
+   * frattempo.
+   */
+  ngOnDestroy(): void {
+    this._destroy$.next();
+    this._destroy$.complete();
+  }
+
+  /**
+   * Apre il picker foto (camera/galleria) e mantiene la foto selezionata in memoria,
+   * pronta per essere inviata al salvataggio.
+   */
+  async pickPhoto(): Promise<void> {
+    this.state$.next(EProfileEditState.UPLOADING_PHOTO);
+    try {
+      this.selectedPhoto = await this._cameraSvc.addProfilePhoto();
+      this.state$.next(EProfileEditState.IDLE);
+    } catch (e) {
+      // Annullamento esplicito dell'utente o permesso negato: torna a IDLE senza
+      // mostrare un errore (non è un fallimento, è una scelta dell'utente).
+      this.state$.next(EProfileEditState.IDLE);
+    }
+  }
+
+  /**
+   * Valida il form e, se valido, dispatcha `updateUserProfile` con i nuovi valori
+   * (nome sempre presente, cognome/foto opzionali) e osserva l'esito dell'azione per
+   * transizionare a `SUCCESS`/`ERROR` e chiudere il modale o mostrare un alert.
+   */
+  save(): void {
+    this.submitted$.next(true);
+    if (this.profileForm.invalid) {
+      return;
+    }
+
+    this.state$.next(EProfileEditState.SAVING);
+    this._store.dispatch(
+      AuthActions.updateUserProfile({
+        name: this.profileForm.value.name,
+        surname: this.profileForm.value.surname,
+        avatarPhoto: this.selectedPhoto ?? undefined,
+      }),
+    );
+
+    this._actions$
+      .pipe(
+        ofType(AuthActions.loadAuthsSuccess, AuthActions.updateUserProfileFailure),
+        take(1),
+        takeUntil(this._destroy$),
+      )
+      .subscribe(action => {
+        if (action.type === AuthActions.loadAuthsSuccess.type) {
+          this.state$.next(EProfileEditState.SUCCESS);
+          this._modalCtrl.dismiss();
+        } else {
+          this.state$.next(EProfileEditState.ERROR);
+          this._showSaveErrorAlert();
+        }
+      });
+  }
+
+  /**
+   * Alert nativo mostrato quando `updateUserProfile` fallisce lato backend — stesso
+   * pattern (message via `LangService.instant`) già usato da `deleteTrack()` in
+   * `ugc-track-properties.component.ts`.
+   */
+  private _showSaveErrorAlert(): void {
+    from(
+      this._alertCtrl.create({
+        message: this._langSvc.instant(
+          'Non è stato possibile salvare le modifiche al profilo. Riprova.',
+        ),
+        buttons: [this._langSvc.instant('OK')],
+      }),
+    ).subscribe(alert => alert.present());
+  }
+}

--- a/projects/wm-core/src/profile/profile-user/profile-user.component.html
+++ b/projects/wm-core/src/profile/profile-user/profile-user.component.html
@@ -1,16 +1,14 @@
 <ng-container *ngIf="(isLogged$|async)">
-  <div class="wm-profile-user-container">
-    <ion-avatar
-      class="wm-profile-user-avatar"
-      [ngClass]="{
-      'wm-profile-user-avatar-icon': !avatarUrl
-    }"
-    >
-      <i class="wm-icon-user-outline"></i>
+  <div class="wm-profile-user-container" *ngIf="user$|async as currentUser" (click)="openEditProfile(currentUser)">
+    <ion-avatar class="wm-profile-user-avatar">
+      <img *ngIf="currentUser?.avatar_url" [src]="currentUser.avatar_url" />
+      <div class="wm-profile-user-avatar-initials" *ngIf="!currentUser?.avatar_url">
+        {{ currentUser?.name | userInitials }}
+      </div>
     </ion-avatar>
-    <div class="wm-profile-user-header-container" *ngIf="user$|async as user">
-      <h4 class="wm-profile-user-name">{{user?.name}}</h4>
-      <div class="wm-profile-user-email">{{user?.email}}</div>
+    <div class="wm-profile-user-header-container">
+      <h4 class="wm-profile-user-name">{{currentUser?.name}}</h4>
+      <div class="wm-profile-user-email">{{currentUser?.email}}</div>
     </div>
   </div>
 </ng-container>

--- a/projects/wm-core/src/profile/profile-user/profile-user.component.scss
+++ b/projects/wm-core/src/profile/profile-user/profile-user.component.scss
@@ -3,6 +3,7 @@ wm-profile-user{
     --user-container-padding: 15px;
     --user-container-content-height: 64px;
 
+    cursor: pointer;
     padding: var(--user-container-padding);
     display: flex;
     width: 100%;
@@ -10,16 +11,21 @@ wm-profile-user{
     align-items: center;
     .wm-profile-user-avatar {
       display: block;
+      flex-shrink: 0;
       width: var(--user-container-content-height);
       height: var(--user-container-content-height);
-      &.wm-profile-user-avatar-icon {
-        font-size: 30px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        color: var(--wm-color-light);
-        background: rgba(var(--wm-color-secondary-rgb), 0.5);
-      }
+    }
+    .wm-profile-user-avatar-initials {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--wm-color-primary, #4285f4);
+      color: #fff;
+      font-size: 1.2rem;
+      font-weight: 600;
+      border-radius: 50%;
     }
     .wm-profile-user-header-container {
       display: flex;
@@ -27,12 +33,21 @@ wm-profile-user{
       align-items: flex-start;
       justify-content: center;
       flex-direction: column;
+      min-width: 0;
       .wm-profile-user-name {
         margin: 0 0 3px;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .wm-profile-user-email {
         font-size: var(--wm-font-sm);
         color: var(--wm-color-darkgrey);
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
   }

--- a/projects/wm-core/src/profile/profile-user/profile-user.component.ts
+++ b/projects/wm-core/src/profile/profile-user/profile-user.component.ts
@@ -1,9 +1,11 @@
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {select, Store} from '@ngrx/store';
-import {Observable} from 'rxjs';
+import {from, Observable} from 'rxjs';
 import {IUser} from '@wm-core/store/auth/auth.model';
 import {isLogged, user} from '@wm-core/store/auth/auth.selectors';
 import {confAUTHEnable} from '@wm-core/store/conf/conf.selector';
+import {ModalController} from '@ionic/angular';
+import {ProfileEditComponent} from '@wm-core/profile/profile-edit/profile-edit.component';
 
 @Component({
   standalone: false,
@@ -15,9 +17,33 @@ import {confAUTHEnable} from '@wm-core/store/conf/conf.selector';
 })
 export class ProfileUserComponent {
   authEnable$: Observable<boolean> = this._store.select(confAUTHEnable);
-  avatarUrl: string;
   isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));
   user$: Observable<IUser> = this._store.pipe(select(user));
 
-  constructor(private _store: Store) {}
+  constructor(
+    private _store: Store,
+    private _modalCtrl: ModalController,
+  ) {}
+
+  /**
+   * Apre la modale di modifica profilo (`ProfileEditComponent`), precompilandola con
+   * i valori correnti dell'utente passati come `@Input`.
+   *
+   * @param currentUser utente corrente, letto dal template da `user$|async`
+   */
+  openEditProfile(currentUser: IUser): void {
+    from(
+      this._modalCtrl.create({
+        component: ProfileEditComponent,
+        componentProps: {
+          currentName: currentUser?.name,
+          currentSurname: currentUser?.surname,
+          currentAvatarUrl: currentUser?.avatar_url,
+        },
+        canDismiss: true,
+        mode: 'ios',
+        id: 'wm-profile-edit-modal',
+      }),
+    ).subscribe(modal => modal.present());
+  }
 }

--- a/projects/wm-core/src/profile/profile.module.ts
+++ b/projects/wm-core/src/profile/profile.module.ts
@@ -1,21 +1,24 @@
 import {CUSTOM_ELEMENTS_SCHEMA, NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {IonicModule} from '@ionic/angular';
+import {ReactiveFormsModule} from '@angular/forms';
 import {WmPipeModule} from '../pipes/pipe.module';
 import {ProfileAuthComponent} from './profile-auth/profile-auth.component';
 import {ProfileUserComponent} from './profile-user/profile-user.component';
 import {ProfileDataComponent} from './profile-data/profile-data.component';
 import {WmProfilePopupComponent} from './profile-popup/profile-popup.component';
+import {ProfileEditComponent} from './profile-edit/profile-edit.component';
 import {WmSharedModule} from '../shared/shared.module';
 const components = [
   ProfileAuthComponent,
   ProfileUserComponent,
   ProfileDataComponent,
   WmProfilePopupComponent,
+  ProfileEditComponent,
 ];
 @NgModule({
   declarations: components,
-  imports: [CommonModule, IonicModule, WmPipeModule, WmSharedModule],
+  imports: [CommonModule, IonicModule, WmPipeModule, WmSharedModule, ReactiveFormsModule],
   exports: components,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/projects/wm-core/src/services/camera.service.ts
+++ b/projects/wm-core/src/services/camera.service.ts
@@ -51,13 +51,17 @@ export class CameraService {
             {
               text: this._lanSvc.instant('Scatta una foto'),
               handler: () => {
-                this.shotPhoto().then(photo => resolve([photo]));
+                this.shotPhoto()
+                  .then(photo => resolve([photo]))
+                  .catch(() => reject());
               },
             },
             {
               text: this._lanSvc.instant('Dalla libreria'),
               handler: () => {
-                this.getPhotos(null).then(photos => resolve(photos));
+                this.getPhotos(null)
+                  .then(photos => resolve(photos))
+                  .catch(() => reject());
               },
             },
             {
@@ -75,6 +79,57 @@ export class CameraService {
     });
 
     return retProm;
+  }
+
+  /**
+   * Same action sheet as addPhotos() (Scatta una foto / Dalla libreria / Annulla)
+   * but returns a single Photo — used for profile avatar upload. Does not touch
+   * addPhotos(), which is shared by the UGC flows and returns Photo[]. Caps the
+   * capture at 1600px/quality 80 via an explicit options override passed to
+   * shotPhoto()/getPhotos() — the shared UGC defaults (full resolution) stay
+   * untouched for every other caller.
+   */
+  async addProfilePhoto(): Promise<Photo> {
+    return new Promise<Photo>((resolve, reject) => {
+      this._actionSheetCtrl
+        .create({
+          header: this._lanSvc.instant("Origine dell'immagine"),
+          buttons: [
+            {
+              text: this._lanSvc.instant('Scatta una foto'),
+              handler: () => {
+                this.shotPhoto(1600)
+                  .then(photo => resolve(photo))
+                  .catch(() => reject());
+              },
+            },
+            {
+              text: this._lanSvc.instant('Dalla libreria'),
+              handler: () => {
+                this.getPhotos(null, {quality: 80, width: 1600})
+                  .then(photos => {
+                    if (photos.length === 0) {
+                      reject();
+                      return;
+                    }
+                    resolve(photos[0]);
+                  })
+                  .catch(() => reject());
+              },
+            },
+            {
+              text: this._lanSvc.instant('Annulla'),
+              role: 'cancel',
+              handler: () => {
+                reject();
+              },
+            },
+          ],
+        })
+        .then(actionSheet => {
+          actionSheet.present();
+        });
+    });
   }
 
   public async getBlob(url: string) {
@@ -163,20 +218,23 @@ export class CameraService {
 
     return String(input);
   }
-  async getPhotos(dateLimit: Date = null): Promise<Photo[]> {
+  /**
+   * @param options optional overrides merged into the default gallery options
+   * (e.g. `{quality: 80, width: 1600}` for the avatar flow). Left unset, this
+   * keeps the original full-resolution behavior relied upon by the UGC photo
+   * flows (`addPhotos()`) — those must never be resized as a side effect of
+   * an option only the avatar flow actually needs.
+   */
+  async getPhotos(dateLimit: Date = null, options?: Partial<GalleryImageOptions>): Promise<Photo[]> {
     if (!(await Camera.checkPermissions())) {
       await Camera.requestPermissions();
       if (!(await Camera.checkPermissions())) return [];
     }
-    const options: GalleryImageOptions = {
-      quality: 100, //	number	The quality of image to return as JPEG, from 0-100		1.2.0
-      // width:	10000, //number	The width of the saved image		1.2.0
-      // height:10000,	//number	The height of the saved image		1.2.0
-      // correctOrientation: false, // 	boolean	Whether to automatically rotate the image “up” to correct for orientation in portrait mode	: true	1.2.0
-      // presentationStyle:	'fullscreen' | 'popover'	// iOS only: The presentation style of the Camera.	: 'fullscreen'	1.2.0
-      // limit : 100 //	number	iOS only: Maximum number of pictures the user will be able to choose.	0 (unlimited)	1.2.0
+    const galleryOptions: GalleryImageOptions = {
+      quality: 100,
+      ...options,
     };
-    const gallery: GalleryPhotos = await Camera.pickImages(options);
+    const gallery: GalleryPhotos = await Camera.pickImages(galleryOptions);
     const photos = (gallery.photos as Photo[]).map(photo => {
       photo.exif = this._sanitizeObjectValues(photo.exif);
       return photo;
@@ -248,14 +306,20 @@ export class CameraService {
     }
   }
 
-  async shotPhoto(): Promise<Photo> {
+  /**
+   * @param maxWidth optional max width (px) forwarded to `Camera.getPhoto()`'s `width`
+   * option. Left unset (the default) for `addPhotos()`'s UGC callers, where full
+   * resolution may be intentional/acceptable; `addProfilePhoto()` passes 1600 to cap
+   * the avatar capture at the same size already used for the gallery path.
+   */
+  async shotPhoto(maxWidth?: number): Promise<Photo> {
     if (!this._geoLocationSvc.active) await this._geoLocationSvc.startNavigation();
     const photo: Photo = await Camera.getPhoto({
       quality: 90,
       // allowEditing: true,
       resultType: CameraResultType.Uri,
       saveToGallery: true, //boolean	Whether to save the photo to the gallery. If the photo was picked from the gallery, it will only be saved if edited. Default: false
-      // width: 10000,//	number	The width of the saved image
+      ...(maxWidth != null && {width: maxWidth}), //	number	The width of the saved image
       // height: 10000,//	number	The height of the saved image
       // preserveAspectRatio: true, //	boolean	Whether to preserve the aspect ratio of the image.If this flag is true, the width and height will be used as max values and the aspect ratio will be preserved.This is only relevant when both a width and height are passed.When only width or height is provided the aspect ratio is always preserved(and this option is a no- op).A future major version will change this behavior to be default, and may also remove this option altogether.Default: false
       // correctOrientation: true,	//boolean	Whether to automatically rotate the image “up” to correct for orientation in portrait mode Default: true

--- a/projects/wm-core/src/shared/shared.module.ts
+++ b/projects/wm-core/src/shared/shared.module.ts
@@ -9,6 +9,7 @@ import {WmPipeModule} from '../pipes/pipe.module';
 import {WmPrivacyAgreeButtonComponent} from './privacy-agree-button/privacy-agree-button.component';
 import {WmProfileDeleteButtonComponent} from './profile-delete-button/profile-delete-button.component';
 import {WmSwiperComponent} from '../swiper/swiper.component';
+import {ModalHeaderComponent} from '../modal-header/modal-header.component';
 
 const declarations = [
   WmImgComponent,
@@ -17,6 +18,7 @@ const declarations = [
   WmPrivacyAgreeButtonComponent,
   WmProfileDeleteButtonComponent,
   WmSwiperComponent,
+  ModalHeaderComponent,
 ];
 
 @NgModule({

--- a/projects/wm-core/src/store/auth/auth.actions.ts
+++ b/projects/wm-core/src/store/auth/auth.actions.ts
@@ -1,5 +1,6 @@
 import {HttpErrorResponse} from '@angular/common/http';
 import {createAction, props} from '@ngrx/store';
+import {Photo} from '@capacitor/camera';
 import {IUser} from './auth.model';
 
 export const loadSignUps = createAction(
@@ -53,5 +54,14 @@ export const loadSignOutsSuccess = createAction('[Auth] Load SignOut Success');
 export const updateUserPrivacy = createAction('[Auth] update user privacy', props<{agree}>());
 export const updatePrivacyFailure = createAction(
   '[Auth] update user privacy failure',
+  props<{error: HttpErrorResponse}>(),
+);
+
+export const updateUserProfile = createAction(
+  '[Auth] update user profile',
+  props<{name?: string; surname?: string; avatarPhoto?: Photo}>(),
+);
+export const updateUserProfileFailure = createAction(
+  '[Auth] update user profile failure',
   props<{error: HttpErrorResponse}>(),
 );

--- a/projects/wm-core/src/store/auth/auth.effects.ts
+++ b/projects/wm-core/src/store/auth/auth.effects.ts
@@ -113,6 +113,22 @@ export class AuthEffects {
       ),
     );
   });
+  updateUserProfile$ = createEffect(() => {
+    return this._actions$.pipe(
+      ofType(AuthActions.updateUserProfile),
+      switchMap(action =>
+        this._authSvc.updateProfile(action).pipe(
+          map(user => {
+            saveAuth(user);
+            return AuthActions.loadAuthsSuccess({user});
+          }),
+          catchError(error => {
+            return of(AuthActions.updateUserProfileFailure({error}));
+          }),
+        ),
+      ),
+    );
+  });
   syncUgcAfterAuthSuccess$ = createEffect(
     () => {
       return this._actions$.pipe(

--- a/projects/wm-core/src/store/auth/auth.model.ts
+++ b/projects/wm-core/src/store/auth/auth.model.ts
@@ -2,6 +2,8 @@ export interface IUser {
   id: number;
   email?: string;
   name?: string;
+  surname?: string;
+  avatar_url?: string;
   createdAt?: string;
   updatedAt?: string;
   role?: string;

--- a/projects/wm-core/src/store/auth/auth.service.ts
+++ b/projects/wm-core/src/store/auth/auth.service.ts
@@ -12,6 +12,8 @@ import {AlertController, ModalController} from '@ionic/angular';
 import {updateUserPrivacy} from './auth.actions';
 import {WmInnerHtmlComponent} from '@wm-core/inner-html/inner-html.component';
 import {DEFAULT_PRIVACY_POLICY_URL} from '@wm-core/constants/links';
+import {Photo} from '@capacitor/camera';
+import {CameraService} from '@wm-core/services/camera.service';
 @Injectable({
   providedIn: 'root',
 })
@@ -24,6 +26,7 @@ export class AuthService {
     private _langSvc: LangService,
     private _alertCtrl: AlertController,
     private _modalCtrl: ModalController,
+    private _cameraSvc: CameraService,
   ) {}
 
   login(email: string, password: string, referrer?: string): Observable<IUser> {
@@ -89,6 +92,48 @@ export class AuthService {
         return this._http.post(`${this._environmentSvc.origin}/api/auth/user`, {
           privacy,
         }) as Observable<IUser>;
+      }),
+    );
+  }
+
+  /**
+   * Update name, surname and/or avatar photo. Builds multipart FormData only
+   * when an avatarPhoto is provided; otherwise sends plain JSON (same endpoint
+   * already used by updatePrivacyAgree, POST /api/auth/user).
+   *
+   * @param data the fields to update
+   *
+   * @returns {Observable<IUser>} the updated user
+   */
+  updateProfile(data: {name?: string; surname?: string; avatarPhoto?: Photo}): Observable<IUser> {
+    if (!data.avatarPhoto) {
+      const body: {name?: string; surname?: string} = {};
+      if (data.name != null) body.name = data.name;
+      if (data.surname != null) body.surname = data.surname;
+      return this._http.post(
+        `${this._environmentSvc.origin}/api/auth/user`,
+        body,
+      ) as Observable<IUser>;
+    }
+
+    return from(
+      this._cameraSvc.getPhotoFile({
+        date: new Date(),
+        id: data.avatarPhoto.path ?? data.avatarPhoto.webPath,
+        photoURL: data.avatarPhoto.webPath,
+        datasrc: data.avatarPhoto.webPath,
+        position: null,
+      }),
+    ).pipe(
+      switchMap(blob => {
+        const formData = new FormData();
+        if (data.name != null) formData.append('name', data.name);
+        if (data.surname != null) formData.append('surname', data.surname);
+        formData.append('avatar', blob, 'avatar.jpg');
+        return this._http.post(
+          `${this._environmentSvc.origin}/api/auth/user`,
+          formData,
+        ) as Observable<IUser>;
       }),
     );
   }

--- a/projects/wm-core/src/wm-core.module.ts
+++ b/projects/wm-core/src/wm-core.module.ts
@@ -36,7 +36,6 @@ import {WmFeatureUsefulUrlsComponent} from './feature-useful-urls/feature-useful
 import {AuthInterceptor} from './store/auth/auth.interceptor';
 import {AuthEffects} from './store/auth/auth.effects';
 import {authReducer} from './store/auth/auth.reducer';
-import {ModalHeaderComponent} from './modal-header/modal-header.component';
 import {LoginComponent} from './login/login.component';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {WmProfileModule} from './profile/profile.module';
@@ -125,7 +124,6 @@ export const declarations = [
   LoginComponent,
   RegisterComponent,
   GenericPopoverComponent,
-  ModalHeaderComponent,
   WmFormComponent,
   WmSearchBarComponent,
   WmGeoboxMapComponent,


### PR DESCRIPTION
## Summary
- Nuovo modale `ProfileEditComponent` per modificare nome, cognome e foto profilo
- Fallback a iniziali (pipe `userInitials`) quando manca l'avatar reale
- Nuovo metodo dedicato `CameraService.addProfilePhoto()` (action sheet scatta/libreria, foto singola) senza toccare `addPhotos()` esistente
- Nuove action/effect/service NgRx (`updateUserProfile`) per l'aggiornamento multipart verso `POST /api/auth/user`
- `profile-user.component` aggiornato per mostrare l'avatar reale/iniziali e aprire il modale di edit
- Nuove chiavi i18n in tutte le lingue supportate

Dipende dal contratto API di webmappsrl/wm-package#254 (surname, avatar_url)

## Test plan
- [ ] Verificare il flusso di modifica profilo (nome/cognome/foto) su dev server contro backend con webmappsrl/wm-package#254
- [ ] Verificare fallback iniziali quando l'utente non ha avatar
- [ ] Verificare che `addPhotos()` (flussi UGC) non sia stato impattato
- [ ] `npx ng test wm-core --watch=false` (richiede Node v20.19.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)